### PR TITLE
Filter My Forms list to not show forms you can just launch

### DIFF
--- a/app/frontend/src/components/designer/FormsTable.vue
+++ b/app/frontend/src/components/designer/FormsTable.vue
@@ -41,7 +41,7 @@
       class="submissions-table"
       :headers="headers"
       item-key="title"
-      :items="formList"
+      :items="filteredFormList"
       :search="search"
       :loading="loading"
       loading-text="Loading... Please wait"
@@ -111,6 +111,13 @@ export default {
   },
   computed: {
     ...mapGetters('form', ['formList']),
+    filteredFormList() {
+      // At this point, we're only showing forms you can manage or view submissions of here
+      // This may get reconceptualized in the future to different pages or something
+      return this.formList.filter(
+        (f) => checkFormManage(f) || checkSubmissionView(f)
+      );
+    },
   },
   methods: {
     ...mapActions('form', ['getFormsForCurrentUser']),

--- a/app/frontend/src/utils/permissionUtils.js
+++ b/app/frontend/src/utils/permissionUtils.js
@@ -29,7 +29,8 @@ export function checkFormManage(userForm) {
     FormPermissions.FORM_UPDATE,
     FormPermissions.FORM_DELETE,
     FormPermissions.DESIGN_UPDATE,
-    FormPermissions.DESIGN_DELETE
+    FormPermissions.DESIGN_DELETE,
+    FormPermissions.TEAM_UPDATE
   ];
   return userForm && userForm.permissions && userForm.permissions.some(p => perms.includes(p));
 }

--- a/app/frontend/tests/unit/store/modules/form.getters.spec.js
+++ b/app/frontend/tests/unit/store/modules/form.getters.spec.js
@@ -1,0 +1,67 @@
+import { cloneDeep } from 'lodash';
+import { createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import formStore from '@/store/modules/form';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('form getters', () => {
+  let store;
+
+  const sampleState = {
+    form: {
+      name: 'ABC'
+    },
+    formList: [
+      {
+        name: 'ABC'
+      }, {
+        name: 'XYZ'
+      }
+    ],
+    formSubmission: {
+      confirmationId: '1234',
+      submission: {
+        data: { field: '123' }
+      }
+    },
+    permissions: ['SUBMIT', 'READ'],
+    submissionList: ['test', 'sub'],
+    version: { type: 'form' }
+  };
+
+  beforeEach(() => {
+    store = new Vuex.Store(cloneDeep(formStore));
+    store.replaceState(cloneDeep(sampleState));
+  });
+
+  it('form should return the state form', () => {
+    expect(store.getters.form).toEqual(sampleState.form);
+  });
+
+  it('formlist should return the state formlist', () => {
+    expect(store.getters.formlist).toEqual(sampleState.formlist);
+  });
+
+  it('formSubmission should return the state formSubmission', () => {
+    expect(store.getters.formSubmission).toEqual(sampleState.formSubmission);
+  });
+
+  it('permissions should return the state permissions', () => {
+    expect(store.getters.permissions).toEqual(sampleState.permissions);
+  });
+
+  it('submissionList should return the state submissionList', () => {
+    expect(store.getters.submissionList).toEqual(sampleState.submissionList);
+  });
+
+  it('submissionList should return the state submissionList', () => {
+    expect(store.getters.submissionList).toEqual(sampleState.submissionList);
+  });
+
+  it('version should return the state version', () => {
+    expect(store.getters.version).toEqual(sampleState.version);
+  });
+});

--- a/app/frontend/tests/unit/store/modules/form.getters.spec.js
+++ b/app/frontend/tests/unit/store/modules/form.getters.spec.js
@@ -41,8 +41,8 @@ describe('form getters', () => {
     expect(store.getters.form).toEqual(sampleState.form);
   });
 
-  it('formlist should return the state formlist', () => {
-    expect(store.getters.formlist).toEqual(sampleState.formlist);
+  it('formList should return the state formList', () => {
+    expect(store.getters.formList).toEqual(sampleState.formList);
   });
 
   it('formSubmission should return the state formSubmission', () => {

--- a/app/frontend/tests/unit/utils/permissionUtils.spec.js
+++ b/app/frontend/tests/unit/utils/permissionUtils.spec.js
@@ -37,6 +37,7 @@ describe('checkFormManage', () => {
     expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.FORM_DELETE] })).toBeTruthy();
     expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.DESIGN_UPDATE] })).toBeTruthy();
     expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.DESIGN_DELETE] })).toBeTruthy();
+    expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.TEAM_UPDATE] })).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1768

Don't throw all the forms that you can only launch into the forms list. Those can be accessed by the share link.
We may revisit this in the future for a forms catalogue or a User forms screen.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->