### PR TITLE
Email service for Submission notifications

### DIFF
--- a/app/src/forms/email/assets/confirmation-number-email.html
+++ b/app/src/forms/email/assets/confirmation-number-email.html
@@ -1,0 +1,112 @@
+<div class="WordSection1">
+  <p class="MsoNormal"><span lang="EN-US">&nbsp;</span></p>
+  <table class="MsoNormalTable" border="0" cellspacing="0" cellpadding="0" width="518"
+         style="width:388.65pt; background:#003366; border-collapse:collapse">
+    <tbody>
+    <tr>
+      <td width="217" colspan="2" valign="top"
+          style="width:163.05pt; border-top:none; border-left:solid windowtext 1.0pt; border-bottom:solid #FCBA19 3.0pt; border-right:none; padding:3mm 0mm 3mm 3mm">
+        <img src="https://www2.gov.bc.ca/StaticWebResources/static/gov3/images/gov_bc_logo.svg"
+             alt="Government of B.C." title="Government of B.C.">
+      </td>
+      <td width="207" colspan="2"
+          style="width:155.05pt; border:none; border-bottom:solid #FCBA19 3.0pt; padding:0cm 0cm 0cm 0cm">
+        <p class="MsoNormal" align="center"
+           style="margin-bottom:0cm; margin-bottom:.0001pt; text-align:center; line-height:normal">
+          <span style="font-size:16.0pt; color:white">{{ title }}</span></p>
+      </td>
+      <td width="94" colspan="2"
+          style="width:70.55pt; border:none; border-bottom:solid #FCBA19 3.0pt; padding:0cm 0cm 0cm 0cm">
+        <p class="MsoNormal" align="center"
+           style="margin-bottom:0cm; margin-bottom:.0001pt; text-align:center; line-height:normal">
+          <span style="font-size:16.0pt">&nbsp;</span></p>
+      </td>
+    </tr>
+    <tr style="height:13.6pt">
+      <td width="47" valign="top"
+          style="width:35.45pt; border:none; border-left:solid #D9D9D9 1.0pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:13.6pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          &nbsp;</p>
+      </td>
+      <td width="184" colspan="2" valign="top"
+          style="width:138.25pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:13.6pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          <span style="font-size:12.0pt; color:#595959">&nbsp;</span></p>
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          <span style="font-size:12.0pt; color:#595959">Confirmation Number</span></p>
+      </td>
+      <td width="232" colspan="2" valign="top"
+          style="width:173.8pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:13.6pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          <b><span style="font-size:12.0pt; color:#595959">&nbsp;</span></b></p>
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          <b><span style="font-size:12.0pt; color:#595959">{{ confirmationNumber }}</span></b></p>
+      </td>
+      <td width="55" valign="top"
+          style="width:41.15pt; border:none; border-right:solid #D9D9D9 1.0pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:13.6pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          &nbsp;</p>
+      </td>
+    </tr>
+
+    <tr style="height:25pt">
+      <td width="47" valign="top"
+          style="width:35.45pt; border:none; border-left:solid #D9D9D9 1.0pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:56.9pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          &nbsp;</p>
+      </td>
+      <td width="416" colspan="4" valign="top"
+          style="width:312.05pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:56.9pt">
+
+      </td>
+      <td width="55" valign="top"
+          style="width:41.15pt; border:none; border-right:solid #D9D9D9 1.0pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:56.9pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          &nbsp;</p>
+      </td>
+    </tr>
+    <tr>
+      <td width="47" valign="top"
+          style="width:41.15pt; border:none; border-left:solid #D9D9D9 1.0pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:56.9pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          &nbsp;</p>
+      </td>
+      <td colspan="4" width="416" valign="top"
+          style="width:41.15pt; border:none; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:56.9pt">
+        <p>
+          <a href="{{ messageLinkUrl }}">{{ messageLinkText }}</a>
+        </p>
+      </td>
+      <td width="55" valign="top"
+          style="width:41.15pt; border:none; border-right:solid #D9D9D9 1.0pt; background:white; padding:0cm 5.4pt 0cm 5.4pt; height:56.9pt">
+        <p class="MsoNormal" style="margin-bottom:0cm; margin-bottom:.0001pt; line-height:normal">
+          &nbsp;</p>
+      </td>
+    </tr>
+    <tr style="height:22.3pt">
+      <td width="518" colspan="6"
+          style="width:388.65pt; border:none; border-top:solid #FCBA19 3.0pt; padding:0cm 5.4pt 0cm 5.4pt; height:22.3pt">
+        <p class="MsoNormal" align="right"
+           style="margin-bottom:0cm; margin-bottom:.0001pt; text-align:right; line-height:normal">
+            <span style="color:white">
+              <a href="https://github.com/bcgov/common-hosted-email-service" target="_blank"
+                 title="Data Source Feedback">
+                <span style="color:white; text-decoration:none">Email powered by BC Gov Common Services</span>
+              </a>
+            </span>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td width="59" style="width:44.25pt; padding:0cm 0cm 0cm 0cm"></td>
+      <td width="213" style="width:159.75pt; padding:0cm 0cm 0cm 0cm"></td>
+      <td width="18" style="width:13.5pt; padding:0cm 0cm 0cm 0cm"></td>
+      <td width="241" style="width:180.75pt; padding:0cm 0cm 0cm 0cm"></td>
+      <td width="49" style="width:36.75pt; padding:0cm 0cm 0cm 0cm"></td>
+      <td width="69" style="width:51.75pt; padding:0cm 0cm 0cm 0cm"></td>
+    </tr>
+    </tbody>
+  </table>
+  <p class="MsoNormal"><span lang="EN-US">&nbsp;</span></p>
+  <p class="MsoNormal"><span>&nbsp;</span></p>
+</div>

