### PR TITLE
Hide / show 'file upload' component depending on form user type

### DIFF
--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -439,11 +439,11 @@ export default {
     }
   },
   watch: {
-    // if form userType (public, idir, team, etc) changes, re-render the form builder
-    userType() {
+    advancedForm() {
       this.reRenderFormIo += 1;
     },
-    advancedForm() {
+    // if form userType (public, idir, team, etc) changes, re-render the form builder
+    userType() {
       this.reRenderFormIo += 1;
     },
   },

--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -260,6 +260,12 @@ export default {
         return {
           builder: {
             premium: false,
+            basic: {
+              components: {
+                // add 'simplefile' file upload component to formBuilder in advanced mode
+                simplefile: this.userType !== this.ID_MODE.PUBLIC
+              }
+            }
           },
         };
       }
@@ -433,6 +439,10 @@ export default {
     }
   },
   watch: {
+    // if form userType (public, idir, team, etc) changes, re-render the form builder
+    userType() {
+      this.reRenderFormIo += 1;
+    },
     advancedForm() {
       this.reRenderFormIo += 1;
     },

--- a/app/frontend/src/lib/components/SimpleFile/Component.js
+++ b/app/frontend/src/lib/components/SimpleFile/Component.js
@@ -36,7 +36,7 @@ import editForm from './Component.form';
 import { Constants } from '../Common/Constants';
 var uniqueName = Utils.uniqueName;
 var ID = 'simplefile';
-var DISPLAY = 'Upload';
+var DISPLAY = 'File Upload';
 var Component = /** @class */ (function (_super) {
     __extends(Component, _super);
     function Component() {

--- a/components/src/components/SimpleFile/Component.ts
+++ b/components/src/components/SimpleFile/Component.ts
@@ -7,7 +7,7 @@ import { Constants } from '../Common/Constants';
 import uniqueName = Utils.uniqueName;
 
 const ID = 'simplefile';
-const DISPLAY = 'Upload';
+const DISPLAY = 'File Upload';
 
 export default class Component extends (ParentComponent as any) {
     static schema(...extend) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

deployed here:
https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-127/

# Description

ticket [https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1838](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1838)

- force a re-render of the formBuilder component (with injected options) when the form userType (public, idir, team, etc) is changed.

- add file upload component to for builder in 'advanced' mode
It sounded like we will need to re-visit UX issues when switching between basic and advanced. 



## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->