### PR TITLE
Skip coverage steps if CC test reporter is missing

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -44,8 +44,10 @@ jobs:
         env:
           CI: true
       - name: Save Coverage Results
-        if: github.ref == 'refs/heads/master' && matrix.node-version == '14.x'
+        if: env.CC_TEST_REPORTER_ID == 'true' && matrix.node-version == '14.x'
         uses: actions/upload-artifact@v2
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           name: coverage-app
           path: ${{ github.workspace }}/app/coverage
@@ -90,14 +92,15 @@ jobs:
         env:
           CI: true
       - name: Save Coverage Results
-        if: github.ref == 'refs/heads/master' && matrix.node-version == '14.x'
+        if: env.CC_TEST_REPORTER_ID == 'true' && matrix.node-version == '14.x'
         uses: actions/upload-artifact@v2
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           name: coverage-frontend
           path: ${{ github.workspace }}/app/frontend/coverage
           retention-days: 1
   test-coverage:
-    if: github.ref == 'refs/heads/master'
     needs:
       - test-app
       - test-frontend
@@ -110,6 +113,7 @@ jobs:
       - name: Restore Coverage Results
         uses: actions/download-artifact@v2
       - name: Publish code coverage
+        if: env.CC_TEST_REPORTER_ID == 'true'
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
We want to prevent situations where the test-coverage step fails because the secret is not defined. It is more reliable to determine whether to execute based on the existence of the secret variable instead.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->