--- a/app/src/forms/email/emailService.js
+++ b/app/src/forms/email/emailService.js
@@ -1,0 +1,142 @@
+const chesService = require('../../components/chesService');
+const fs = require('fs');
+const log = require('npmlog');
+const path = require('path');
+
+const formService = require('../form/service');
+
+const service = {
+
+  _appUrl: (referer) => {
+    try {
+      const url = new URL(referer);
+      const p = url.pathname.split('/')[1];
+      const u = url.href.substring(0, url.href.indexOf(`/${p}`));
+      return `${u}/${p}`;
+    } catch (err) {
+      log.error('_appUrl', `URL = ${JSON.stringify(referer)}. Error: ${err.message}.`);
+      log.error(err);
+      throw err;
+    }
+  },
+
+  _sendSubmissionConfirmation: async (form, submission, body, referer) => {
+    // body = { to }
+    if (form.showSubmissionConfirmation) {
+      try {
+        // these may get persisted at some point...
+        // along with a template path, mess
+        const config = {
+          template: 'confirmation-number-email.html',
+          from: 'donotreply@gov.bc.ca',
+          subject: `${form.name} Submission`,
+          title: `${form.name} Submission`,
+          priority: 'normal',
+          messageLinkText: 'Click to view your Submission',
+          messageLinkUrl: `${service._appUrl(referer)}/form/view?s=`
+        };
+
+        const assetsPath = path.join(__dirname, 'assets');
+        const emailBody = fs.readFileSync(`${assetsPath}/${config.template}`, 'utf8');
+
+        const contexts = [
+          {
+            context: {
+              confirmationNumber: submission.confirmationId,
+              title: config.title,
+              messageLinkText: config.messageLinkText,
+              messageLinkUrl: `${config.messageLinkUrl}${submission.submission.id}`
+            },
+            to: [body.to]
+          }
+        ];
+
+        const data = {
+          body: emailBody,
+          bodyType: 'html',
+          contexts: contexts,
+          ...config
+        };
+        return await chesService.merge(data);
+      } catch (err) {
+        log.error('sendSubmissionConfirmation', `Error: ${err.message}.`);
+        log.error(err);
+        throw err;
+      }
+    }
+  },
+
+  _sendSubmissionReceived: async (form, submission, referer) => {
+    if (form.submissionReceivedEmails && form.submissionReceivedEmails.length) {
+      try {
+        // these may get persisted at some point...
+        // along with a template path, mess
+        const config = {
+          template: 'confirmation-number-email.html',
+          from: 'donotreply@gov.bc.ca',
+          subject: `${form.name} Accepted`,
+          title: `${form.name} Accepted`,
+          priority: 'normal',
+          messageLinkText: `Please login to view the details of this ${form.name} submission`,
+          messageLinkUrl: `${service._appUrl(referer)}/form/submissions?f=`
+        };
+
+        const assetsPath = path.join(__dirname, 'assets');
+        const emailBody = fs.readFileSync(`${assetsPath}/${config.template}`, 'utf8');
+
+        const contexts = [
+          {
+            context: {
+              confirmationNumber: submission.confirmationId,
+              title: config.title,
+              messageLinkText: config.messageLinkText,
+              messageLinkUrl: `${config.messageLinkUrl}${form.id}`
+            },
+            to: form.submissionReceivedEmails
+          }
+        ];
+
+        const data = {
+          body: emailBody,
+          bodyType: 'html',
+          contexts: contexts,
+          ...config
+        };
+        return await chesService.merge(data);
+      } catch (err) {
+        log.error('sendSubmissionReceived', `Error: ${err.message}.`);
+        log.error(err);
+        throw err;
+      }
+    }
+  },
+
+  submissionConfirmation: async (formId, submissionId, body, referer) => {
+    try {
+      const form = await formService.readForm(formId);
+      const submission = await formService.readSubmission(submissionId);
+      return service._sendSubmissionConfirmation(form, submission, body, referer);
+    } catch (e) {
+      // only want logging for failed notifications
+      log.error('submissionConfirmation', `formId: ${formId}, submissionId: ${submissionId}, body: ${JSON.stringify(body)}, referer: ${referer}`);
+      log.error('submissionConfirmation', e.message);
+      log.error(e);
+    }
+  },
+
+  submissionReceived: async (formId, submissionId, referer) => {
+    try {
+      const form = await formService.readForm(formId);
+      const submission = await formService.readSubmission(submissionId);
+      return service._sendSubmissionReceived(form, submission, referer);
+    } catch (e) {
+      // only want logging for failed notifications
+      log.error('submissionReceived', `formId: ${formId}, submissionId: ${submissionId}, referer: ${referer}`);
+      log.error('submissionReceived', e.message);
+      log.error(e);
+    }
+  }
+
+};
+
+module.exports = service;

