### PR TITLE
Implement version-scoped column field query discovery support

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -11,13 +11,13 @@ info:
     export, as well as notifications, document generation and reporting.
   license:
     name: Apache 2.0
-    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
   contact:
     name: NR Common Service Showcase
     email: NR.CommonServiceShowcase@gov.bc.ca
 externalDocs:
   description: Project Readmes
-  url: 'https://github.com/bcgov/common-hosted-form-service'
+  url: https://github.com/bcgov/common-hosted-form-service
 servers:
   - url: /api/v1
     description: This Server
@@ -146,7 +146,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}':
+  /forms/{formId}:
     get:
       summary: Get details of a form (and metadata for versions)
       operationId: readForm
@@ -165,6 +165,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Form'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -197,6 +199,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Form'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -223,6 +227,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormBasic'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -231,7 +237,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/apiKey':
+  /forms/{formId}/apiKey:
     get:
       summary: Get current API Key
       description: Get the active api key secret for a form
@@ -297,7 +303,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/export':
+  /forms/{formId}/export:
     get:
       summary: Export submissions for a form
       operationId: export
@@ -353,6 +359,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormSubmissionExport'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -361,7 +369,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/versions':
+  /forms/{formId}/versions:
     get:
       summary: List all versions of a form
       operationId: listVersions
@@ -382,6 +390,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormVersion'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -390,7 +400,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/versions/{formVersionId}':
+  /forms/{formId}/versions/{formVersionId}:
     get:
       summary: Get a single form version
       operationId: readVersion
@@ -410,6 +420,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormVersion'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -418,7 +430,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/version':
+  /forms/{formId}/versions/{formVersionId}/fields:
+    get:
+      summary: Get a list of valid form fields in this form version
+      operationId: readVersionFields
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
+      tags:
+        - Version
+      parameters:
+        - $ref: '#/components/parameters/formIdParam'
+        - $ref: '#/components/parameters/formVersionIdParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FormVersionFields'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /forms/{formId}/version:
     get:
       summary: Get published version of a form
       operationId: readPublishedForm
@@ -437,6 +479,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Form'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -445,7 +489,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/versions/{formVersionId}/publish':
+  /forms/{formId}/versions/{formVersionId}/publish:
     post:
       summary: Publish a version of a form
       operationId: publishVersion
@@ -472,6 +516,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormVersionBasic'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -480,7 +526,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/drafts':
+  /forms/{formId}/drafts:
     get:
       summary: List drafts for a form
       operationId: listDrafts
@@ -501,6 +547,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormDraft'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -541,6 +589,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormDraft'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -549,7 +599,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/drafts/{formVersionDraftId}':
+  /forms/{formId}/drafts/{formVersionDraftId}:
     get:
       summary: Get a form draft
       operationId: readDraft
@@ -569,6 +619,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormDraft'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -598,7 +650,6 @@ paths:
               properties:
                 schema:
                   $ref: '#/components/schemas/FormSchema'
-                  description: this is the json for the form design.
       responses:
         '200':
           description: OK
@@ -606,6 +657,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormDraft'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -629,6 +682,8 @@ paths:
       responses:
         '204':
           description: OK
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -637,7 +692,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/drafts/{formVersionDraftId}/publish':
+  /forms/{formId}/drafts/{formVersionDraftId}/publish:
     post:
       summary: Publish a form draft
       operationId: publishDraft
@@ -657,6 +712,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormVersionBasic'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -665,7 +722,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/submissions':
+  /forms/{formId}/submissions:
     get:
       summary: List submissions for a form
       operationId: listFormSubmissions
@@ -686,6 +743,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormSubmissionSummary'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -694,7 +753,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/versions/{formVersionId}/submissions':
+  /forms/{formId}/versions/{formVersionId}/submissions:
     get:
       summary: List submissions from a form version
       operationId: listSubmissions
@@ -716,6 +775,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormSubmission'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -749,6 +810,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormSubmission'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
         default:
