### PR TITLE
Allow Public and IDP submitter access regardless of roles.

### DIFF
--- a/app/src/forms/auth/service.js
+++ b/app/src/forms/auth/service.js
@@ -146,34 +146,37 @@ const service = {
   },
 
   filterForms: (userInfo, items, accessLevels = []) => {
+    // note that the user form access query returns submitter roles for everyone
+    // we need to filter out the true access level here.
+    // so we need a role, or a valid idp from login, or form needs to be public.
     let forms = [];
-    // we always remove idp only access forms that do not match our idp.
-    let idpFiltered = items.filter(x => {
-      return x.roles.length || (!x.roles.length && (x.idps.includes('public') || x.idps.includes(userInfo.idp)));
+
+    let filtered = items.filter(x => {
+      // include if user has idp, or form is public, or user has an explicit role.
+      return x.idps.includes(userInfo.idp) || x.idps.includes('public') || x.roles.length;
     });
 
     if (accessLevels && accessLevels.length) {
-      idpFiltered.forEach(item => {
+      filtered.forEach(item => {
         let hasPublic = false;
         let hasIdp = false;
         let hasTeam = false;
-        let hasElevated = false;
         if (accessLevels.includes('public')) {
-          // must have public in form idps and must not have any roles...
-          hasPublic = item.idps.includes('public') && !item.roles.length;
+          // must have public in form idps...
+          hasPublic = item.idps.includes('public');
         } else if (accessLevels.includes('idp')) {
-          // must have user's idp in idps and not have any roles...
-          hasIdp = item.idps.includes(userInfo.idp) && !item.roles.length;
+          // must have user's idp in idps...
+          hasIdp = item.idps.includes(userInfo.idp);
         } else if (accessLevels.includes('team')) {
           // must have a role...
           hasTeam = item.roles.length;
         }
-        if (hasPublic || hasIdp || hasTeam || hasElevated) {
+        if (hasPublic || hasIdp || hasTeam) {
           forms.push(service.formAccessToForm(item));
         }
       });
     } else {
-      forms = idpFiltered.map(item => service.formAccessToForm(item));
+      forms = filtered.map(item => service.formAccessToForm(item));
     }
     return forms;
   },

--- a/app/src/forms/permission/service.js
+++ b/app/src/forms/permission/service.js
@@ -32,9 +32,9 @@ const service = {
 
   read: async (code) => {
     return Permission.query()
-      .findById(code)
+      .findOne('code', code)
       .allowGraph('[roles]')
-      .withGraphFetched('roles(orderNameAscending)')
+      .withGraphFetched('roles(orderDefault)')
       .throwIfNotFound();
   },
 

--- a/app/src/forms/role/service.js
+++ b/app/src/forms/role/service.js
@@ -32,9 +32,9 @@ const service = {
 
   read: async (code) => {
     return Role.query()
-      .findById(code)
+      .findOne('code', code)
       .allowGraph('[permissions]')
-      .withGraphFetched('permissions(orderNameAscending)')
+      .withGraphFetched('permissions(orderDefault)')
       .throwIfNotFound();
   },
 


### PR DESCRIPTION
See [SHOWCASE-1730](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1730)

The issue was that any role assignment was considered more important than the Public or IDP access.  If a form is Public, the user should always have submission permissions ({submission_create,form_read}).  If a form is protected by a particular IDP and the use has that IDP, they should always have submission permissions ({submission_create,form_read}).  It shouldn't matter if they have other roles (which may NOT include submission permissions).
Basically, make public/IDP permissions additive to role permissions.

Also... Bugfix read for permission and role.  D'oh.

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->