--- a/app/src/forms/email/emailService.js
+++ b/app/src/forms/email/emailService.js
@@ -117,10 +117,10 @@ const service = {
       const submission = await formService.readSubmission(submissionId);
       return service._sendSubmissionConfirmation(form, submission, body, referer);
     } catch (e) {
-      // only want logging for failed notifications
       log.error('submissionConfirmation', `formId: ${formId}, submissionId: ${submissionId}, body: ${JSON.stringify(body)}, referer: ${referer}`);
       log.error('submissionConfirmation', e.message);
       log.error(e);
+      throw e;
     }
   },
 
@@ -130,10 +130,10 @@ const service = {
       const submission = await formService.readSubmission(submissionId);
       return service._sendSubmissionReceived(form, submission, referer);
     } catch (e) {
-      // only want logging for failed notifications
       log.error('submissionReceived', `formId: ${formId}, submissionId: ${submissionId}, referer: ${referer}`);
       log.error('submissionReceived', e.message);
       log.error(e);
+      throw e;
     }
   }
 

--- a/app/src/forms/email/emailService.js
+++ b/app/src/forms/email/emailService.js
@@ -45,7 +45,7 @@ const service = {
               confirmationNumber: submission.confirmationId,
               title: config.title,
               messageLinkText: config.messageLinkText,
-              messageLinkUrl: `${config.messageLinkUrl}${submission.submission.id}`
+              messageLinkUrl: `${config.messageLinkUrl}${submission.id}`
             },
             to: [body.to]
           }

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -1,5 +1,6 @@
-const service = require('./service');
+const emailService = require('../email/emailService');
 const exportService = require('./exportService');
