### PR TITLE
Include public data in submission data (export) view

### DIFF
--- a/app/src/db/migrations/20201019100738_007-public-submission-data-vw.js
+++ b/app/src/db/migrations/20201019100738_007-public-submission-data-vw.js
@@ -14,7 +14,7 @@ order by s."createdAt", s."formName", s.version`));
 };
 
 exports.down = function (knex) {
-  // Restore original definition of this view from 001-views
+  // Restore original definition of this view from 005
   return Promise.resolve()
     .then(() => knex.schema.raw(`create or replace view submissions_data_vw as  
 select s."confirmationId", s."formName", s.version, s."createdAt",

--- a/app/src/db/migrations/20201019100738_007-public-submission-data-vw.js
+++ b/app/src/db/migrations/20201019100738_007-public-submission-data-vw.js
@@ -1,0 +1,30 @@
+
+exports.up = function (knex) {
+  return Promise.resolve()
+    .then(() => knex.schema.raw(`create or replace view submissions_data_vw as  
+select s."confirmationId", s."formName", s.version, s."createdAt",
+       case when u.id is null then 'public'::varchar(255) else u."fullName" end as "fullName", case when u.id is null then 'public'::varchar(255) else u.username end as "username", u.email,
+       fs.submission -> 'data' AS "submission", s.deleted, s.draft,
+       s."submissionId", s."formId", s."formVersionId", u.id as "userId", u."keycloakId", u."firstName", u."lastName"
+from submissions_vw s
+    inner join form_submission fs on s."submissionId" = fs.id
+    left outer join form_submission_user fsu on s."submissionId" = fsu."formSubmissionId" and fsu.permission = 'submission_create'
+    left outer join "user" u on fsu."userId" = u.id
+order by s."createdAt", s."formName", s.version`));
+};
+
+exports.down = function (knex) {
+  // Restore original definition of this view from 001-views
+  return Promise.resolve()
+    .then(() => knex.schema.raw(`create or replace view submissions_data_vw as  
+select s."confirmationId", s."formName", s.version, s."createdAt",
+       u."fullName", u.username, u.email,
+       fs.submission -> 'data' AS "submission", s.deleted, s.draft,
+       s."submissionId", s."formId", s."formVersionId", u.id as "userId", u."keycloakId", u."firstName", u."lastName"
+from submissions_vw s
+    inner join form_submission fs on s."submissionId" = fs.id
+    inner join form_submission_user fsu on s."submissionId" = fsu."formSubmissionId" and fsu.permission = 'submission_create'
+    inner join "user" u on fsu."userId" = u.id
+order by s."createdAt", s."formName", s.version`));
+};
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Public users do not get permissions to a submission, but their data needs to be included in export.
The underlying view used for exports would not include any of their data, so use left outer joins on the permissions table and account for nulls in fullName and username fields (as we do with their currentUser tokens).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->