### PR TITLE
Share/qr/launch should not be version specific

### DIFF
--- a/app/frontend/src/components/designer/FormsTable.vue
+++ b/app/frontend/src/components/designer/FormsTable.vue
@@ -1,16 +1,30 @@
 <template>
   <div>
-    <!-- search input -->
-    <div class="submissions-search mt-6 mt-sm-0">
-      <v-text-field
-        v-model="search"
-        append-icon="mdi-magnify"
-        label="Search"
-        single-line
-        hide-details
-        class="pb-5"
-      />
-    </div>
+    <v-row>
+      <v-col cols="12" sm="6">
+        <router-link :to="{ name: 'FormCreate' }" v-if="isAdmin">
+          <v-btn color="primary" text small v-bind="attrs" v-on="on">
+            <v-icon class="mr-1">add_circle</v-icon>
+            <span>Create a New Form</span>
+          </v-btn>
+        </router-link>
+      </v-col>
+
+      <v-col cols="12" sm="6">
+        <!-- search input -->
+        <div class="submissions-search">
+          <v-text-field
+            v-model="search"
+            append-icon="mdi-magnify"
+            label="Search"
+            single-line
+            hide-details
+            class="pb-5"
+          />
+        </div>
+      </v-col>
+    </v-row>
+
     <!-- table header -->
     <v-data-table
       class="submissions-table"
@@ -77,7 +91,10 @@ export default {
       search: '',
     };
   },