@@ -757,7 +820,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/submissions/{formSubmissionId}':
+  /forms/{formId}/versions/{formVersionId}/submissions/discover:
+    get:
+      summary: List field value submissions from a form version
+      description: >-
+        A queryable endpoint for acquiring a specific subset of data from the
+        submissions
+      operationId: listDiscoverSubmissions
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
+      tags:
+        - Submission
+      parameters:
+        - $ref: '#/components/parameters/formIdParam'
+        - $ref: '#/components/parameters/formVersionIdParam'
+        - in: query
+          name: fields
+          schema:
+            type: string
+            example: textField1,checkbox1,radioGroup1,email1
+          description: >-
+            A list of form fields to search on. Refer to the related `/fields`
+            endpoint for a list of valid values to query for. The list can be
+            comma separated or by repeating the same fields query multiple
+            times.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/FormSubmissionDiscover'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /submissions/{formSubmissionId}:
     get:
       summary: Get a form submission
       operationId: readSubmission
@@ -830,7 +938,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/submissions/{formSubmissionId}/email':
+  /submissions/{formSubmissionId}/email:
     post:
       summary: Email a message with link to a submission
       operationId: emailSubmission
@@ -873,7 +981,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/submissions/{formSubmissionId}/edits':
+  /submissions/{formSubmissionId}/edits:
     get:
       summary: Get an audit list of edits to a submission
       operationId: readSubmissionEdits
@@ -898,7 +1006,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/forms/{formId}/statusCodes':
+  /forms/{formId}/statusCodes:
     get:
       summary: List status codes for a form
       operationId: getStatusCodes
@@ -923,7 +1031,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/submissions/{formSubmissionId}/status':
+  /submissions/{formSubmissionId}/status:
     get:
       summary: Get the list of status history for a submission
       operationId: readSubmissionStatus
@@ -978,7 +1086,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/submissions/{formSubmissionId}/notes':
+  /submissions/{formSubmissionId}/notes:
     get:
       summary: Get the list of notes for a submission
       operationId: readSubmissioNotes
@@ -1071,7 +1179,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/files/{fileId}':
+  /files/{fileId}:
     get:
       summary: Get a file
       operationId: fileGet
@@ -1170,7 +1278,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/permissions/{code}':
+  /permissions/{code}:
     get:
       summary: Get a permission
       operationId: readPermission
@@ -1293,7 +1401,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/roles/{code}':
+  /roles/{code}:
     get:
       summary: Get a role
       operationId: getRole
@@ -1385,7 +1493,7 @@ paths:
           name: accessLevels
           schema:
             type: string
-          description: 'filter on the user access level for the form (public, idp, team)'
+          description: filter on the user access level for the form (public, idp, team)
       responses:
         '200':
           description: OK
@@ -1889,7 +1997,7 @@ paths:
           name: search
           schema:
             type: string
-          description: 'string to match against  username, fullName and Email'
+          description: string to match against  username, fullName and Email
       responses:
         '200':
           description: OK
@@ -1907,7 +2015,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/users/{userId}':
+  /users/{userId}:
     get:
       summary: Get a user and their roles
       operationId: readUser
@@ -1971,7 +2079,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/admin/forms/{formId}':
+  /admin/forms/{formId}:
     get:
       summary: Get top level details of a form
       operationId: adminReadForm
@@ -1997,7 +2105,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/admin/forms/{formId}/restore':
+  /admin/forms/{formId}/restore:
     put:
       summary: Un-delete a soft deleted form
       operationId: adminRestoreForm
@@ -2075,7 +2183,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  '/admin/users/{userId}':
+  /admin/users/{userId}:
     get:
       summary: Get a user
       operationId: adminReadUser
@@ -2118,7 +2226,7 @@ components:
       bearerFormat: JWT
     OpenID:
       type: openIdConnect
-      openIdConnectUrl: 'https://example.com/.well-known/openid-configuration'
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
   parameters:
     fileIdParam:
       in: path
@@ -2176,7 +2284,7 @@ components:
             title:
               example: Bad Request
             type:
-              example: 'https://httpstatuses.com/400'
+              example: https://httpstatuses.com/400
     Conflict:
       allOf:
         - $ref: '#/components/schemas/Problem'
@@ -2187,7 +2295,7 @@ components:
             title:
               example: Conflict
             type:
-              example: 'https://httpstatuses.com/409'
+              example: https://httpstatuses.com/409
     CurrentUser:
       type: object
       properties:
@@ -2248,7 +2356,7 @@ components:
             title:
               example: Internal Server Error
             type:
-              example: 'https://httpstatuses.com/500'
+              example: https://httpstatuses.com/500
     FileUpload:
       type: object
       properties:
@@ -2412,7 +2520,7 @@ components:
               example: a675ab2a-1e88-4fb5-88f9-c7cb051a18b2
             confirmationId:
               type: string
