### PR TITLE
Make sure form.name is a string

### DIFF
--- a/app/src/forms/common/models/models.js
+++ b/app/src/forms/common/models/models.js
@@ -10,6 +10,15 @@ class Form extends Timestamps(Model) {
     return 'form';
   }
 
+  $parseDatabaseJson(json) {
+    json = super.$parseDatabaseJson(json);
+    // Need to make sure that name is a string (could be a number)
+    if (json.name !== undefined) {
+      json.name = json.name.toString();
+    }
+    return json;
+  }
+
   snake() {
     // like a slug, but not guaranteed to be unique (as names are not unique).
     // use this for file names or any other instances we want a standardized name without punctuation etc.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
If Form name is entered as a number, when knex reads from the DB, it auto converts to a number. We need it to be a string because of our virtual attribute: snake.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->