### PR TITLE
include custom form component templates a better way

### DIFF
--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -145,6 +145,7 @@ import { mapActions } from 'vuex';
 import { FormBuilder } from 'vue-formio';
 import { mapFields } from 'vuex-map-fields';
 
+import templateExtensions from '@/plugins/templateExtensions';
 import { formService } from '@/services';
 import { IdentityMode, NotificationTypes } from '@/utils/constants';
 import { generateIdps } from '@/utils/transformUtils';
@@ -280,6 +281,7 @@ export default {
             },
           },
         },
+        templates: templateExtensions,
       };
     },
   },

--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -76,15 +76,12 @@ import Vue from 'vue';
 import { mapActions, mapGetters } from 'vuex';
 import { Form } from 'vue-formio';
 
+import templateExtensions from '@/plugins/templateExtensions';
 import { formService, rbacService } from '@/services';
 import FormViewerActions from '@/components/designer/FormViewerActions.vue';
 import { isFormPublic } from '@/utils/permissionUtils';
 import { attachAttributesToLinks } from '@/utils/transformUtils';
 import { NotificationTypes } from '@/utils/constants';
-import templateExtensions from '@/plugins/templateExtensions';
-
-// override Formio component html templates
-Form.use(templateExtensions);
 
 export default {
   name: 'FormViewer',
@@ -146,6 +143,7 @@ export default {
           addTags: ['iframe'],
           ALLOWED_TAGS: ['iframe'],
         },
+        templates: templateExtensions,
         readOnly: this.readOnly,
         hooks: {
           beforeSubmit: this.onBeforeSubmit,

--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -81,6 +81,10 @@ import FormViewerActions from '@/components/designer/FormViewerActions.vue';
 import { isFormPublic } from '@/utils/permissionUtils';
 import { attachAttributesToLinks } from '@/utils/transformUtils';
 import { NotificationTypes } from '@/utils/constants';
+import templateExtensions from '@/plugins/templateExtensions';
+
+// override Formio component html templates
+Form.use(templateExtensions);
 
 export default {
   name: 'FormViewer',

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -18,8 +18,7 @@ import store from '@/store';
 // No idea why, probably a polyfill clash
 import { Formio } from 'vue-formio';
 import BcGovFormioComponents from '@/formio/lib';
-import templateExtensions from '@/plugins/templateExtensions';
-Formio.use(BcGovFormioComponents, templateExtensions);
+Formio.use(BcGovFormioComponents);
 
 import VueKeycloakJs from '@/plugins/keycloak';
 import vuetify from '@/plugins/vuetify';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

My pr to add aria/required tags to inputs (pr 233) introduced some console statements saying 'x plugin not found' when you view a form.
I believe the way i was including the templates (in the main.js) was not waiting for the formio base templates and plugins to load.
i think this is a better way of doing it.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
