### PR TITLE
find fields nested in columns in a form schema

### DIFF
--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -268,11 +268,17 @@ const service = {
     // TODO: Consider if this should be a form utils function instead?
     const findFields = (obj) => {
       const fields = [];
-      // Only add key if it is an input and visible
-      if (obj.input && !obj.hidden) fields.push(obj.key);
-      // Check children components that aren't inputs
-      else if (!obj.hidden && obj.components && obj.components.length) {
-        fields.push(obj.components.flatMap(o => findFields(o)));
+      if (!obj.hidden) {
+        // Only add key if it is an input and visible
+        if (obj.input) fields.push(obj.key);
+        // Recursively check all children attributes that are arrays
+        else {
+          Object.keys(obj).forEach(key => {
+            if (Array.isArray(obj[key]) && obj[key].length) {
+              fields.push(obj[key].flatMap(o => findFields(o)));
+            }
+          });
+        }
       }
       return fields.flat();
     };

--- a/app/tests/unit/forms/form/service.spec.js
+++ b/app/tests/unit/forms/form/service.spec.js
@@ -251,3 +251,73 @@ describe('_findFileIds', () => {
   });
 
 });
+
+describe('readVersionFields', () => {
+
+  it('should return right number of fields without columns',  async () => {
+    const schema = {
+      type: 'form',
+      components: [
+        {
+          type: 'textfield',
+          input: true,
+          key: 'firstName'
+        }
+      ]
+    };
+
+    // mock readVersion function
+    service.readVersion = jest.fn().mockReturnValue( { schema } );
+    // get fields
+    const fields = await service.readVersionFields();
+    // test cases
+    expect(fields.length).toEqual(1);
+  });
+
+  it('should return right number of fields with columns',  async () => {
+    const schema = {
+      type: 'form',
+      components: [
+        {
+          type: 'textfield',
+          input: true,
+          key: 'firstName'
+        },
+        {
+          type: 'columns',
+          input: false,
+          key: 'myColumns',
+          columns: [
+            {
+              size: 'lg',
+              components: []
+            },
+            {
+              size: 'lg',
+              components: [
+                {
+                  type: 'textfield',
+                  input: true,
+                  key: 'lastName'
+                },
+              ]
+            },
+            {
+              size: 'lg',
+              components: []
+            }
+          ]
+        }
+      ]
+    };
+
+    // mock readVersion function
+    service.readVersion = jest.fn().mockReturnValue( { schema } );
+    // get fields
+    const fields = await service.readVersionFields();
+    // test cases
+    expect(fields.length).toEqual(2);
+  });
+
+});
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

the `readVersionFields()` function that is called when customizing columns doesn't find the fields for this form design:
https://chefs.nrs.gov.bc.ca/app/form/submissions?f=b6c5b8c8-0961-4347-b0fe-4153b3c67b31
It should look for components nested in the 'columns' component.

the unit tests i added were more of an afterthought.. 
A real form schema (fixtures to come in another pr) will be more useful.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
