### PR TITLE
Make draft look like the next version

### DIFF
--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -63,7 +63,7 @@
           <template #activator="{ on, attrs }">
             <router-link
               :to="{ name: 'FormManage', query: { f: formId } }"
-              :class="{ disabled_router: !formId }"
+              :class="{ 'disabled-router': !formId }"
             >
               <v-btn
                 class="mx-1"
@@ -483,7 +483,7 @@ export default {
 @import 'https://unpkg.com/formiojs@4.11.2/dist/formio.builder.min.css';
 
 /* disable router-link */
-.disabled_router {
+.disabled-router {
   pointer-events: none;
 }
 </style>

--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -61,7 +61,10 @@
         </v-tooltip>
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
-            <router-link :to="{ name: 'FormManage', query: { f: formId } }" :class="{ disabled_router: !formId }">
+            <router-link
+              :to="{ name: 'FormManage', query: { f: formId } }"
+              :class="{ disabled_router: !formId }"
+            >
               <v-btn
                 class="mx-1"
                 color="primary"
@@ -79,7 +82,9 @@
       </v-col>
     </v-row>
 
-    <p class="mb-3"><em>Version: {{ this.displayVersion }}</em></p>
+    <p class="mb-3">
+      <em>Version: {{ this.displayVersion }}</em>
+    </p>
 
     <v-alert
       v-if="saved || saving"
@@ -107,14 +112,16 @@
     </v-alert>
 
     <BaseInfoCard class="my-6">
-      <h4 class="primary--text"><v-icon class="mr-1" color="primary">info</v-icon>IMPORTANT!</h4>
+      <h4 class="primary--text">
+        <v-icon class="mr-1" color="primary">info</v-icon>IMPORTANT!
+      </h4>
       <p class="my-0">
-        Use the <strong>SAVE DESIGN</strong> button when you are
-        done building this form.
+        Use the <strong>SAVE DESIGN</strong> button when you are done building
+        this form.
       </p>
       <p class="my-0">
-        The <strong>SUBMIT</strong> button is provided for your user to submit this form and will
-        be activated after it is saved.
+        The <strong>SUBMIT</strong> button is provided for your user to submit
+        this form and will be activated after it is saved.
       </p>
     </BaseInfoCard>
     <v-row class="mt-4" no-gutters>
@@ -269,8 +276,8 @@ export default {
               default: false,
               components: {
                 // add 'simplefile' file upload component to formBuilder in advanced mode
-                simplefile: this.userType !== this.ID_MODE.PUBLIC
-              }
+                simplefile: this.userType !== this.ID_MODE.PUBLIC,
+              },
             },
             advanced: {
               weight: 30,
@@ -285,8 +292,6 @@ export default {
                 orgbook: true,
               },
             },
-
-
           },
         };
       }

--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -61,7 +61,7 @@
         </v-tooltip>
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
-            <router-link :to="{ name: 'FormManage', query: { f: formId } }">
+            <router-link :to="{ name: 'FormManage', query: { f: formId } }" :class="{ disabled_router: !formId }">
               <v-btn
                 class="mx-1"
                 color="primary"
@@ -79,7 +79,7 @@
       </v-col>
     </v-row>
 
-    <p v-if="draftId" class="mb-3"><em>Draft</em></p>
+    <p class="mb-3"><em>Version: {{ this.displayVersion }}</em></p>
 
     <v-alert
       v-if="saved || saving"
@@ -107,12 +107,13 @@
     </v-alert>
 
     <BaseInfoCard class="my-6">
+      <h4 class="primary--text"><v-icon class="mr-1" color="primary">info</v-icon>IMPORTANT!</h4>
       <p class="my-0">
-        Use the SAVE DESIGN (<v-icon small>save</v-icon>) button when you are
+        Use the <strong>SAVE DESIGN</strong> button when you are
         done building this form.
       </p>
       <p class="my-0">
-        The SUBMIT button is provided for your user to submit this form and will
+        The <strong>SUBMIT</strong> button is provided for your user to submit this form and will
         be activated after it is saved.
       </p>
     </BaseInfoCard>
@@ -174,6 +175,7 @@ export default {
         type: 'form',
         components: [],
       },
+      displayVersion: 1,
       reRenderFormIo: 0,
       saving: false,
     };
@@ -189,6 +191,7 @@ export default {
       'form.submissionReceivedEmails',
       'form.snake',
       'form.userType',
+      'form.versions',
     ]),
     ID_MODE() {
       return IdentityMode;
@@ -310,6 +313,8 @@ export default {
           consoleError: `Error loading form ${this.formId} schema (version: ${this.versionId} draft: ${this.draftId}): ${error}`,
         });
       }