-  computed: mapGetters('form', ['formList']),
+  computed: {
+    ...mapGetters('form', ['formList']),
+    ...mapGetters('auth', ['isAdmin']),
+  },
   methods: {
     ...mapActions('form', ['getFormsForCurrentUser']),
     checkFormManage: checkFormManage,

--- a/app/frontend/src/components/forms/ExportSubmissions.vue
+++ b/app/frontend/src/components/forms/ExportSubmissions.vue
@@ -2,7 +2,7 @@
   <span>
     <v-dialog v-model="dialog" width="900">
       <template v-slot:activator="{ on, attrs }">
-        <v-btn color="blue" text small v-bind="attrs" v-on="on">
+        <v-btn color="primary" text small v-bind="attrs" v-on="on">
           <v-icon class="mr-1">cloud_download</v-icon>
           <span>Export CSV</span>
         </v-btn>

--- a/app/frontend/src/components/forms/ShareForm.vue
+++ b/app/frontend/src/components/forms/ShareForm.vue
@@ -81,11 +81,7 @@ export default {
     formId: {
       type: String,
       required: true,
-    },
-    versionId: {
-      type: String,
-      required: true,
-    },
+    }
   },
   data() {
     return {
@@ -98,7 +94,7 @@ export default {
   computed: {
     formLink() {
       // TODO: Consider using vue-router to generate this url string instead
-      return `${window.location.origin}${process.env.BASE_URL}form/submit?f=${this.formId}&v=${this.versionId}`;
+      return `${window.location.origin}${process.env.BASE_URL}form/submit?f=${this.formId}`;
     },
   },
   methods: {

--- a/app/frontend/src/services/formService.js
+++ b/app/frontend/src/services/formService.js
@@ -68,6 +68,16 @@ export default {
   //
 
   /**
+   * @function readPublished
+   * Get the most recently published form version schema
+   * @param {string} formId The form uuid
+   * @returns {Promise} An axios response
+   */
+  readPublished(formId) {
+    return appAxios().get(`${ApiRoutes.FORMS}/${formId}/version`);
+  },
+
+  /**
    * @function readVersion
    * Get a specific form version schema
    * @param {string} formId The form uuid

--- a/app/frontend/src/store/modules/form.js
+++ b/app/frontend/src/store/modules/form.js
@@ -135,9 +135,9 @@ export default {
     resetForm({ commit }) {
       commit('SET_FORM', genInitialForm());
     },
-    async updateForm({ state }) {
+    async updateForm({ state, dispatch }) {
       try {
-        formService.updateForm(state.form.id, {
+        await formService.updateForm(state.form.id, {
           name: state.form.name,
           description: state.form.description,
           identityProviders: generateIdps({
@@ -146,7 +146,11 @@ export default {
           })
         });
       } catch (error) {
-        console.error(`Error updating form: ${error}`); // eslint-disable-line no-console
+        dispatch('notifications/addNotification', {
+          message:
+            'An error occurred while updating the settings for this form.',
+          consoleError: `Error updating form ${state.form.id}: ${error}`,
+        }, { root: true });
       }
     },
 

--- a/app/frontend/src/utils/permissionUtils.js
+++ b/app/frontend/src/utils/permissionUtils.js
@@ -35,8 +35,8 @@ const checkFormManage = userForm => {
     return false;
 
   if (userForm && userForm.permissions && userForm.permissions.includes(
-    FormPermissions.FORM_READ, FormPermissions.FORM_UPDATE, FormPermissions.FORM_DELETE,
-    FormPermissions.DESIGN_READ, FormPermissions.DESIGN_UPDATE, FormPermissions.DESIGN_DELETE)) {
+    FormPermissions.FORM_UPDATE, FormPermissions.FORM_DELETE,
+    FormPermissions.DESIGN_UPDATE, FormPermissions.DESIGN_DELETE)) {
     return true;
   }
 

--- a/app/frontend/src/views/form/Manage.vue
+++ b/app/frontend/src/views/form/Manage.vue
@@ -1,54 +1,8 @@
 <template>
   <div>
-    <v-breadcrumbs :items="breadcrumbs" />
-    <h1 class="my-6 text-center">{{ form.name }}</h1>
-    <p><strong>Description: </strong>{{ form.description }}</p>
-    <p>
-      <strong>Created: </strong>{{ form.createdAt | formatDate }} ({{
-        form.createdBy
-      }})
-    </p>
-    <!-- <strong>Labels:</strong>
-      <v-chip
-        class="ma-1"
-        v-for="label in form.labels"
-        :key="label"
-        close
-        @click:close="chip1 = false"
-      >{{ label }}</v-chip>
-      <v-btn color="blue" text small>
-        <v-icon class="mr-1">add</v-icon>
-        <span>Add</span>
-      </v-btn>-->
-    <p>
-      <strong>Share this form:</strong>
-      <ShareForm :formId="f" />
-    </p>
-    <!-- TODO: Change this from temporary button to actually embedded in Manage page -->
-    <router-link :to="{ name: 'FormSettings', query: { f: f } }">
-      <v-btn color="blue" text small>
-        <v-icon class="mr-1">edit</v-icon>
-        <span>Edit Settings</span>
-      </v-btn>
-    </router-link>
-    <v-row>
-      <v-col cols="6">
-        <!-- TODO: Change this card to potentially use TeamManagement component -->
-        <v-card outlined>
-          <v-list-item three-line>
-            <v-list-item-content>
-              <div class="overline mb-4">
-                TEAM MANGEMENT
-                <router-link :to="{ name: 'FormTeams', query: { f: f } }">
-                  <v-btn color="blue" text small>
-                    <v-icon class="mr-1">edit</v-icon>
-                    <span>Edit</span>
-                  </v-btn>
-                </router-link>
-              </div>
-            </v-list-item-content>
-          </v-list-item>
-        </v-card>
+    <v-row no-gutters class="mb-5">
+      <v-col cols="12" sm="8">
+        <h1>Manage Form</h1>
       </v-col>
       <v-col cols="12" sm="4" class="text-sm-right">
         <span class="ml-5">
@@ -247,7 +201,9 @@ export default {
       this.formSettingsDisabled = false;
     },
     showDeleteDialog() {
-      alert('Not implemented. Button only shows for Showcase Admins right now.');
+      alert(
+        'Not implemented. Button only shows for Showcase Admins right now.'
+      );
     },
     updateSettings() {
       try {

--- a/app/frontend/src/views/form/Manage.vue
+++ b/app/frontend/src/views/form/Manage.vue
@@ -190,7 +190,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions('form', ['getFormPermissionsForUser', 'fetchForm']),
+    ...mapActions('form', ['getFormPermissionsForUser', 'fetchForm', 'updateForm']),
     ...mapActions('notifications', ['addNotification']),
     cancelSettingsEdit() {
       this.formSettingsDisabled = true;
@@ -205,9 +205,10 @@ export default {
         'Not implemented. Button only shows for Showcase Admins right now.'
       );
     },
-    updateSettings() {
+    async updateSettings() {
       try {
         if (this.$refs.settingsForm.validate()) {
+          await this.updateForm();
           this.formSettingsDisabled = true;
           this.addNotification({
             type: NotificationTypes.SUCCESS,

--- a/app/frontend/src/views/form/Manage.vue
+++ b/app/frontend/src/views/form/Manage.vue
@@ -118,13 +118,13 @@
             >
               <v-btn v-if="canCreateDesign" color="primary" text small>
                 <v-icon class="mr-1 ml-5">edit</v-icon>
-                <span>Edit Current Form</span>
+                <span>Edit Current Design</span>
               </v-btn>
             </router-link>
           </p>
 
           <BaseInfoCard>
-            Editing this form and saving the changes will create and publish a
+            Editing this form design and saving the changes will create and publish a
             new version. Any submissions made to previous versions will maintain
             the design of the form at the time of that submission.
           </BaseInfoCard>

--- a/app/frontend/src/views/form/Manage.vue
+++ b/app/frontend/src/views/form/Manage.vue
@@ -1,8 +1,54 @@
 <template>
   <div>
-    <v-row no-gutters class="mb-5">
-      <v-col cols="12" sm="8">
-        <h1>Manage Form</h1>
+    <v-breadcrumbs :items="breadcrumbs" />
+    <h1 class="my-6 text-center">{{ form.name }}</h1>
+    <p><strong>Description: </strong>{{ form.description }}</p>
+    <p>
+      <strong>Created: </strong>{{ form.createdAt | formatDate }} ({{
+        form.createdBy
+      }})
+    </p>
+    <!-- <strong>Labels:</strong>
+      <v-chip
+        class="ma-1"
+        v-for="label in form.labels"
+        :key="label"
+        close
+        @click:close="chip1 = false"
+      >{{ label }}</v-chip>
+      <v-btn color="blue" text small>
+        <v-icon class="mr-1">add</v-icon>
+        <span>Add</span>
+      </v-btn>-->
+    <p>
+      <strong>Share this form:</strong>
+      <ShareForm :formId="f" />
+    </p>
+    <!-- TODO: Change this from temporary button to actually embedded in Manage page -->
+    <router-link :to="{ name: 'FormSettings', query: { f: f } }">
+      <v-btn color="blue" text small>
+        <v-icon class="mr-1">edit</v-icon>
+        <span>Edit Settings</span>
+      </v-btn>
+    </router-link>
+    <v-row>
+      <v-col cols="6">
+        <!-- TODO: Change this card to potentially use TeamManagement component -->
+        <v-card outlined>
+          <v-list-item three-line>
+            <v-list-item-content>
+              <div class="overline mb-4">
+                TEAM MANGEMENT
+                <router-link :to="{ name: 'FormTeams', query: { f: f } }">
+                  <v-btn color="blue" text small>
+                    <v-icon class="mr-1">edit</v-icon>
+                    <span>Edit</span>
+                  </v-btn>
+                </router-link>
+              </div>
+            </v-list-item-content>
+          </v-list-item>
+        </v-card>
       </v-col>
       <v-col cols="12" sm="4" class="text-sm-right">
         <span class="ml-5">

--- a/app/frontend/src/views/form/Preview.vue
+++ b/app/frontend/src/views/form/Preview.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <v-breadcrumbs v-if="!success" :items="breadcrumbs" />
     <FormViewer :formId="f" readOnly :versionId="v" />
   </div>
 </template>
@@ -16,21 +15,6 @@ export default {
   },
   components: {
     FormViewer,
-  },
-  computed: {
-    breadcrumbs() {
-      const path = [
-        {
-          text: 'Form',
-        },
-      ];
-      if (this.$route.meta.breadcrumbTitle) {
-        path.push({
-          text: this.$route.meta.breadcrumbTitle,
-        });
-      }
-      return path;
-    },
-  },
+  }
 };
 </script>

--- a/app/frontend/src/views/form/Submit.vue
+++ b/app/frontend/src/views/form/Submit.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <FormViewer :formId="f" :versionId="v" />
+    <FormViewer :formId="f" />
   </div>
 </template>
 

--- a/app/frontend/src/views/form/Submit.vue
+++ b/app/frontend/src/views/form/Submit.vue
@@ -13,8 +13,7 @@ export default {
     FormViewer,
   },
   props: {
-    f: String,
-    v: String,
+    f: String
   },
 };
 </script>

--- a/app/frontend/src/views/form/Teams.vue
+++ b/app/frontend/src/views/form/Teams.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <v-breadcrumbs :items="breadcrumbs" />
     <h1 class="my-6 text-center">Team Management</h1>
     <TeamManagement :formId="f" />
   </div>
@@ -19,24 +18,6 @@ export default {
       type: String,
       required: true,
     },
-  },
-  computed: {
-    breadcrumbs() {
-      const path = [
-        {
-          text: 'Form',
-        },
-        {
-          text: 'Manage Form'
-        }
-      ];
-      if (this.$route.meta.breadcrumbTitle) {
-        path.push({
-          text: this.$route.meta.breadcrumbTitle,
-        });
-      }
-      return path;
-    },
-  },
+  }
 };
 </script>

--- a/app/frontend/src/views/form/View.vue
+++ b/app/frontend/src/views/form/View.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <v-breadcrumbs :items="breadcrumbs" />
     <FormViewer
       :formId="f"
       :versionId="v"
@@ -21,24 +20,6 @@ export default {
   },
   components: {
     FormViewer,
-  },
-  computed: {
-    breadcrumbs() {
-      const path = [
-        {
-          text: 'Form',
-        },
-        {
-          text: 'Submissions'
-        }
-      ];
-      if (this.$route.meta.breadcrumbTitle) {
-        path.push({
-          text: this.$route.meta.breadcrumbTitle,
-        });
-      }
-      return path;
-    },
-  },
+  }
 };
 </script>

--- a/app/frontend/src/views/user/Forms.vue
+++ b/app/frontend/src/views/user/Forms.vue
@@ -1,11 +1,6 @@
 <template>
   <div>
     <h1 class="my-6 text-center">My Forms</h1>
-    <div class="text-right">
-      <strong>
-        <router-link :to="{ name: 'FormCreate' }">Create a New Form</router-link>
-      </strong>
-    </div>
     <FormsTable />
   </div>
 </template>

--- a/app/frontend/src/views/user/History.vue
+++ b/app/frontend/src/views/user/History.vue
@@ -1,27 +1,11 @@
 <template>
   <div>
-    <v-breadcrumbs :items="breadcrumbs" />
     <h1 class="my-6 text-center">Your Submission History (TBD)</h1>
   </div>
 </template>
 
 <script>
 export default {
-  name: 'UserHistory',
-  computed: {
-    breadcrumbs() {
-      const path = [
-        {
-          text: 'User',
-        },
-      ];
-      if (this.$route.meta.breadcrumbTitle) {
-        path.push({
-          text: this.$route.meta.breadcrumbTitle,
-        });
-      }
-      return path;
-    },
-  },
+  name: 'UserHistory'
 };
 </script>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1632
When Launching the form, or getting the Share URL, the version ID should not be relevant. The form submit page should just call the endpoint that fetches the currently published form version.
Old submissions should call the endpoint to get the specific version schema.

https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1639
Remove breadcrumbs for now

Also was missing the update form call when updating settings on manage, so added that back in.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->