### PR TITLE
Default ID mode in the form settings

### DIFF
--- a/app/frontend/src/components/designer/FormSettings.vue
+++ b/app/frontend/src/components/designer/FormSettings.vue
@@ -211,6 +211,9 @@ export default {
     if (this.formId) {
       this.id = this.formId;
       await this.fetchForm(this.id);
+    } else {
+      // default to TEAM on the form Settings when starting new
+      this.userType = this.ID_MODE.TEAM;
     }
     this.loading = false;
   },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
We set the default userType to blank in the store since it was used by Team Management as well. However, when creating a new form we still want the Team option checked by default, so specify in there when that component is created.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->