### PR TITLE
Fix and improve page leave warnings

### DIFF
--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -41,7 +41,7 @@ export default {
       currentForm: {},
       submissionRecord: {},
       version: 0,
-      versionIdToSubmitTo: this.versionId
+      versionIdToSubmitTo: this.versionId,
     };
   },
   computed: {
@@ -56,6 +56,7 @@ export default {
   },
   methods: {
     ...mapActions('notifications', ['addNotification']),
+    ...mapActions('form', ['setDirtyFlag']),
     // Get the data for a form submission
     async getFormData() {
       try {
@@ -168,10 +169,7 @@ export default {
       // console.info(`onSubmit(${JSON.stringify(submission)})`) ; // eslint-disable-line no-console
       this.currentForm.events.emit('formio.submitDone');
     },
-    onSubmitDone() {
-      // Once the form is done disable the native browser "leave site" message so they can quit without getting whined at
-      window.onbeforeunload = null;
-
+    async onSubmitDone() {
       // huzzah!
       // really nothing to do, the formio button has consumed the event and updated its display
       // is there anything here for us to do?
@@ -201,7 +199,7 @@ export default {
 @import 'https://unpkg.com/formiojs@4.11.2/dist/formio.builder.min.css';
 
 .form-wrapper ::v-deep .formio-form {
-  &.formio-read-only{
+  &.formio-read-only {
     // in submission review mode, make readonly formio fields consistently greyed-out
     .form-control,
     .formio-component-simpletextarea .card-body.bg-light,

--- a/app/frontend/src/store/modules/form.js
+++ b/app/frontend/src/store/modules/form.js
@@ -140,8 +140,8 @@ export default {
       commit('SET_FORM', genInitialForm());
     },
     async setDirtyFlag({ commit, state }, isDirty) {
-      // When the form is deteced to be dirty set the browser gaurds for closing the tab etc
-      // There are also Vue route-specific gaurds so that we can ask before navigating away with the links
+      // When the form is detected to be dirty set the browser guards for closing the tab etc
+      // There are also Vue route-specific guards so that we can ask before navigating away with the links
       // Look for those in the Views for the relevant pages, look for "beforeRouteLeave" lifecycle
       if (!state.form || state.form.isDirty === isDirty) return; // don't do anything if not changing the val (or if form is blank for some reason)
       window.onbeforeunload = isDirty ? () => true : null;

--- a/app/frontend/src/store/modules/form.js
+++ b/app/frontend/src/store/modules/form.js
@@ -7,6 +7,7 @@ const genInitialForm = () => ({
   description: '',
   id: '',
   idps: [],
+  isDirty: false,
   name: '',
   userType: 'team'
 });
@@ -48,6 +49,9 @@ export default {
     },
     SET_FORM(state, form) {
       state.form = form;
+    },
+    SET_FORM_DIRTY(state, isDirty) {
+      state.form.isDirty = isDirty;
     },
     SET_FORM_PERMISSIONS(state, permissions) {
       state.permissions = permissions;
@@ -134,6 +138,14 @@ export default {
     },
     resetForm({ commit }) {
       commit('SET_FORM', genInitialForm());
+    },
+    async setDirtyFlag({ commit, state }, isDirty) {
+      // When the form is deteced to be dirty set the browser gaurds for closing the tab etc
+      // There are also Vue route-specific gaurds so that we can ask before navigating away with the links
+      // Look for those in the Views for the relevant pages, look for "beforeRouteLeave" lifecycle
+      if (!state.form || state.form.isDirty === isDirty) return; // don't do anything if not changing the val (or if form is blank for some reason)
+      window.onbeforeunload = isDirty ? () => true : null;
+      commit('SET_FORM_DIRTY', isDirty);
     },
     async updateForm({ state, dispatch }) {
       try {

--- a/app/frontend/src/views/form/Create.vue
+++ b/app/frontend/src/views/form/Create.vue
@@ -71,12 +71,9 @@ export default {
     },
   },
   beforeRouteLeave(to, from, next) {
-    const answer = window.confirm('Do you really want to leave this page?');
-    if (answer) {
-      next();
-    } else {
-      next(false);
-    }
+    window.confirm('Do you really want to leave this page?')
+      ? next()
+      : next(false);
   },
 };
 </script>

--- a/app/frontend/src/views/form/Create.vue
+++ b/app/frontend/src/views/form/Create.vue
@@ -53,7 +53,7 @@ export default {
     FormDesigner,
     FormSettings,
   },
-  computed: mapFields('form', ['form.idps', 'form.userType']),
+  computed: mapFields('form', ['form.idps', 'form.isDirty', 'form.userType']),
   data() {
     return {
       creatorStep: 1,
@@ -71,9 +71,9 @@ export default {
     },
   },
   beforeRouteLeave(to, from, next) {
-    window.confirm('Do you really want to leave this page?')
-      ? next()
-      : next(false);
+    this.isDirty
+      ? next(window.confirm('Do you really want to leave this page? Changes you made will not be saved.'))
+      : next();
   },
 };
 </script>

--- a/app/frontend/src/views/form/Design.vue
+++ b/app/frontend/src/views/form/Design.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import FormDesigner from '@/components/designer/FormDesigner.vue';
 
 export default {
@@ -15,6 +16,12 @@ export default {
   props: {
     f: String,
     v: String,
+  },
+  computed: mapGetters('form', ['form']),
+  beforeRouteLeave(to, from, next) {
+    this.form.isDirty
+      ? next(window.confirm('Do you really want to leave this page? Changes you made will not be saved.'))
+      : next();
   },
 };
 </script>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Fix so create page asks you if you want to leave again. This is for close tab/browser or refresh.
Add Vue route guards so that you get prompted if you use a nav, go back etc.
Add a dirty flag on change to trigger when to do either of these.

Changes to create new form and edit form.
No changes to Submit mode, since that opens a new instance of the form there's no navigating so keeping it simple as it is.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->