### PR TITLE
Submission Access

### DIFF
--- a/app/src/db/migrations/20200925103025_003-submission-users.js
+++ b/app/src/db/migrations/20200925103025_003-submission-users.js
@@ -1,0 +1,22 @@
+const stamps = require('../stamps');
+
+exports.up = function(knex) {
+  return Promise.resolve()
+    .then(() => knex.schema.createTable('form_submission_user', table => {
+      table.uuid('id').primary();
+      table.uuid('formSubmissionId').references('id').inTable('form_submission').notNullable().index();
+      table.uuid('userId').references('id').inTable('user').notNullable().index();
+      table.string('permission').references('code').inTable('permission').notNullable();
+      stamps(knex, table);
+    }))
+    .then(() => knex.schema.raw(`create view form_submission_users_vw as 
+select fsu."formSubmissionId", fsu."userId", array_agg(distinct(fsu.permission)) as permissions
+from form_submission_user fsu
+group by fsu."formSubmissionId", fsu."userId"`));
+};
+
+exports.down = function(knex) {
+  return Promise.resolve()
+    .then(() => knex.schema.raw('DROP VIEW IF EXISTS form_submission_users_vw'))
+    .then(() => knex.schema.dropTableIfExists('form_submission_user'));
+};

--- a/app/src/forms/common/models/utils.js
+++ b/app/src/forms/common/models/utils.js
@@ -1,0 +1,20 @@
+const toArray = (values) => {
+  if (values) {
+    return Array.isArray(values) ? values.filter(p => p && p.trim().length > 0) : [values].filter(p => p && p.trim().length > 0);
+  }
+  return [];
+};
+const inArrayClause = (column, values) => {
+  return values.map(p => `'${p}' = ANY("${column}")`).join(' or ');
+};
+
+const inArrayFilter = (column, values) => {
+  const clause = inArrayClause(column, values);
+  return `(array_length("${column}", 1) > 0 and (${clause}))`;
+};
+
+module.exports = {
+  toArray: toArray,
+  inArrayClause: inArrayClause,
+  inArrayFilter: inArrayFilter
+};

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -1,0 +1,21 @@
+const service = require('./service');
+
+module.exports = {
+  read:  async (req, res, next) => {
+    try {
+      const response = await service.read(req.params.formSubmissionId, req.currentUser);
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  },
+  update: async (req, res, next) => {
+    try {
+      const response = await service.update(req.params.formSubmissionId, req.body, req.currentUser);
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+};

--- a/app/src/forms/submission/index.js
+++ b/app/src/forms/submission/index.js
@@ -1,0 +1,9 @@
+const dataErrors = require('../common/middleware').dataErrors;
+const routes = require('./routes');
+
+module.exports.mount = (app) => {
+  const p = '/submissions';
+  app.use(p, routes);
+  app.use(dataErrors);
+  return p;
+};

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -1,0 +1,17 @@
+const routes = require('express').Router();
+
+const currentUser = require('../auth/middleware/userAccess').currentUser;
+
+const controller = require('./controller');
+
+routes.use(currentUser);
+
+routes.get('/:formSubmissionId', async (req, res, next) => {
+  await controller.read(req, res, next);
+});
+
+routes.put('/:formSubmissionId', async (req, res, next) => {
+  await controller.update(req, res, next);
+});
+
+module.exports = routes;

--- a/app/src/forms/submission/service.js
+++ b/app/src/forms/submission/service.js
@@ -1,0 +1,100 @@
+const { Form, FormVersion, FormSubmission, FormSubmissionUserPermissions, SubmissionMetadata, UserFormAccess } = require('../common/models');
+
+const Permissions = require('../common/constants').Permissions;
+
+const Problem = require('api-problem');
+const {transaction} = require('objection');
+
+const service = {
+
+  _fetchSubmissionData: async(formSubmissionId) => {
+    const meta = await SubmissionMetadata.query()
+      .where('submissionId', formSubmissionId)
+      .first()
+      .throwIfNotFound();
+
+    const submission = await FormSubmission.query()
+      .findById(meta.submissionId)
+      .throwIfNotFound();
+    const version = await FormVersion.query()
+      .findById(meta.formVersionId)
+      .throwIfNotFound();
+    const form = await Form.query()
+      .findById(meta.formId)
+      .allowGraph('identityProviders')
+      .withGraphFetched('identityProviders(orderDefault)')
+      .throwIfNotFound();
+
+    return {
+      form: form,
+      version: version,
+      submission: submission
+    };
+  },
+
+  read: async (formSubmissionId, currentUser, permissions = [Permissions.SUBMISSION_READ]) => {
+    const result = await service._fetchSubmissionData(formSubmissionId);
+
+    const checkFormSubmissionsPermission = async () => {
+      if (currentUser.public) return false;
+      return UserFormAccess.query()
+        .modify('filterFormId', result.form.id)
+        .modify('filterUserId', currentUser.id)
+        .modify('filterByAccess', null, null, permissions)
+        .first();
+    };
+
+    const checkSubmissionPermission = async () => {
+      if (currentUser.public) return false;
+      return FormSubmissionUserPermissions.query()
+        .modify('filterSubmissionId', formSubmissionId)
+        .modify('filterUserId', currentUser.id)
+        .modify('filterByPermissions', permissions)
+        .first();
+    };
+
+    const isDeleted = result.submission.deleted;
+    const isDraft = result.submission.draft;
+    const publicAllowed = result.form.identityProviders.find(p => p.code === 'public');
+    const idpAllowed = result.form.identityProviders.find(p => p.code === currentUser.idp);
+    const formSubmissionsPermission = await checkFormSubmissionsPermission();
+    const submissionPermission = await checkSubmissionPermission();
+
+    if (!isDraft && !isDeleted) {
+      if (publicAllowed || idpAllowed || formSubmissionsPermission || submissionPermission) return result;
+    }
+    if (isDraft) {
+      if (formSubmissionsPermission || submissionPermission) return result;
+    }
+    if (isDeleted) {
+      if (submissionPermission) return result;
+    }
+    // no access to this submission...
+
+    throw new Problem(401, 'You do not have access to this submission.');
+  },
+
+  update: async (formSubmissionId, data, currentUser) => {
+    let trx;
+    try {
+      await service.read(formSubmissionId, currentUser, [Permissions.SUBMISSION_UPDATE]);
+
+      trx = await transaction.start(FormSubmission.knex());
+
+      // TODO: check if we can update this submission
+      // TODO: we may have to update permissions for users (draft = false, then no delete?)
+
+      await FormSubmission.query(trx).patchAndFetchById(formSubmissionId, {draft: data.draft, submission: data.submission, updatedBy: currentUser.username});
+      await trx.commit();
+      const result = await service.read(formSubmissionId);
+      return result;
+    } catch (err) {
+      if (trx) await trx.rollback();
+      throw err;
+    }
+
+  }
+
+};
+
+module.exports = service;

--- a/app/src/routes/v1.js
+++ b/app/src/routes/v1.js
@@ -9,12 +9,14 @@ const form = require('../forms/form');
 const permission = require('../forms/permission');
 const rbac = require('../forms/rbac');
 const role = require('../forms/role');
+const submission = require('../forms/submission');
 
 admin.mount(router);
 const formPath = form.mount(router);
 const permissionPath = permission.mount(router);
 const rbacPath = rbac.mount(router);
 const rolePath = role.mount(router);
+const submissionPath = submission.mount(router);
 
 const getSpec = () => {
   const rawSpec = fs.readFileSync(path.join(__dirname, '../docs/v1.api-spec.yaml'), 'utf8');
@@ -32,7 +34,8 @@ router.get('/', (_req, res) => {
       formPath,
       permissionPath,
       rbacPath,
-      rolePath
+      rolePath,
+      submissionPath
     ]
   });
 });

--- a/app/tests/unit/routes/v1.spec.js
+++ b/app/tests/unit/routes/v1.spec.js
@@ -15,12 +15,13 @@ describe(`GET ${basePath}`, () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
     expect(Array.isArray(response.body.endpoints)).toBeTruthy();
-    expect(response.body.endpoints).toHaveLength(5);
+    expect(response.body.endpoints).toHaveLength(6);
     expect(response.body.endpoints).toContain('/docs');
     expect(response.body.endpoints).toContain('/forms');
     expect(response.body.endpoints).toContain('/permissions');
     expect(response.body.endpoints).toContain('/rbac');
     expect(response.body.endpoints).toContain('/roles');
+    expect(response.body.endpoints).toContain('/submissions');
   });
 });
 


### PR DESCRIPTION
Make direct submission routes. GET /submissions/:id
Do more fine-grained permissions checks (user can have permissions on the submission itself).
New table and view for user permissions on a submission, allows us to have many users have access to the submission (ex. creator and a staff reviewer can have read/write access).

**NOTE**: the API result for read is an object that has {form, version, submission}, this allows the caller to create a complete view of the submission without calling for form metadata or version/schema data separately.

See [SHOWCASE-1554](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1554)
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Once this is in place and being used for reading submission, we should remove the other routes/services for read and update and force all reads/writes through this service.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->