### PR TITLE
Dropdown Height Style Fix

### DIFF
--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -480,6 +480,13 @@ a,
   }
 }
 
+// allow dropdowns to continue expanding downwards within a modal
+.formio-dialog-content {
+  .component-edit-container {
+    overflow: visible;
+  }
+}
+
 // formio component buttons
 .btn-primary.formcomponent.drag-copy,
 .btn-primary.formcomponent.drag-copy:hover,

--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -487,6 +487,18 @@ a,
   }
 }
 
+.choices.form-group.formio-choices {
+  .choices__list.choices__list--dropdown {
+    overflow: auto;
+  }
+}
+
+.choices__list.choices__list--dropdown {
+  div {
+    max-height: 175px;
+  }
+}
+
 // formio component buttons
 .btn-primary.formcomponent.drag-copy,
 .btn-primary.formcomponent.drag-copy:hover,

--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -484,18 +484,14 @@ a,
 .formio-dialog-content {
   .component-edit-container {
     overflow: visible;
-  }
-}
 
-.choices.form-group.formio-choices {
-  .choices__list.choices__list--dropdown {
-    overflow: auto;
-  }
-}
+    .choices__list.choices__list--dropdown {
+      overflow: auto;
 
-.choices__list.choices__list--dropdown {
-  div {
-    max-height: 175px;
+      div.choices__list {
+        max-height: 175px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Adding CSS to fix dropdowns from being cut off within a Component's Details Modal.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Made changes only in the main style.scss
<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