+      // get a version number to show in header
+      this.displayVersion = this.versions.length + 1;
     },
     async loadFile(event) {
       try {
@@ -471,4 +476,9 @@ export default {
 <style lang="scss" scoped>
 @import '~font-awesome/css/font-awesome.min.css';
 @import 'https://unpkg.com/formiojs@4.11.2/dist/formio.builder.min.css';
+
+/* disable router-link */
+.disabled_router {
+  pointer-events: none;
+}
 </style>

--- a/app/frontend/src/components/forms/manage/ManageForm.vue
+++ b/app/frontend/src/components/forms/manage/ManageForm.vue
@@ -40,11 +40,21 @@
             <FormSettings :disabled="formSettingsDisabled" />
           </v-form>
 
-          <div v-if="canEditForm && !formSettingsDisabled" class="mb-5">
-            <v-btn class="mr-5" color="primary" @click="updateSettings">
+          <div
+            v-if="canEditForm && !formSettingsDisabled"
+            class="mb-5"
+          >
+            <v-btn
+              class="mr-5"
+              color="primary"
+              @click="updateSettings"
+            >
               <span>Update</span>
             </v-btn>
-            <v-btn outlined @click="cancelSettingsEdit">
+            <v-btn
+              outlined
+              @click="cancelSettingsEdit"
+            >
               <span>Cancel</span>
             </v-btn>
           </div>
@@ -107,13 +117,16 @@ export default {
       return this.permissions.includes(FormPermissions.FORM_UPDATE);
     },
     combinedVersionAndDraftCount() {
-      return ( (this.form.versions ? this.form.versions.length : 0) + (this.drafts ? this.drafts.length : 0) );
+      return (
+        (this.form.versions ? this.form.versions.length : 0) +
+        (this.drafts ? this.drafts.length : 0)
+      );
     },
     currentVersion() {
       let cv = 'N/A';
       if (this.form.versions && this.form.versions.length) {
         const vers = this.form.versions.find((v) => v.published);
-        if(vers) {
+        if (vers) {
           cv = vers.version;
         }
       }
@@ -122,8 +135,7 @@ export default {
     versionState() {
       if (this.form.versions && this.form.versions.some((v) => v.published)) {
         return `Published (ver ${this.currentVersion})`;
-      }
-      else {
+      } else {
         return 'Unpublished';
       }
     },

--- a/app/frontend/src/components/forms/manage/ManageForm.vue
+++ b/app/frontend/src/components/forms/manage/ManageForm.vue
@@ -11,7 +11,7 @@
             <v-icon class="icon">$expand</v-icon>
           </template>
           <div class="header">
-            <span>Form Settings</span>
+            <strong>Form Settings</strong>
             <span>
               <small>
                 Created: {{ form.createdAt | formatDate }} ({{
@@ -62,11 +62,11 @@
             <v-icon class="icon">$expand</v-icon>
           </template>
           <div class="header">
-            <span>Form Design</span>
+            <strong>Form Design History</strong>
             <div>
               <span>
-                <strong>Current Version:</strong>
-                {{ currentVersion }}
+                <strong>Total Versions:</strong>
+                {{ combinedVersionAndDraftCount }}
               </span>
               <span class="ml-12 mr-2">
                 <strong>Status:</strong>
@@ -106,6 +106,9 @@ export default {
     canEditForm() {
       return this.permissions.includes(FormPermissions.FORM_UPDATE);
     },
+    combinedVersionAndDraftCount() {
+      return ( (this.form.versions ? this.form.versions.length : 0) + (this.drafts ? this.drafts.length : 0) );
+    },
     currentVersion() {
       let cv = 'N/A';
       if (this.form.versions && this.form.versions.length) {
@@ -118,11 +121,10 @@ export default {
     },
     versionState() {
       if (this.form.versions && this.form.versions.some((v) => v.published)) {
-        return 'Published';
-      } else if (this.drafts && this.drafts.length) {
-        return 'Draft';
-      } else {
-        return 'Not Published';
+        return `Published (ver ${this.currentVersion})`;
+      }
+      else {
+        return 'Unpublished';
       }
     },
   },
@@ -163,7 +165,7 @@ export default {
 </script>
 
 <style>
-.v-expansion-panel:not(.v-expansion-panel--active){
-  margin-bottom: 30px;
+.v-expansion-panel:not(.v-expansion-panel--active) {
+  margin-bottom: 20px;
 }
 </style>

--- a/app/frontend/src/components/forms/manage/ManageVersions.vue
+++ b/app/frontend/src/components/forms/manage/ManageVersions.vue
@@ -233,8 +233,8 @@ export default {
         { text: 'Last Update', align: 'start', value: 'updatedAt' },
         {
           text: 'Actions',
-          value: 'action',
           align: 'end',
+          value: 'action',
           filterable: false,
           sortable: false,
           width: 200,
@@ -356,7 +356,8 @@ export default {
       this.fetchDrafts(this.form.id);
     },
 
-    onExportClick(id, isDraft) {
+    async onExportClick(id, isDraft) {
+      await this.getFormSchema(id, isDraft);
       let snek = this.form.snake;
       if (!this.form.snake) {
         snek = this.form.name
@@ -364,8 +365,6 @@ export default {
           .replace(/[^-_0-9a-z]/gi, '')
           .toLowerCase();
       }
-
-      this.getFormSchema(id, isDraft);
 
       const a = document.createElement('a');
       a.href = `data:application/json;charset=utf-8,${encodeURIComponent(

--- a/app/frontend/src/components/forms/manage/ManageVersions.vue
+++ b/app/frontend/src/components/forms/manage/ManageVersions.vue
@@ -1,41 +1,46 @@
 <template>
   <div>
     <BaseInfoCard class="my-4">
-      When you create a form, it becomes a Draft. Once you publish this form,
-      you are no longer able to edit it, instead you can create a new version
-      and edit from there. A new version of the form will carry the existing
-      version that you created. If you unpublish the form, the submitter won't
-      be able to access the form.
+      <h4 class="primary--text">
+        <v-icon class="mr-1" color="primary">info</v-icon>IMPORTANT!
+      </h4>
+      <p>If there are no published versions, users are unable to access this form until there
+        is a published version assigned. Once a version is published, that version is no longer editable. You must create a new version based on one of the previous form versions to continue editing.</p>
     </BaseInfoCard>
 
-    <CurrentDraft v-if="hasDraft" class="my-8" />
-
-    <strong>History</strong>
+    <div class="mt-8 mb-5">
+      <v-icon class="mr-1" color="primary">info</v-icon>Note: Only one version can be published.
+    </div>
     <v-data-table
       :key="rerenderTable"
       class="submissions-table"
       :headers="headers"
       :items="versionList"
     >
-      <template #no-data>
-        No versions yet. Publish a draft to release a form version.
-      </template>
-
       <!-- Version  -->
       <template #[`item.version`]="{ item }">
         <router-link
-          :to="{
-            name: 'FormPreview',
-            query: { f: item.formId, v: item.id },
-          }"
+          :to=" item.isDraft ? { name: 'FormPreview', query: { f: item.formId, d: item.id } } : { name: 'FormPreview', query: { f: item.formId, v: item.id } }"
           class="mx-5"
           target="_blank"
         >
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
-              <span v-bind="attrs" v-on="on">Version {{ item.version }}</span>
+              <span v-bind="attrs" v-on="on">
+                Version {{ item.version }}
+                <v-chip
+                  v-if="item.isDraft"
+                  class="mb-5 px-1"
+                  x-small
+                  color="secondary"
+                  text-color="black"
+                >Draft</v-chip>
+              </span>
             </template>
-            <span> Click to preview <v-icon>open_in_new</v-icon></span>
+            <span>
+              Click to preview
+              <v-icon>open_in_new</v-icon>
+            </span>
           </v-tooltip>
         </router-link>
       </template>
@@ -47,48 +52,100 @@
           value
           :input-value="item.published"
           :label="item.published ? 'Published' : 'Unpublished'"
-          @change="togglePublish($event, item.id, item.version)"
+          @change="togglePublish($event, item.id, item.version, item.isDraft)"
         />
       </template>
 
       <!-- Update date  -->
       <template #[`item.updatedAt`]="{ item }">
         {{ item.updatedAt | formatDateLong }}
-        - {{ item.updatedBy }}
+        - {{ item.updatedBy ? item.updatedBy : item.createdBy }}
       </template>
 
-      <!-- Create new version  -->
-      <template #[`item.create`]="{ item }">
+      <!-- Edit draft version -->
+      <template #[`item.edit`]="{ item }">
+        <div v-if="item.isDraft" class="a1">
+          <v-tooltip bottom>
+            <template #activator="{ on, attrs }">
+              <div v-bind="attrs" v-on="on">
+                <router-link
+                  :to="{
+                    name: 'FormDesigner',
+                    query: { d: item.id, f: item.formId },
+                  }"
+                >
+                  <v-btn color="primary" text small>
+                    <v-icon>edit</v-icon>
+                  </v-btn>
+                </router-link>
+              </div>
+            </template>
+            <span>Edit Version</span>
+          </v-tooltip>
+        </div>
+      </template>
+
+      <!-- export -->
+      <template #[`item.export`]="{ item }">
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
             <div v-bind="attrs" v-on="on">
-              <v-btn
-                :disabled="hasDraft"
-                color="primary"
-                text
-                small
-                @click="createVersion(item.formId, item.id)"
-              >
-                <v-icon>add_circle</v-icon>
+              <v-btn color="primary" text small @click="onExportClick(item.id, item.isDraft)">
+                <v-icon>get_app</v-icon>
               </v-btn>
             </div>
           </template>
-          <span v-if="hasDraft">
-            Please edit, publish or delete the existing draft before starting a
-            new draft.
-          </span>
-          <span v-else>
-            Use version {{ item.version }} as the base for a new version
-          </span>
+          <span>Export Design</span>
         </v-tooltip>
+      </template>
+
+      <template #[`item.action`]="{ item }">
+        <!-- create new version -->
+        <div v-if="!item.isDraft">
+          <v-tooltip bottom>
+            <template #activator="{ on, attrs }">
+              <div v-bind="attrs" v-on="on">
+                <v-btn
+                  :disabled="hasDraft"
+                  color="primary"
+                  text
+                  small
+                  @click="createVersion(item.formId, item.id)"
+                >
+                  <v-icon>add</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            <span v-if="hasDraft">
+              Please publish or delete your latest draft version before starting a
+              new version.
+            </span>
+            <span v-else>Use version {{ item.version }} as the base for a new version</span>
+          </v-tooltip>
+        </div>
+
+        <!-- delete draft version -->
+        <div v-if="item.isDraft">
+          <v-tooltip bottom>
+            <template #activator="{ on, attrs }">
+              <v-btn
+                class="mx-1"
+                color="red"
+                @click="showDeleteDraftDialog = true"
+                icon
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon>delete</v-icon>
+              </v-btn>
+            </template>
+            <span>Delete Version</span>
+          </v-tooltip>
+        </div>
       </template>
     </v-data-table>
 
-    <BaseDialog
-      v-model="showHasDraftsDialog"
-      type="OK"
-      @close-dialog="showHasDraftsDialog = false"
-    >
+    <BaseDialog v-model="showHasDraftsDialog" type="OK" @close-dialog="showHasDraftsDialog = false">
       <template #title>Draft already exists</template>
       <template #text>
         Please edit, publish or delete the existing draft before starting a new
@@ -103,19 +160,30 @@
       @close-dialog="cancelPublish"
     >
       <template #title>
-        <span v-if="publishOpts.publishing">
-          Publish Version {{ publishOpts.version }}
-        </span>
+        <span v-if="publishOpts.publishing">Publish Version {{ publishOpts.version }}</span>
         <span v-else>Unpublish Version {{ publishOpts.version }}</span>
       </template>
       <template #text>
-        <span v-if="publishOpts.publishing">
-          This will set Version {{ publishOpts.version }} to the live form.
-        </span>
+        <span
+          v-if="publishOpts.publishing"
+        >This will set Version {{ publishOpts.version }} to the live form.</span>
         <span v-else>
           Unpublishing this form will take the form out of circulation until a
           version is published again.
         </span>
+      </template>
+    </BaseDialog>
+
+    <BaseDialog
+      v-model="showDeleteDraftDialog"
+      type="CONTINUE"
+      @close-dialog="showDeleteDraftDialog = false"
+      @continue-dialog="deleteCurrentDraft"
+    >
+      <template #title>Confirm Deletion</template>
+      <template #text>Are you sure you wish to delete this Version?</template>
+      <template #button-text-continue>
+        <span>Delete</span>
       </template>
     </BaseDialog>
   </div>
@@ -124,12 +192,11 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 
+import { formService } from '@/services';
 import { FormPermissions } from '@/utils/constants';
-import CurrentDraft from '@/components/forms/manage/CurrentDraft.vue';
 
 export default {
   name: 'ManageVersions',
-  components: { CurrentDraft },
   data() {
     return {
       headers: [
@@ -137,20 +204,38 @@ export default {
         { text: 'Status', align: 'start', value: 'status' },
         { text: 'Last Update', align: 'start', value: 'updatedAt' },
         {
-          text: 'Create a New Version',
+          text: 'Actions',
           align: 'center',
-          value: 'create',
+          value: 'edit',
+          filterable: false,
+          sortable: false,
+        },
+        {
+          text: '',
+          value: 'export',
+          filterable: false,
+          sortable: false,
+        },
+        {
+          text: '',
+          value: 'action',
           filterable: false,
           sortable: false,
         },
       ],
+      formSchema: {
+        display: 'form',
+        type: 'form',
+        components: [],
+      },
       publishOpts: {
         publishing: true,
         version: '',
-        versionId: '',
+        id: '',
       },
       showHasDraftsDialog: false,
       showPublishDialog: false,
+      showDeleteDraftDialog: false,
       rerenderTable: 0,
     };
   },
@@ -163,12 +248,28 @@ export default {
       return this.drafts && this.drafts.length > 0;
     },
     versionList() {
-      return this.form ? this.form.versions : [];
+      if(this.hasDraft) {
+        // reformat draft object and then join with versions array
+        const reDraft = this.drafts.map(obj => {
+          obj.published = false;
+          obj.version = this.form.versions.length + 1;
+          obj.isDraft = true;
+          delete obj.formVersionId;
+          delete obj.schema;
+
+          return obj;
+        });
+        const merged = reDraft.concat(this.form.versions);
+        return this.form ? merged : [];
+      }
+      else {
+        return this.form ? this.form.versions : [];
+      }
     },
   },
   methods: {
     ...mapActions('notifications', ['addNotification']),
-    ...mapActions('form', ['fetchForm', 'toggleVersionPublish']),
+    ...mapActions('form', ['fetchForm', 'fetchDrafts', 'publishDraft', 'deleteDraft', 'toggleVersionPublish']),
     createVersion(formId, versionId) {
       if (this.hasDraft) {
         this.showHasDraftsDialog = true;
@@ -188,25 +289,80 @@ export default {
       // To get the toggle back to original state
       this.rerenderTable += 1;
     },
-    togglePublish(value, versionId, version) {
+    togglePublish(value, id, version, isDraft) {
       this.publishOpts = {
         publishing: value,
         version: version,
-        versionId: versionId,
+        id: id,
+        isDraft: isDraft
       };
       this.showPublishDialog = true;
     },
     async updatePublish() {
       this.showPublishDialog = false;
-      await this.toggleVersionPublish({
-        formId: this.form.id,
-        versionId: this.publishOpts.versionId,
-        publish: this.publishOpts.publishing,
-      });
+      // if publishing a draft version
+      if(this.publishOpts.isDraft){
+        await this.publishDraft({
+          formId: this.form.id,
+          draftId: this.publishOpts.id
+        });
+        // Refresh draft in form version list
+        this.fetchDrafts(this.form.id);
+      }
+      // else, we toggle status of a version
+      else {
+        await this.toggleVersionPublish({
+          formId: this.form.id,
+          versionId: this.publishOpts.id,
+          publish: this.publishOpts.publishing,
+        });
+      }
       // Refresh form version list
       this.fetchForm(this.form.id);
     },
     // ----------------------------------------------------------------------/ Publish/unpublish actions
+
+    async deleteCurrentDraft() {
+      this.showDeleteDraftDialog = false;
+      await this.deleteDraft({ formId: this.form.id, draftId: this.drafts[0].id });
+      this.fetchDrafts(this.form.id);
+    },
+
+    onExportClick(id, isDraft) {
+      let snek = this.form.snake;
+      if (!this.form.snake) {
+        snek = this.form.name
+          .replace(/\s+/g, '_')
+          .replace(/[^-_0-9a-z]/gi, '')
+          .toLowerCase();
+      }
+
+      this.getFormSchema(id, isDraft);
+
+      const a = document.createElement('a');
+      a.href = `data:application/json;charset=utf-8,${encodeURIComponent(
+        JSON.stringify(this.formSchema)
+      )}`;
+      a.download = `${snek}_schema.json`;
+      a.style.display = 'none';
+      a.classList.add('hiddenDownloadTextElement');
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    },
+
+    async getFormSchema(id, isDraft = false) {
+      try {
+        let res = (!isDraft ) ? await formService.readVersion(this.form.id, id) : await formService.readDraft(this.form.id, id);
+        this.formSchema = { ...this.formSchema, ...res.data.schema };
+      } catch (error) {
+        this.addNotification({
+          message: 'An error occurred while loading the form design.',
+          consoleError: `Error loading form ${this.form.id} schema (version / draft: ${id}): ${error}`,
+        });
+      }
+    },
+
   },
 };
 </script>
@@ -229,5 +385,9 @@ export default {
   font-weight: normal;
   color: #003366 !important;
   font-size: 1.1em;
+}
+.submissions-table
+  >>> td:not(.v-data-table__mobile-row):nth-last-child(-n + 3) {
+  padding: 0;
 }
 </style>

--- a/app/frontend/src/components/forms/manage/ManageVersions.vue
+++ b/app/frontend/src/components/forms/manage/ManageVersions.vue
@@ -39,11 +39,13 @@
                 Version {{ item.version }}
                 <v-chip
                   v-if="item.isDraft"
+                  color="secondary"
                   class="mb-5 px-1"
                   x-small
-                  color="secondary"
                   text-color="black"
-                >Draft</v-chip>
+                >
+                  Draft
+                </v-chip>
               </span>
             </template>
             <span>
@@ -73,92 +75,95 @@
 
       <!-- Actions -->
       <template #[`item.action`]="{ item }">
-
         <!-- Edit draft version -->
-        <div v-if="item.isDraft" class="action">
+        <span v-if="item.isDraft">
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
-              <div v-bind="attrs" v-on="on">
-                <router-link
-                  :to="{
-                    name: 'FormDesigner',
-                    query: { d: item.id, f: item.formId },
-                  }"
+              <router-link
+                :to="{
+                  name: 'FormDesigner',
+                  query: { d: item.id, f: item.formId },
+                }"
+              >
+                <v-btn
+                  color="primary"
+                  class="mx-1"
+                  icon
+                  v-bind="attrs"
+                  v-on="on"
                 >
-                  <v-btn color="primary" text small>
-                    <v-icon>edit</v-icon>
-                  </v-btn>
-                </router-link>
-              </div>
+                  <v-icon>edit</v-icon>
+                </v-btn>
+              </router-link>
             </template>
             <span>Edit Version</span>
           </v-tooltip>
-        </div>
+        </span>
 
         <!-- export -->
-        <div class="action">
+        <span>
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
-              <div v-bind="attrs" v-on="on">
-                <v-btn
-                  color="primary"
-                  text
-                  small
-                  @click="onExportClick(item.id, item.isDraft)"
-                >
-                  <v-icon>get_app</v-icon>
-                </v-btn>
-              </div>
+              <v-btn
+                color="primary"
+                class="mx-1"
+                icon
+                @click="onExportClick(item.id, item.isDraft)"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon>get_app</v-icon>
+              </v-btn>
             </template>
             <span>Export Design</span>
           </v-tooltip>
-        </div>
+        </span>
 
         <!-- create new version -->
-        <div v-if="!item.isDraft" class="action">
+        <span v-if="!item.isDraft">
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
-              <div v-bind="attrs" v-on="on">
+              <span v-bind="attrs" v-on="on">
                 <v-btn
-                  :disabled="hasDraft"
                   color="primary"
-                  text
-                  small
+                  class="mx-1"
+                  :disabled="hasDraft"
+                  icon
                   @click="createVersion(item.formId, item.id)"
                 >
                   <v-icon>add</v-icon>
                 </v-btn>
-              </div>
+              </span>
             </template>
             <span v-if="hasDraft">
               Please publish or delete your latest draft version before starting
               a new version.
             </span>
-            <span v-else>Use version {{ item.version }} as the base for a new
-              version
+            <span v-else>
+              Use version {{ item.version }} as the base for a new version
             </span>
           </v-tooltip>
-        </div>
+        </span>
 
         <!-- delete draft version -->
-        <div v-else class="action">
+        <span v-else>
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
-              <v-btn
-                class="mx-1"
-                color="red"
-                @click="showDeleteDraftDialog = true"
-                :disabled="!hasVersions"
-                icon
-                v-bind="attrs"
-                v-on="on"
-              >
-                <v-icon>delete</v-icon>
-              </v-btn>
+              <span v-bind="attrs" v-on="on">
+                <v-btn
+                  color="red"
+                  class="mx-1"
+                  :disabled="!hasVersions"
+                  icon
+                  @click="showDeleteDraftDialog = true"
+                >
+                  <v-icon>delete</v-icon>
+                </v-btn>
+              </span>
             </template>
             <span>Delete Version</span>
           </v-tooltip>
-        </div>
+        </span>
       </template>
     </v-data-table>
 
@@ -409,9 +414,5 @@ export default {
   font-weight: normal;
   color: #003366 !important;
   font-size: 1.1em;
-}
-.submissions-table >>> .action {
-  display: inline-block;
-  width: 50px;
 }
 </style>

--- a/app/frontend/src/components/forms/manage/ManageVersions.vue
+++ b/app/frontend/src/components/forms/manage/ManageVersions.vue
@@ -71,9 +71,11 @@
         - {{ item.updatedBy ? item.updatedBy : item.createdBy }}
       </template>
 
-      <!-- Edit draft version -->
-      <template #[`item.edit`]="{ item }">
-        <div v-if="item.isDraft" class="a1">
+      <!-- Actions -->
+      <template #[`item.action`]="{ item }">
+
+        <!-- Edit draft version -->
+        <div v-if="item.isDraft" class="action">
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
               <div v-bind="attrs" v-on="on">
@@ -92,30 +94,28 @@
             <span>Edit Version</span>
           </v-tooltip>
         </div>
-      </template>
 
-      <!-- export -->
-      <template #[`item.export`]="{ item }">
-        <v-tooltip bottom>
-          <template #activator="{ on, attrs }">
-            <div v-bind="attrs" v-on="on">
-              <v-btn
-                color="primary"
-                text
-                small
-                @click="onExportClick(item.id, item.isDraft)"
-              >
-                <v-icon>get_app</v-icon>
-              </v-btn>
-            </div>
-          </template>
-          <span>Export Design</span>
-        </v-tooltip>
-      </template>
+        <!-- export -->
+        <div class="action">
+          <v-tooltip bottom>
+            <template #activator="{ on, attrs }">
+              <div v-bind="attrs" v-on="on">
+                <v-btn
+                  color="primary"
+                  text
+                  small
+                  @click="onExportClick(item.id, item.isDraft)"
+                >
+                  <v-icon>get_app</v-icon>
+                </v-btn>
+              </div>
+            </template>
+            <span>Export Design</span>
+          </v-tooltip>
+        </div>
 
-      <template #[`item.action`]="{ item }">
         <!-- create new version -->
-        <div v-if="!item.isDraft">
+        <div v-if="!item.isDraft" class="action">
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
               <div v-bind="attrs" v-on="on">
@@ -141,7 +141,7 @@
         </div>
 
         <!-- delete draft version -->
-        <div v-else>
+        <div v-else class="action">
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
               <v-btn
@@ -187,7 +187,7 @@
       </template>
       <template #text>
         <span v-if="publishOpts.publishing">
-          This will set Version {{ publishOpts.version }} to the live form.
+          This will make Version {{ publishOpts.version }} of your form live.
         </span>
         <span v-else>
           Unpublishing this form will take the form out of circulation until a
@@ -227,22 +227,11 @@ export default {
         { text: 'Last Update', align: 'start', value: 'updatedAt' },
         {
           text: 'Actions',
-          align: 'center',
-          value: 'edit',
-          filterable: false,
-          sortable: false,
-        },
-        {
-          text: '',
-          value: 'export',
-          filterable: false,
-          sortable: false,
-        },
-        {
-          text: '',
           value: 'action',
+          align: 'end',
           filterable: false,
           sortable: false,
+          width: 200,
         },
       ],
       formSchema: {
@@ -417,8 +406,8 @@ export default {
   color: #003366 !important;
   font-size: 1.1em;
 }
-.submissions-table
-  >>> td:not(.v-data-table__mobile-row):nth-last-child(-n + 3) {
-  padding: 0;
+.submissions-table >>> .action {
+  display: inline-block;
+  width: 50px;
 }
 </style>

--- a/app/frontend/src/components/forms/manage/ManageVersions.vue
+++ b/app/frontend/src/components/forms/manage/ManageVersions.vue
@@ -148,6 +148,7 @@
                 class="mx-1"
                 color="red"
                 @click="showDeleteDraftDialog = true"
+                :disabled="!hasVersions"
                 icon
                 v-bind="attrs"
                 v-on="on"
@@ -257,6 +258,9 @@ export default {
     },
     hasDraft() {
       return this.drafts && this.drafts.length > 0;
+    },
+    hasVersions() {
+      return this.form && this.form.versions && this.form.versions.length;
     },
     versionList() {
       if (this.hasDraft) {

--- a/app/frontend/src/components/forms/manage/ManageVersions.vue
+++ b/app/frontend/src/components/forms/manage/ManageVersions.vue
@@ -4,12 +4,17 @@
       <h4 class="primary--text">
         <v-icon class="mr-1" color="primary">info</v-icon>IMPORTANT!
       </h4>
-      <p>If there are no published versions, users are unable to access this form until there
-        is a published version assigned. Once a version is published, that version is no longer editable. You must create a new version based on one of the previous form versions to continue editing.</p>
+      <p>
+        If there are no published versions, users are unable to access this form
+        until there is a published version assigned. Once a version is
+        published, that version is no longer editable. You must create a new
+        version based on one of the previous form versions to continue editing.
+      </p>
     </BaseInfoCard>
 
     <div class="mt-8 mb-5">
-      <v-icon class="mr-1" color="primary">info</v-icon>Note: Only one version can be published.
+      <v-icon class="mr-1" color="primary">info</v-icon>Note: Only one version
+      can be published.
     </div>
     <v-data-table
       :key="rerenderTable"
@@ -20,7 +25,11 @@
       <!-- Version  -->
       <template #[`item.version`]="{ item }">
         <router-link
-          :to=" item.isDraft ? { name: 'FormPreview', query: { f: item.formId, d: item.id } } : { name: 'FormPreview', query: { f: item.formId, v: item.id } }"
+          :to="
+            item.isDraft
+              ? { name: 'FormPreview', query: { f: item.formId, d: item.id } }
+              : { name: 'FormPreview', query: { f: item.formId, v: item.id } }
+          "
           class="mx-5"
           target="_blank"
         >
@@ -90,7 +99,12 @@
         <v-tooltip bottom>
           <template #activator="{ on, attrs }">
             <div v-bind="attrs" v-on="on">
-              <v-btn color="primary" text small @click="onExportClick(item.id, item.isDraft)">
+              <v-btn
+                color="primary"
+                text
+                small
+                @click="onExportClick(item.id, item.isDraft)"
+              >
                 <v-icon>get_app</v-icon>
               </v-btn>
             </div>
@@ -117,15 +131,17 @@
               </div>
             </template>
             <span v-if="hasDraft">
-              Please publish or delete your latest draft version before starting a
-              new version.
+              Please publish or delete your latest draft version before starting
+              a new version.
             </span>
-            <span v-else>Use version {{ item.version }} as the base for a new version</span>
+            <span v-else>Use version {{ item.version }} as the base for a new
+              version
+            </span>
           </v-tooltip>
         </div>
 
         <!-- delete draft version -->
-        <div v-if="item.isDraft">
+        <div v-else>
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
               <v-btn
@@ -145,7 +161,11 @@
       </template>
     </v-data-table>
 
-    <BaseDialog v-model="showHasDraftsDialog" type="OK" @close-dialog="showHasDraftsDialog = false">
+    <BaseDialog
+      v-model="showHasDraftsDialog"
+      type="OK"
+      @close-dialog="showHasDraftsDialog = false"
+    >
       <template #title>Draft already exists</template>
       <template #text>
         Please edit, publish or delete the existing draft before starting a new
@@ -160,13 +180,15 @@
       @close-dialog="cancelPublish"
     >
       <template #title>
-        <span v-if="publishOpts.publishing">Publish Version {{ publishOpts.version }}</span>
+        <span v-if="publishOpts.publishing">
+          Publish Version {{ publishOpts.version }}
+        </span>
         <span v-else>Unpublish Version {{ publishOpts.version }}</span>
       </template>
       <template #text>
-        <span
-          v-if="publishOpts.publishing"
-        >This will set Version {{ publishOpts.version }} to the live form.</span>
+        <span v-if="publishOpts.publishing">
+          This will set Version {{ publishOpts.version }} to the live form.
+        </span>
         <span v-else>
           Unpublishing this form will take the form out of circulation until a
           version is published again.
@@ -248,9 +270,9 @@ export default {
       return this.drafts && this.drafts.length > 0;
     },
     versionList() {
-      if(this.hasDraft) {
+      if (this.hasDraft) {
         // reformat draft object and then join with versions array
-        const reDraft = this.drafts.map(obj => {
+        const reDraft = this.drafts.map((obj) => {
           obj.published = false;
           obj.version = this.form.versions.length + 1;
           obj.isDraft = true;
@@ -261,15 +283,20 @@ export default {
         });
         const merged = reDraft.concat(this.form.versions);
         return this.form ? merged : [];
-      }
-      else {
+      } else {
         return this.form ? this.form.versions : [];
       }
     },
   },
   methods: {
     ...mapActions('notifications', ['addNotification']),
-    ...mapActions('form', ['fetchForm', 'fetchDrafts', 'publishDraft', 'deleteDraft', 'toggleVersionPublish']),
+    ...mapActions('form', [
+      'fetchForm',
+      'fetchDrafts',
+      'publishDraft',
+      'deleteDraft',
+      'toggleVersionPublish',
+    ]),
     createVersion(formId, versionId) {
       if (this.hasDraft) {
         this.showHasDraftsDialog = true;
@@ -294,17 +321,17 @@ export default {
         publishing: value,
         version: version,
         id: id,
-        isDraft: isDraft
+        isDraft: isDraft,
       };
       this.showPublishDialog = true;
     },
     async updatePublish() {
       this.showPublishDialog = false;
       // if publishing a draft version
-      if(this.publishOpts.isDraft){
+      if (this.publishOpts.isDraft) {
         await this.publishDraft({
           formId: this.form.id,
-          draftId: this.publishOpts.id
+          draftId: this.publishOpts.id,
         });
         // Refresh draft in form version list
         this.fetchDrafts(this.form.id);
@@ -324,7 +351,10 @@ export default {
 
     async deleteCurrentDraft() {
       this.showDeleteDraftDialog = false;
-      await this.deleteDraft({ formId: this.form.id, draftId: this.drafts[0].id });
+      await this.deleteDraft({
+        formId: this.form.id,
+        draftId: this.drafts[0].id,
+      });
       this.fetchDrafts(this.form.id);
     },
 
@@ -353,7 +383,9 @@ export default {
 
     async getFormSchema(id, isDraft = false) {
       try {
-        let res = (!isDraft ) ? await formService.readVersion(this.form.id, id) : await formService.readDraft(this.form.id, id);
+        let res = !isDraft
+          ? await formService.readVersion(this.form.id, id)
+          : await formService.readDraft(this.form.id, id);
         this.formSchema = { ...this.formSchema, ...res.data.schema };
       } catch (error) {
         this.addNotification({
@@ -362,7 +394,6 @@ export default {
         });
       }
     },
-
   },
 };
 </script>

--- a/app/frontend/src/views/About.vue
+++ b/app/frontend/src/views/About.vue
@@ -13,7 +13,7 @@
           </p>
           <video class="main-video" width="100%" controls>
             <source
-              src="https://github.com/bcgov/common-hosted-form-service/wiki/videos/drag_drop.mp4"
+              src="https://github.com/bcgov/common-hosted-form-service/wiki/videos/intro_720.mp4"
               type="video/mp4"
             />
             Your browser does not support the video tag.

--- a/app/frontend/src/views/About.vue
+++ b/app/frontend/src/views/About.vue
@@ -13,7 +13,7 @@
           </p>
           <video class="main-video" width="100%" controls>
             <source
-              src="https://github.com/bcgov/common-hosted-form-service/wiki/videos/intro_720.mp4"
+              src="https://github.com/bcgov/common-hosted-form-service/wiki/videos/drag_drop.mp4"
               type="video/mp4"
             />
             Your browser does not support the video tag.

--- a/app/frontend/src/views/form/Manage.vue
+++ b/app/frontend/src/views/form/Manage.vue
@@ -3,6 +3,7 @@
     <v-row class="my-6" no-gutters>
       <v-col cols="12" sm="6">
         <h1>Manage Form</h1>
+        <h3>{{ this.form.name }}</h3>
       </v-col>
       <v-spacer />
       <v-col class="text-sm-right" cols="12" sm="6">
@@ -18,7 +19,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapGetters } from 'vuex';
 
 import ManageForm from '@/components/forms/manage/ManageForm.vue';
 import ManageFormActions from '@/components/forms/manage/ManageFormActions.vue';
@@ -36,6 +37,9 @@ export default {
     return {
       loading: true,
     };
+  },
+  computed: {
+    ...mapGetters('form', ['form'])
   },
   methods: {
     ...mapActions('form', [

--- a/app/frontend/src/views/form/Manage.vue
+++ b/app/frontend/src/views/form/Manage.vue
@@ -39,7 +39,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters('form', ['form'])
+    ...mapGetters('form', ['form']),
   },
   methods: {
     ...mapActions('form', [


### PR DESCRIPTION
# Description
supports: [https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1881](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1881)

I'll add a few notes to the code here in github.

requirements:

 * Call out: make it visually stand out (people are missing this)
 ** Add icon
 * Version info under the form title when created
 ** User wants to see version information right away (not draft)
 * Draft -> just next version (start from version 1, no draft)
 * Edit, Export, delete (draft), button on the version history table
 * Form Design title (on Manage Form page) & Team Management page
 
See screenshots in Jira ticket [https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1881](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-1881)



## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

it would be good if the 'last updated' date in the form design history table was accurate. its to do with the way we're updating the db table with createDraft.  out of scope i guess.