-              description: 'shortend version of the id, useful for visual representation'
+              description: shortend version of the id, useful for visual representation
               example: AEB3B705
             deleted:
               type: boolean
@@ -2432,6 +2540,18 @@ components:
               type: object
               description: this is the json for the form submission.
         - $ref: '#/components/schemas/TimeStampUserData'
+    FormSubmissionDiscover:
+      type: object
+      properties:
+        id:
+          type: string
+          example: aeb3b705-1de5-4f4e-a4e6-0716b7671034
+      example:
+        id: aeb3b705-1de5-4f4e-a4e6-0716b7671034
+        textField1: foo
+        checkbox1: bar
+        radioGroup1: baz
+        email1: test@email.com
     FormSubmissionExport:
       allOf:
         - type: object
@@ -2441,7 +2561,7 @@ components:
               properties:
                 confirmationId:
                   type: string
-                  description: 'shortend version of the id, useful for visual representation'
+                  description: shortend version of the id, useful for visual representation
                   example: AEB3B705
                 formName:
                   type: string
@@ -2492,7 +2612,7 @@ components:
               example: a675ab2a-1e88-4fb5-88f9-c7cb051a18b2
             confirmationId:
               type: string
-              description: 'shortend version of the id, useful for visual representation'
+              description: shortend version of the id, useful for visual representation
               example: AEB3B705
             deleted:
               type: boolean
@@ -2546,6 +2666,15 @@ components:
               type: boolean
               example: true
         - $ref: '#/components/schemas/TimeStampUserData'
+    FormVersionFields:
+      type: array
+      example:
+        - textField1
+        - checkbox1
+        - radioGroup1
+        - email1
+      items:
+        type: string
     IdentityProvider:
       allOf:
         - type: object
@@ -2590,7 +2719,7 @@ components:
             title:
               example: Not Found
             type:
-              example: 'https://httpstatuses.com/404'
+              example: https://httpstatuses.com/404
     PermissionBasic:
       allOf:
         - type: object
@@ -2627,10 +2756,10 @@ components:
       properties:
         type:
           type: string
-          description: 'What type of problem, link to explanation of problem'
+          description: What type of problem, link to explanation of problem
         title:
           type: string
-          description: 'Title of problem, generally the Http Status Code description'
+          description: Title of problem, generally the Http Status Code description
         status:
           type: string
           description: The Http Status code
@@ -2766,8 +2895,6 @@ components:
         updatedAt:
           type: string
           example: 2020-06-04T18:49:20.672Z
-    UnauthorizedError:
-      description: Access token is missing or invalid
     User:
       allOf:
         - type: object
@@ -3096,7 +3223,7 @@ components:
             title:
               example: Unprocessable Entity
             type:
-              example: 'https://httpstatuses.com/422'
+              example: https://httpstatuses.com/422
   responses:
     Accepted:
       description: Accepted
@@ -3129,7 +3256,7 @@ components:
           schema:
             $ref: '#/components/schemas/NotFound'
     UnauthorizedError:
-      description: Access token is missing or invalid
+      description: Invalid authorization credentials
     UnprocessableEntity:
       description: >-
         The server was unable to process the contained instructions. Generally

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -124,16 +124,21 @@ module.exports = {
   },
   listSubmissionFields: async (req, res, next) => {
     try {
-      const fields = [];
+      let fields = [];
       if (req.query.fields) {
+        let splitFields = [];
         if (Array.isArray(req.query.fields)) {
-          fields.push(req.query.fields.flatMap(f => f.split(',').map(s => s.trim())));
+          splitFields = req.query.fields.flatMap(f => f.split(',').map(s => s.trim()));
         } else {
-          fields.push(req.query.fields.split(',').map(s => s.trim()));
+          splitFields = req.query.fields.split(',').map(s => s.trim());
         }
+
+        // Drop invalid fields
+        const validFields = await service.readVersionFields(req.params.formVersionId);
+        fields = splitFields.filter(f => validFields.includes(f));
       }
 
-      const response = await service.listSubmissionFields(req.params.formVersionId, fields.flat());
+      const response = await service.listSubmissionFields(req.params.formVersionId, fields);
       res.status(200).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -122,6 +122,23 @@ module.exports = {
       next(error);
     }
   },
+  listSubmissionFields: async (req, res, next) => {
+    try {
+      const fields = [];
+      if (req.query.fields) {
+        if (Array.isArray(req.query.fields)) {
+          fields.push(req.query.fields.flatMap(f => f.split(',').map(s => s.trim())));
+        } else {
+          fields.push(req.query.fields.split(',').map(s => s.trim()));
+        }
+      }
+
+      const response = await service.listSubmissionFields(req.params.formVersionId, fields.flat());
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  },
   listDrafts: async (req, res, next) => {
     try {
       const response = await service.listDrafts(req.params.formId, req.query);

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -87,6 +87,14 @@ module.exports = {
       next(error);
     }
   },
+  readVersionFields: async (req, res, next) => {
+    try {
+      const response = await service.readVersionFields(req.params.formVersionId);
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  },
   publishVersion: async (req, res, next) => {
     try {
       const response = await service.publishVersion(req.params.formId, req.params.formVersionId, req.query, req.currentUser);

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -75,6 +75,10 @@ routes.post('/:formId/versions/:formVersionId/submissions', apiAccess, hasFormPe
   await controller.createSubmission(req, res, next);
 });
 
+routes.get('/:formId/versions/:formVersionId/submissions/discover', (req, res, next) => {
+  controller.listSubmissionFields(req, res, next);
+});
+
 // routes.get('/:formId/versions/:formVersionId/submissions/:formSubmissionId', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
 //   next(new Problem(410, { detail: 'This method is deprecated, use /submissions to read a submission.' }));
 // });

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -55,7 +55,7 @@ routes.get('/:formId/versions/:formVersionId', apiAccess, hasFormPermissions([P.
   await controller.readVersion(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId/fields', async (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId/fields', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.readVersionFields(req, res, next);
 });
 
@@ -75,7 +75,7 @@ routes.post('/:formId/versions/:formVersionId/submissions', apiAccess, hasFormPe
   await controller.createSubmission(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId/submissions/discover', (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId/submissions/discover', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), (req, res, next) => {
   controller.listSubmissionFields(req, res, next);
 });
 

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -55,6 +55,10 @@ routes.get('/:formId/versions/:formVersionId', apiAccess, hasFormPermissions([P.
   await controller.readVersion(req, res, next);
 });
 
+routes.get('/:formId/versions/:formVersionId/fields', async (req, res, next) => {
+  await controller.readVersionFields(req, res, next);
+});
+
 // routes.put('/:formId/versions/:formVersionId', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
 //   next(new Problem(410, { detail: 'This method is deprecated, use /forms/id/drafts to modify form versions.' }));
 // });

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -215,7 +215,7 @@ const service = {
     }
   },
 
-  readVersion: async (formVersionId) => {
+  readVersion: (formVersionId) => {
     return FormVersion.query()
       .findById(formVersionId)
       .throwIfNotFound();
@@ -235,10 +235,7 @@ const service = {
       return fields.flat();
     };
 
-    const { schema } = await FormVersion.query()
-      .findById(formVersionId)
-      .throwIfNotFound();
-
+    const { schema } = await service.readVersion(formVersionId);
     return schema.components.flatMap(c => findFields(c));
   },
 

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -228,8 +228,8 @@ const service = {
       const fields = [];
       // Only add key if it is an input and visible
       if (obj.input && !obj.hidden) fields.push(obj.key);
-      // Check children components
-      if (obj.components && obj.components.length) {
+      // Check children components that aren't inputs
+      else if (!obj.hidden && obj.components && obj.components.length) {
         fields.push(obj.components.flatMap(o => findFields(o)));
       }
       return fields.flat();

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -221,6 +221,26 @@ const service = {
       .throwIfNotFound();
   },
 
+  readVersionFields: async (formVersionId) => {
+    const fields = [];
+
+    // Recursively find field key names
+    const findFields = (obj) => {
+      if (obj.components && obj.components.length) {
+        obj.components.forEach(o => findFields(o));
+      }
+      // Only add to list if it is an input field
+      if (obj.input) fields.push(obj.key);
+    };
+
+    const { schema } = await FormVersion.query()
+      .findById(formVersionId)
+      .throwIfNotFound();
+
+    schema.components.forEach(c => findFields(c));
+    return fields;
+  },
+
   listSubmissions: async (formVersionId) => {
     return FormSubmission.query()
       .where('formVersionId', formVersionId)

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -5,7 +5,7 @@ const { Permissions, Roles, Statuses } = require('../common/constants');
 const Rolenames = [Roles.OWNER, Roles.TEAM_MANAGER, Roles.FORM_DESIGNER, Roles.SUBMISSION_REVIEWER, Roles.FORM_SUBMITTER];
 
 const Problem = require('api-problem');
-const { transaction } = require('objection');
+const { ref, transaction } = require('objection');
 const { v4: uuidv4 } = require('uuid');
 
 const service = {
@@ -326,6 +326,13 @@ const service = {
       if (trx) await trx.rollback();
       throw err;
     }
+  },
+
+  listSubmissionFields: (formVersionId, fields) => {
+    return FormSubmission.query()
+      .select(fields.map(f => ref(`submission:data.${f}`).as(f.split('.').slice(-1))))
+      .where('formVersionId', formVersionId)
+      .modify('orderDescending');
   },
 
   readSubmission: async (id) => {

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -222,23 +222,24 @@ const service = {
   },
 
   readVersionFields: async (formVersionId) => {
-    const fields = [];
-
-    // Recursively find field key names
+    // Recursively find all field key names
+    // TODO: Consider if this should be a form utils function instead?
     const findFields = (obj) => {
+      const fields = [];
+      // Only add key if it is an input and visible
+      if (obj.input && !obj.hidden) fields.push(obj.key);
+      // Check children components
       if (obj.components && obj.components.length) {
-        obj.components.forEach(o => findFields(o));
+        fields.push(obj.components.flatMap(o => findFields(o)));
       }
-      // Only add to list if it is an input field
-      if (obj.input) fields.push(obj.key);
+      return fields.flat();
     };
 
     const { schema } = await FormVersion.query()
       .findById(formVersionId)
       .throwIfNotFound();
 
-    schema.components.forEach(c => findFields(c));
-    return fields;
+    return schema.components.flatMap(c => findFields(c));
   },
 
   listSubmissions: async (formVersionId) => {

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -330,12 +330,12 @@ const service = {
 
   listSubmissionFields: (formVersionId, fields) => {
     return FormSubmission.query()
-      .select(fields.map(f => ref(`submission:data.${f}`).as(f.split('.').slice(-1))))
+      .select('id', fields.map(f => ref(`submission:data.${f}`).as(f.split('.').slice(-1))))
       .where('formVersionId', formVersionId)
       .modify('orderDescending');
   },
 
-  readSubmission: async (id) => {
+  readSubmission: (id) => {
     return FormSubmission.query()
       .findById(id)
       .throwIfNotFound();

--- a/app/tests/unit/routes/v1/form.spec.js
+++ b/app/tests/unit/routes/v1/form.spec.js
@@ -7,6 +7,7 @@ const { expressHelper } = require('../../../common/helper');
 // mock middleware
 //
 const keycloak = require('../../../../src/components/keycloak');
+
 //
 // test assumes that caller has appropriate token, we are not testing middleware here...
 //
@@ -25,6 +26,7 @@ userAccess.hasFormPermissions = jest.fn(() => {
     next();
   });
 });
+
 //
 // we will mock the underlying data service calls...
 //
@@ -32,7 +34,6 @@ const service = require('../../../../src/forms/form/service');
 const exportService = require('../../../../src/forms/form/exportService');
 const emailService = require('../../../../src/forms/email/emailService');
 const fileService = require('../../../../src/forms/file/service');
-
 
 //
 // mocks are in place, create the router
@@ -363,7 +364,6 @@ describe(`GET ${basePath}/formId/versions`, () => {
 // describe(`POST ${basePath}/formId/versions`, () => {
 
 //   it('should return 410', async () => {
-
 //     const response = await request(app).post(`${basePath}/formId/versions`);
 
 //     expect(response.statusCode).toBe(410);
@@ -399,6 +399,40 @@ describe(`GET ${basePath}/formId/versions/formVersionId`, () => {
     service.readVersion = jest.fn(() => { throw new Error(); });
 
     const response = await request(app).get(`${basePath}/formId/versions/formVersionId`);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toBeTruthy();
+  });
+
+});
+
+describe(`GET ${basePath}/formId/versions/formVersionId/fields`, () => {
+
+  it('should return 200', async () => {
+    // mock a success return value...
+    service.readVersionFields = jest.fn().mockReturnValue([]);
+
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 401', async () => {
+    // mock an authentication/permission issue...
+    service.readVersionFields = jest.fn(() => { throw new Problem(401); });
+
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 500', async () => {
+    // mock an unexpected error...
+    service.readVersionFields = jest.fn(() => { throw new Error(); });
+
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -543,6 +577,52 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
 
     expect(response.statusCode).toBe(201);
+    expect(response.body).toBeTruthy();
+  });
+
+});
+
+describe(`GET ${basePath}/formId/versions/formVersionId/submissions/discover`, () => {
+
+  it('should return 200 with comma separated fields', async () => {
+    // mock a success return value...
+    service.listSubmissionFields = jest.fn().mockReturnValue([]);
+    service.readVersionFields = jest.fn().mockReturnValue([]);
+
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`).query({ fields: 'foo,bar' });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should return 200 with discrete fields', async () => {
+    // mock a success return value...
+    service.listSubmissionFields = jest.fn().mockReturnValue([]);
+    service.readVersionFields = jest.fn().mockReturnValue([]);
+
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`).query({ fields: ['foo', 'bar'] });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 401', async () => {
+    // mock an authentication/permission issue...
+    service.listSubmissionFields = jest.fn(() => { throw new Problem(401); });
+
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 500', async () => {
+    // mock an unexpected error...
+    service.listSubmissionFields = jest.fn(() => { throw new Error(); });
+
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`);
+
+    expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
   });
 
@@ -801,6 +881,108 @@ describe(`GET ${basePath}/formId/statusCodes`, () => {
     service.getStatusCodes = jest.fn(() => { throw new Error(); });
 
     const response = await request(app).get(`${basePath}/formId/statusCodes`);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toBeTruthy();
+  });
+
+});
+
+describe(`GET ${basePath}/formId/apiKey`, () => {
+
+  it('should return 200', async () => {
+    // mock a success return value...
+    service.readApiKey = jest.fn().mockReturnValue([]);
+
+    const response = await request(app).get(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 401', async () => {
+    // mock an authentication/permission issue...
+    service.readApiKey = jest.fn(() => { throw new Problem(401); });
+
+    const response = await request(app).get(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 500', async () => {
+    // mock an unexpected error...
+    service.readApiKey = jest.fn(() => { throw new Error(); });
+
+    const response = await request(app).get(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toBeTruthy();
+  });
+
+});
+
+describe(`PUT ${basePath}/formId/apiKey`, () => {
+
+  it('should return 200', async () => {
+    // mock a success return value...
+    service.createOrReplaceApiKey = jest.fn().mockReturnValue([]);
+
+    const response = await request(app).put(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 401', async () => {
+    // mock an authentication/permission issue...
+    service.createOrReplaceApiKey = jest.fn(() => { throw new Problem(401); });
+
+    const response = await request(app).put(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 500', async () => {
+    // mock an unexpected error...
+    service.createOrReplaceApiKey = jest.fn(() => { throw new Error(); });
+
+    const response = await request(app).put(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).toBeTruthy();
+  });
+
+});
+
+describe(`DELETE ${basePath}/formId/apiKey`, () => {
+
+  it('should return 204', async () => {
+    // mock a success return value...
+    service.deleteApiKey = jest.fn().mockReturnValue([]);
+
+    const response = await request(app).delete(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(204);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 401', async () => {
+    // mock an authentication/permission issue...
+    service.deleteApiKey = jest.fn(() => { throw new Problem(401); });
+
+    const response = await request(app).delete(`${basePath}/formId/apiKey`);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should handle 500', async () => {
+    // mock an unexpected error...
+    service.deleteApiKey = jest.fn(() => { throw new Error(); });
+
+    const response = await request(app).delete(`${basePath}/formId/apiKey`);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -5487,9 +5487,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-root": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR introduces a /fields and /discover endpoint within the /form/version part of the API which allows users to laterally slice and query for certain subsets of information from their form submissions. This is needed in order to eventually allow for customizable submission columns on the frontend.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[SHOWCASE-2180](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2180)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
Check the OpenAPI spec for latest details on endpoint changes. Unit tests coming up soon.
Full path endpoints being proposed:
- `GET {{hostname}}/app/api/v1/forms/:formId/versions/:versionId/fields`
  - https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-220/api/v1/docs#operation/readVersionFields
- `GET {{hostname}}/app/api/v1/forms/:formId/versions/:versionId/submissions/discover?fields=foo,bar,baz`
  - https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-220/api/v1/docs#operation/listDiscoverSubmissions