### PR TITLE
Don't send emails when saving draft

### DIFF
--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -114,7 +114,9 @@ module.exports = {
   createSubmission: async (req, res, next) => {
     try {
       const response = await service.createSubmission(req.params.formVersionId, req.body, req.currentUser);
-      emailService.submissionReceived(req.params.formId, response.id, req.body, req.headers.referer).catch(() => { });
+      if (!req.body.draft) {
+        emailService.submissionReceived(req.params.formId, response.id, req.body, req.headers.referer).catch(() => { });
+      }
       // do we want to await this? could take a while, but it could fail... maybe make an explicit api call?
       fileService.moveSubmissionFiles(response.id, req.currentUser).catch(() => { });
       res.status(201).json(response);

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   update: async (req, res, next) => {
     try {
-      const response = await service.update(req.params.formSubmissionId, req.body, req.currentUser);
+      const response = await service.update(req.params.formSubmissionId, req.body, req.currentUser, req.headers.referer);
       res.status(200).json(response);
     } catch (error) {
       next(error);

--- a/app/tests/unit/routes/v1/form.spec.js
+++ b/app/tests/unit/routes/v1/form.spec.js
@@ -530,6 +530,36 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
 
     const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
 
+    expect(emailService.submissionReceived).toHaveBeenCalledTimes(1);
+    expect(fileService.moveSubmissionFiles).toHaveBeenCalledTimes(1);
+    expect(response.statusCode).toBe(201);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should not call email service if it is a draft', async () => {
+    // mock a success return value...
+    service.createSubmission = jest.fn().mockReturnValue(createSubmissionResult);
+    emailService.submissionReceived = jest.fn(() => Promise.resolve({}));
+    fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
+
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).send({ draft: true });
+
+    expect(emailService.submissionReceived).toHaveBeenCalledTimes(0);
+    expect(fileService.moveSubmissionFiles).toHaveBeenCalledTimes(1);
+    expect(response.statusCode).toBe(201);
+    expect(response.body).toBeTruthy();
+  });
+
+  it('should call email service if draft is provided and false', async () => {
+    // mock a success return value...
+    service.createSubmission = jest.fn().mockReturnValue(createSubmissionResult);
+    emailService.submissionReceived = jest.fn(() => Promise.resolve({}));
+    fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
+
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).send({ draft: false });
+
+    expect(emailService.submissionReceived).toHaveBeenCalledTimes(1);
+    expect(fileService.moveSubmissionFiles).toHaveBeenCalledTimes(1);
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2188?
Was sending the notification email when a user saved a draft. Should only do on submit.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
