### PR TITLE
css change to remove asterisk after inputs in data-grid

### DIFF
--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -437,6 +437,13 @@ a,
     color: $bcgov-error;
   }
 
+  // hide asterisks after input in Data Grid when labels appear as table headers
+  .formio-component-datagrid {
+    label.field-required.control-label--hidden::after {
+      content: "";
+    }
+  }
+
   // dropdowns
   .choices__list--dropdown {
     .choices__item {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
formio default shows asterisks next to required input in a data grid, as well as column headers.
Looks a bit extraneous. I'm hoping this is an unobtrusive fix without side-affects.


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