+const service = require('./service');
 
 module.exports = {
   export: async (req, res, next) => {
@@ -104,6 +105,7 @@ module.exports = {
   createSubmission:  async (req, res, next) => {
     try {
       const response = await service.createSubmission(req.params.formVersionId, req.body, req.currentUser);
+      emailService.submissionReceived(req.params.formId, response.id, req.headers.referer);
       res.status(201).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -105,7 +105,7 @@ module.exports = {
   createSubmission:  async (req, res, next) => {
     try {
       const response = await service.createSubmission(req.params.formVersionId, req.body, req.currentUser);
-      emailService.submissionReceived(req.params.formId, response.id, req.headers.referer);
+      emailService.submissionReceived(req.params.formId, response.id, req.headers.referer).catch(() => {});
       res.status(201).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -1,3 +1,4 @@
+const emailService = require('../email/emailService');
 const service = require('./service');
 
 module.exports = {
@@ -13,6 +14,15 @@ module.exports = {
     try {
       const response = await service.update(req.params.formSubmissionId, req.body, req.currentUser);
       res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  },
+  email: async (req, res, next) => {
+    try {
+      const submission = await service.read(req.params.formSubmissionId, req.currentUser);
+      emailService.submissionConfirmation(submission.form.id, req.params.formSubmissionId, req.body, req.headers.referer);
+      res.sendStatus(202);
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -21,8 +21,8 @@ module.exports = {
   email: async (req, res, next) => {
     try {
       const submission = await service.read(req.params.formSubmissionId, req.currentUser);
-      emailService.submissionConfirmation(submission.form.id, req.params.formSubmissionId, req.body, req.headers.referer);
-      res.sendStatus(202);
+      const response = await emailService.submissionConfirmation(submission.form.id, req.params.formSubmissionId, req.body, req.headers.referer);
+      res.status(200).json(response);
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -14,4 +14,8 @@ routes.put('/:formSubmissionId', async (req, res, next) => {
   await controller.update(req, res, next);
 });
 
+routes.post('/:formSubmissionId/email', async (req, res, next) => {
+  await controller.email(req, res, next);
+});
+
 module.exports = routes;

--- a/app/tests/unit/routes/v1/form.spec.js
+++ b/app/tests/unit/routes/v1/form.spec.js
@@ -458,7 +458,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
   it('should return 201', async () => {
     // mock a success return value...
     service.createSubmission = jest.fn().mockReturnValue(createSubmissionResult);
-    emailService.submissionReceived = jest.fn().mockReturnValue(true);
+    emailService.submissionReceived = jest.fn(() => Promise.resolve({}));
 
     const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
 
@@ -490,7 +490,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
 
   it('should handle error from email service gracefully', async () => {
     service.createSubmission = jest.fn().mockReturnValue(createSubmissionResult);
-    emailService._sendSubmissionReceived = jest.fn(() => { throw new Error(); });
+    emailService.submissionReceived = jest.fn(() => Promise.reject({}));
 
     const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
 

--- a/app/tests/unit/routes/v1/submission.spec.js
+++ b/app/tests/unit/routes/v1/submission.spec.js
@@ -102,14 +102,14 @@ describe(`PUT ${basePath}/ID`, () => {
 describe(`POST ${basePath}/ID/email`, () => {
 
   const submissionResult = { form: { id: '' }, submission: { id: ''}, version: { id: '' } };
-  it('should return 202', async () => {
+  it('should return 200', async () => {
     // mock a success return value...
     service.read = jest.fn().mockReturnValue(submissionResult);
     emailService.submissionConfirmation = jest.fn().mockReturnValue(true);
 
     const response = await request(app).post(`${basePath}/ID/email`, {to:'account@fake.com'});
 
-    expect(response.statusCode).toBe(202);
+    expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
   });
 
@@ -135,14 +135,14 @@ describe(`POST ${basePath}/ID/email`, () => {
     expect(response.body).toBeTruthy();
   });
 
-  it('should handle error from email service gracefully', async () => {
+  it('should handle 500 from email service', async () => {
     // mock an unexpected error from email.
     service.read = jest.fn().mockReturnValue(submissionResult);
-    emailService._sendSubmissionConfirmation = jest.fn(() => { throw new Error(); });
+    emailService.submissionConfirmation = jest.fn(() => { throw new Error(); });
 
     const response = await request(app).post(`${basePath}/ID/email`);
 
-    expect(response.statusCode).toBe(202);
+    expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
   });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Add email service to deliver emails for submission confirmation (submitter enters email and POSTS) and for submission received (emails go to configured staff).

Added new endpoint POST /submissions/ID/email body = {to: <email submitter fills out>}

Email service will throw errors, up to the caller how it is handled.

Expected that calling an email service, the permissions have already been checked, so this service will do no current user permission checking.

**IMPORTANT** since there is no persisted configuration for emails, I am using the request header referrer to determine the links in the email.  This does work on OpenShift and localhost, but using Postman you will need to set this header.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->