### PR TITLE
re-order submission data headers in csv export to match form design

### DIFF
--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -136,6 +136,7 @@ const service = {
   _readLatestFormSchema: async (formId) => {
     return FormVersion.query()
       .select('schema')
+      .withGraphFetched('submissions')
       .where('formId', formId)
       .modify('orderVersionDescending')
       .first().then((row) => row.schema);

--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -145,7 +145,7 @@ const service = {
       .modify('orderDefault');
   },
 
-  _formatSubmissionsJson: async (form, data) => {
+  _formatSubmissionsJson: (form, data) => {
     return {
       data: data,
       headers: {
@@ -175,7 +175,7 @@ const service = {
         //   }
         // }
 
-        // show meta headers first, then field names from form schema, remaining fields in data have columns automatically appended
+        // re-organize our headers to change column ordering or header labels, etc
         headers: await service._buildCsvHeaders(form, data)
       };
 

--- a/app/tests/unit/forms/form/exportService.spec.js
+++ b/app/tests/unit/forms/form/exportService.spec.js
@@ -1,0 +1,57 @@
+const exportService = require('../../../../src/forms/form/exportService');
+
+describe('_buildCsvHeaders', () => {
+
+  it.only('should build correct csv headers', async () => {
+
+    // form object from db
+    const form = { id: 1 };
+
+    // latest form version's schema
+    const formSchema = {
+      type: 'form',
+      components: [
+        {
+          key: 'firstName',
+          label: 'First Name',
+          input: true
+        },
+        {
+          key: 'lastName',
+          label: 'Last Name',
+          input: true
+        }
+      ]
+    };
+
+    // submissions data
+    const submissionsData = [
+      {
+        form: {
+          confirmationId: 'ABC12345',
+        },
+        submit: true,
+        lastName: 'Smith',
+        firstName: 'John',
+      },
+      {
+        form: {
+          confirmationId: 'DEF67890',
+        },
+        submit: true,
+        lastName: 'Doe',
+        firstName: 'Mike',
+      },
+    ];
+
+    // mock latestFormSchema
+    exportService._readLatestFormSchema = jest.fn(() => { return formSchema; });
+
+    // build csv headers
+    const result = await exportService._buildCsvHeaders(form, submissionsData);
+
+    // expect headers array to have 3 element - [ 'form.confirmationId', 'firstName', 'lastName' ]
+    expect(result.length === 3).toBeTruthy();
+  });
+
+});

--- a/app/tests/unit/forms/form/exportService.spec.js
+++ b/app/tests/unit/forms/form/exportService.spec.js
@@ -2,10 +2,10 @@ const exportService = require('../../../../src/forms/form/exportService');
 
 describe('_buildCsvHeaders', () => {
 
-  it.only('should build correct csv headers', async () => {
+  it('should build correct csv headers', async () => {
 
     // form object from db
-    const form = { id: 1 };
+    const form = { id: 123 };
 
     // latest form version's schema
     const formSchema = {
@@ -50,8 +50,13 @@ describe('_buildCsvHeaders', () => {
     // build csv headers
     const result = await exportService._buildCsvHeaders(form, submissionsData);
 
-    // expect headers array to have 3 element - [ 'form.confirmationId', 'firstName', 'lastName' ]
-    expect(result.length === 3).toBeTruthy();
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(expect.arrayContaining([ 'form.confirmationId', 'firstName', 'lastName' ]));
+    expect(exportService._readLatestFormSchema).toHaveBeenCalledTimes(1);
+    expect(exportService._readLatestFormSchema).toHaveBeenCalledWith(123);
+
+    // restore mocked function to it's original implementation
+    exportService._readLatestFormSchema.mockRestore();
   });
 
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

[ticket 2114](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2114)
Order of JSON and CSV columns does not match the top-down order of the form

Submission fields in the export are ordered  as they exist in the database (key length and then alphabetical)
We can re-order the columns in the CSV export with the jsonexport 'headers' argument.
.. passing in the meta columns, followed by the fields as they appear in the form schema.
submission fields that arent in the most recent form schema are appended to columns on the end.
This can be done just for the CSV export.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
