### PR TITLE
order csv export columns

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: true
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
     steps:
@@ -62,7 +61,6 @@ jobs:
       fail-fast: true
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
     steps:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

see: [ticket 2114](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2114)

This is an extra fix to my last PR to get submissions export to match the order of the fields as they appear in the form schema.
`_buildCsvHeaders` references the list of fields created in '_readSchemaFields' function.
we need to go recursively into each component in case that component contains nested components.

The way the form schema is structured makes this process not very reliable. this is a best effort.

because any fields in the submission data that arent defined in headers are appended to the export we should be safe here.. 

-Jujaga -> Fixed some of the nasty recursion and edge cases

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
