### PR TITLE
Time option disabled by default on the SimpleDateTime Custom FormIO Component

### DIFF
--- a/components/src/components/Common/Simple.edit.data.ts
+++ b/components/src/components/Common/Simple.edit.data.ts
@@ -28,9 +28,9 @@ export default [
         valueProperty: 'value',
         data: {
             custom(context) {
-                var values = [];
+                const values = [];
                 values.push({ label: 'Any Change', value: 'data' });
-                context.utils.eachComponent(context.instance.options.editForm.components, function(component, path) {
+                context.utils.eachComponent(context.instance.options.editForm.components, (component, path) => {
                     if (component.key !== context.data.key) {
                         values.push({
                             label: component.label || component.key,

--- a/components/src/components/SimpleContent/Component.form.ts
+++ b/components/src/components/SimpleContent/Component.form.ts
@@ -1,8 +1,8 @@
 import baseEditForm from 'formiojs/components/_classes/component/Component.form';
 
 import EditDisplay from './editForm/Component.edit.display';
-import SimpleApi from "../Common/Simple.edit.api";
-import SimpleConditional from "../Common/Simple.edit.conditional";
+import SimpleApi from '../Common/Simple.edit.api';
+import SimpleConditional from '../Common/Simple.edit.conditional';
 
 export default function(...extend) {
     const editForm = baseEditForm([

--- a/components/src/components/SimpleDateTime/Component.ts
+++ b/components/src/components/SimpleDateTime/Component.ts
@@ -38,7 +38,6 @@ export default class Component extends (ParentComponent as any) {
             timePicker: {
                 hourStep: 1,
                 minuteStep: 1,
-                enableTime: false,
                 showMeridian: true,
                 readonlyInput: false,
                 mousewheel: true,

--- a/components/src/components/SimpleDateTime/Component.ts
+++ b/components/src/components/SimpleDateTime/Component.ts
@@ -18,7 +18,7 @@ export default class Component extends (ParentComponent as any) {
             useLocaleSettings: false,
             allowInput: true,
             enableDate: true,
-            enableTime: true,
+            enableTime: false,
             defaultValue: '',
             defaultDate: '',
             displayInTimezone: 'viewer',
@@ -38,6 +38,7 @@ export default class Component extends (ParentComponent as any) {
             timePicker: {
                 hourStep: 1,
                 minuteStep: 1,
+                enableTime: false,
                 showMeridian: true,
                 readonlyInput: false,
                 mousewheel: true,

--- a/components/src/components/SimpleDateTime/Component.ts
+++ b/components/src/components/SimpleDateTime/Component.ts
@@ -1,13 +1,12 @@
 /* tslint:disable */
-import _ from "lodash";
-import { Components } from "formiojs";
+import { Components } from 'formiojs';
 const ParentComponent = (Components as any).components.datetime;
-import editForm from "./Component.form";
+import editForm from './Component.form';
 
-import { Constants } from "../Common/Constants";
+import { Constants } from '../Common/Constants';
 
-const ID = "simpledatetime";
-const DISPLAY = "Date / Time";
+const ID = 'simpledatetime';
+const DISPLAY = 'Date / Time';
 
 export default class Component extends (ParentComponent as any) {
   static schema(...extend) {
@@ -16,22 +15,22 @@ export default class Component extends (ParentComponent as any) {
         type: ID,
         label: DISPLAY,
         key: ID,
-        format: "yyyy-MM-dd hh:mm a",
+        format: 'yyyy-MM-dd hh:mm a',
         useLocaleSettings: false,
         allowInput: true,
         enableDate: true,
         enableTime: false,
-        defaultValue: "",
-        defaultDate: "",
-        displayInTimezone: "viewer",
-        timezone: "",
-        datepickerMode: "day",
+        defaultValue: '',
+        defaultDate: '',
+        displayInTimezone: 'viewer',
+        timezone: '',
+        datepickerMode: 'day',
         datePicker: {
           showWeeks: true,
           startingDay: 0,
-          initDate: "",
-          minMode: "day",
-          maxMode: "year",
+          initDate: '',
+          minMode: 'day',
+          maxMode: 'year',
           yearRows: 4,
           yearColumns: 5,
           minDate: null,
@@ -56,8 +55,8 @@ export default class Component extends (ParentComponent as any) {
   static get builderInfo() {
     return {
       title: DISPLAY,
-      group: "simple",
-      icon: "calendar",
+      group: 'simple',
+      icon: 'calendar',
       weight: 20,
       documentation: Constants.DEFAULT_HELP_LINK,
       schema: Component.schema(),
@@ -68,7 +67,7 @@ export default class Component extends (ParentComponent as any) {
     super(component, options, data);
     // if enableTime is set to false, manually add time fields since it get removed later on through Form IO
     if (!this.component.enableTime) {
-      this.component.format = this.component.format.concat(" hh:mm a");
+      this.component.format = this.component.format.concat(' hh:mm a');
     }
   }
 }

--- a/components/src/components/SimpleDateTime/Component.ts
+++ b/components/src/components/SimpleDateTime/Component.ts
@@ -1,70 +1,74 @@
 /* tslint:disable */
-import { Components } from 'formiojs';
+import _ from "lodash";
+import { Components } from "formiojs";
 const ParentComponent = (Components as any).components.datetime;
-import editForm from './Component.form';
+import editForm from "./Component.form";
 
-import { Constants } from '../Common/Constants';
+import { Constants } from "../Common/Constants";
 
-const ID = 'simpledatetime';
-const DISPLAY = 'Date / Time';
+const ID = "simpledatetime";
+const DISPLAY = "Date / Time";
 
 export default class Component extends (ParentComponent as any) {
-    static schema(...extend) {
-        return ParentComponent.schema({
-            type: ID,
-            label: DISPLAY,
-            key: ID,
-            format: 'yyyy-MM-dd hh:mm a',
-            useLocaleSettings: false,
-            allowInput: true,
-            enableDate: true,
-            enableTime: false,
-            defaultValue: '',
-            defaultDate: '',
-            displayInTimezone: 'viewer',
-            timezone: '',
-            datepickerMode: 'day',
-            datePicker: {
-                showWeeks: true,
-                startingDay: 0,
-                initDate: '',
-                minMode: 'day',
-                maxMode: 'year',
-                yearRows: 4,
-                yearColumns: 5,
-                minDate: null,
-                maxDate: null
-            },
-            timePicker: {
-                hourStep: 1,
-                minuteStep: 1,
-                showMeridian: true,
-                readonlyInput: false,
-                mousewheel: true,
-                arrowkeys: true
-            },
-            customOptions: {},
-        }, ...extend);
-    }
+  static schema(...extend) {
+    return ParentComponent.schema(
+      {
+        type: ID,
+        label: DISPLAY,
+        key: ID,
+        format: "yyyy-MM-dd hh:mm a",
+        useLocaleSettings: false,
+        allowInput: true,
+        enableDate: true,
+        enableTime: false,
+        defaultValue: "",
+        defaultDate: "",
+        displayInTimezone: "viewer",
+        timezone: "",
+        datepickerMode: "day",
+        datePicker: {
+          showWeeks: true,
+          startingDay: 0,
+          initDate: "",
+          minMode: "day",
+          maxMode: "year",
+          yearRows: 4,
+          yearColumns: 5,
+          minDate: null,
+          maxDate: null,
+        },
+        timePicker: {
+          hourStep: 1,
+          minuteStep: 1,
+          showMeridian: true,
+          readonlyInput: false,
+          mousewheel: true,
+          arrowkeys: true,
+        },
+        customOptions: {},
+      },
+      ...extend
+    );
+  }
 
-    public static editForm = editForm;
+  public static editForm = editForm;
 
-    static get builderInfo() {
-        return {
-            title: DISPLAY,
-            group: 'simple',
-            icon: 'calendar',
-            weight: 20,
-            documentation: Constants.DEFAULT_HELP_LINK,
-            schema: Component.schema()
-        };
-    }
+  static get builderInfo() {
+    return {
+      title: DISPLAY,
+      group: "simple",
+      icon: "calendar",
+      weight: 20,
+      documentation: Constants.DEFAULT_HELP_LINK,
+      schema: Component.schema(),
+    };
+  }
 
-    constructor(component) {
-      super(component);
-      // if enableTime is set to false, manually add time fields since it get removed later on through Form IO
-      if (!this.component.enableTime) {
-        this.component.format = this.component.format.concat(' hh:mm a');
-      }
+  constructor(component, options, data) {
+    super(component, options, data);
+    // if enableTime is set to false, manually add time fields since it get removed later on through Form IO
+    if (!this.component.enableTime) {
+      this.component.format = this.component.format.concat(" hh:mm a");
     }
+  }
 }

--- a/components/src/components/SimpleDateTime/Component.ts
+++ b/components/src/components/SimpleDateTime/Component.ts
@@ -1,5 +1,4 @@
 /* tslint:disable */
-import _ from 'lodash';
 import { Components } from 'formiojs';
 const ParentComponent = (Components as any).components.datetime;
 import editForm from './Component.form';

--- a/components/src/components/SimpleDateTime/Component.ts
+++ b/components/src/components/SimpleDateTime/Component.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+import _ from 'lodash';
 import { Components } from 'formiojs';
 const ParentComponent = (Components as any).components.datetime;
 import editForm from './Component.form';
@@ -58,5 +59,13 @@ export default class Component extends (ParentComponent as any) {
             documentation: Constants.DEFAULT_HELP_LINK,
             schema: Component.schema()
         };
+    }
+
+    constructor(component) {
+      super(component);
+      // if enableTime is set to false, manually add time fields since it get removed later on through Form IO
+      if (!this.component.enableTime) {
+        this.component.format = this.component.format.concat(' hh:mm a');
+      }
     }
 }

--- a/components/src/components/SimpleDateTime/editForm/Component.edit.time.ts
+++ b/components/src/components/SimpleDateTime/editForm/Component.edit.time.ts
@@ -3,7 +3,7 @@ export default [
         type: 'checkbox',
         input: true,
         key: 'enableTime',
-        label: 'Enable Time Input TEST 1',
+        label: 'Enable Time Input',
         tooltip: 'Enables time input for this field.',
         weight: 30
     },

--- a/components/src/components/SimpleDateTime/editForm/Component.edit.time.ts
+++ b/components/src/components/SimpleDateTime/editForm/Component.edit.time.ts
@@ -1,5 +1,13 @@
 export default [
     {
+        type: 'checkbox',
+        input: true,
+        key: 'enableTime',
+        label: 'Enable Time Input TEST 1',
+        tooltip: 'Enables time input for this field.',
+        weight: 30
+    },
+    {
         type: 'number',
         input: true,
         key: 'timePicker.hourStep',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Making the Time option disabled by default on the SimpleDateTime Custom FormIO Component. Added a checkbox field to enable it manually.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Allows a better user experience by not letting the Time option be enabled by default.

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)