### PR TITLE
Tailor form user admin endpoint to formId

### DIFF
--- a/app/frontend/src/components/admin/AdministerForm.vue
+++ b/app/frontend/src/components/admin/AdministerForm.vue
@@ -1,11 +1,17 @@
 <template>
-  <div>
+  <v-skeleton-loader :loading="loading" type="article">
     <h3>{{ form.name }}</h3>
     <p>{{ form.description }}</p>
 
     <div v-if="form.active === false" class="red--text mb-6">
       (DELETED)
-      <v-btn color="primary" class="mt-0" @click="showRestoreDialog = true" text small>
+      <v-btn
+        color="primary"
+        class="mt-0"
+        @click="showRestoreDialog = true"
+        text
+        small
+      >
         <v-icon class="mr-1">build_circle</v-icon>
         <span class="d-none d-sm-flex">Restore this form</span>
       </v-btn>
@@ -19,13 +25,18 @@
         </v-col>
         <v-col cols="6">
           <h4>Form Users</h4>
-          <vue-json-pretty :data="roleDetails.users" />
+          <vue-json-pretty :data="roles" />
         </v-col>
         <v-col cols="6 mt-6">
           <div v-if="apiKey">
             <h4>API Key Details</h4>
             <vue-json-pretty :data="apiKey" />
-            <v-btn class="mt-6" color="primary" :disabled="!apiKey" @click="showDeleteDialog = true">
+            <v-btn
+              class="mt-6"
+              color="primary"
+              :disabled="!apiKey"
+              @click="showDeleteDialog = true"
+            >
               <span>Delete API Key</span>
             </v-btn>
           </div>
@@ -47,7 +58,9 @@
       <template #title>Confirm Restore</template>
       <template #text>
         <div v-if="restoreInProgress" class="text-center">
-          <v-progress-circular indeterminate color="primary" :size="100">Restoring</v-progress-circular>
+          <v-progress-circular indeterminate color="primary" :size="100">
+            Restoring
+          </v-progress-circular>
         </div>
         <div v-else>
           Restore
@@ -71,7 +84,7 @@
         <span>Delete</span>
       </template>
     </BaseDialog>
-  </div>
+  </v-skeleton-loader>
 </template>
 
 <script>
@@ -84,7 +97,7 @@ export default {
   name: 'AdministerForm',
   components: {
     AdminVersions,
-    VueJsonPretty
+    VueJsonPretty,
   },
   props: {
     formId: {
@@ -94,11 +107,12 @@ export default {
   },
   data() {
     return {
-      showRestoreDialog: false,
-      restoreInProgress: false,
-      showDeleteDialog: false,
       formDetails: {},
+      loading: true,
+      restoreInProgress: false,
       roleDetails: {},
+      showDeleteDialog: false,
+      showRestoreDialog: false,
     };
   },
   computed: {
@@ -127,15 +141,13 @@ export default {
     await Promise.all([
       this.readForm(this.formId),
       this.readApiDetails(this.formId),
-      this.readRoles()
+      this.readRoles(this.formId),
     ]);
-
-    this.roleDetails = this.roles.find((role) => {
-      return role.formName === this.form.name;
-    });
 
     this.formDetails = this.form;
     delete this.formDetails.versions;
+
+    this.loading = false;
   },
 };
 </script>

--- a/app/frontend/src/services/adminService.js
+++ b/app/frontend/src/services/adminService.js
@@ -39,10 +39,11 @@ export default {
   /**
    * @function readRoles
    * Get roles for form user
+   * @param {string} formId The GUID
    * @returns {Promise} An axios response
    */
-  readRoles() {
-    return appAxios().get(`${ApiRoutes.ADMIN}/formUsers`);
+  readRoles(formId) {
+    return appAxios().get(`${ApiRoutes.ADMIN}${ApiRoutes.FORMS}/${formId}/formUsers`);
   },
 
   /**

--- a/app/frontend/src/store/modules/admin.js
+++ b/app/frontend/src/store/modules/admin.js
@@ -88,14 +88,14 @@ export default {
         }, { root: true });
       }
     },
-    async readRoles({ commit, dispatch }) {
+    async readRoles({ commit, dispatch }, formId) {
       try {
         // Get specific roles
-        const response = await adminService.readRoles();
+        const response = await adminService.readRoles(formId);
         commit('SET_ROLES', response.data);
       } catch (error) {
         dispatch('notifications/addNotification', {
-          message: 'An error occurred while fetching these roles.',
+          message: 'An error occurred while fetching form user roles.',
           consoleError: `Error getting admin roles data: ${error}`,
         }, { root: true });
       }

--- a/app/frontend/tests/unit/services/adminService.spec.js
+++ b/app/frontend/tests/unit/services/adminService.spec.js
@@ -80,6 +80,20 @@ describe('Admin Service', () => {
     });
   });
 
+
+  describe('admin/forms/{formId}/formUsers', () => {
+    const endpoint = `${ApiRoutes.ADMIN}${ApiRoutes.FORMS}/${zeroUuid}/formUsers`;
+
+    it('calls get on endpoint', async () => {
+      mockAxios.onGet(endpoint).reply(200);
+
+      const result = await adminService.readApiDetails(zeroUuid);
+      expect(result).toBeTruthy();
+      expect(mockAxios.history.get).toHaveLength(1);
+    });
+  });
+
+
   //
   // User
   //

--- a/app/frontend/tests/unit/services/adminService.spec.js
+++ b/app/frontend/tests/unit/services/adminService.spec.js
@@ -87,7 +87,7 @@ describe('Admin Service', () => {
     it('calls get on endpoint', async () => {
       mockAxios.onGet(endpoint).reply(200);
 
-      const result = await adminService.readApiDetails(zeroUuid);
+      const result = await adminService.readRoles(zeroUuid);
       expect(result).toBeTruthy();
       expect(mockAxios.history.get).toHaveLength(1);
     });

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -2422,7 +2422,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /admin/formUsers:
+  /admin/forms/{formId}/formUsers:
     get:
       summary: Get the list of users for the active forms in the system
       operationId: adminReadFormUsers
@@ -2431,6 +2431,8 @@ paths:
       security:
         - OpenID:
             - admin
+      parameters:
+        - $ref: '#/components/parameters/formIdParam'
       responses:
         '200':
           description: OK

--- a/app/src/forms/admin/controller.js
+++ b/app/src/forms/admin/controller.js
@@ -78,7 +78,7 @@ module.exports = {
   },
   getFormUserRoles: async (req, res, next) => {
     try {
-      const response = await service.getFormUserRoles(req.query);
+      const response = await service.getFormUserRoles(req.params.formId);
       res.status(200).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/admin/routes.js
+++ b/app/src/forms/admin/routes.js
@@ -42,7 +42,7 @@ routes.get('/forms/:formId/versions/:formVersionId', async (req, res, next) => {
   await controller.readVersion(req, res, next);
 });
 
-routes.get('/formUsers', async (req, res, next) => {
+routes.get('/forms/:formId/formUsers', async (req, res, next) => {
   await controller.getFormUserRoles(req, res, next);
 });
 

--- a/app/src/forms/admin/service.js
+++ b/app/src/forms/admin/service.js
@@ -67,27 +67,21 @@ const service = {
       .modify('orderLastFirstAscending');
   },
 
-  getFormUserRoles: async (params) => {
-    const accessItems = await UserFormAccess.query()
-      .skipUndefined()
-      .modify('filterFormId', params.formId)
-      .modify('filterFormName', params.formName)
+  getFormUserRoles: async (formId) => {
+    const formAccess = await UserFormAccess.query()
+      .modify('filterFormId', formId)
       .modify('orderDefault');
-    // do a quick transform into a simple structure...
-    const formIds = [...new Set(accessItems.map(x => x.formId))];
-    const results = formIds.map(formId => {
-      // grab all users that have roles on this form...
-      const users = [...new Set(accessItems.filter(x => x.formId === formId && x.roles.length))];
-      const form = accessItems.find(x => x.formId === formId);
-      const userRoles = users.map(x => ({ userId: x.userId, username: x.username, roles: x.roles }));
-      return {
-        formId: formId,
-        formName: form.formName,
-        users: userRoles
-      };
-    });
-
-    return results;
+    return formAccess
+      // grab all users that have roles on this form
+      .filter(fa => fa.roles.length)
+      // do a quick transform into a simple structure.
+      .map(fa => ({
+        userId: fa.userId,
+        keycloakId: fa.keycloakId,
+        username: fa.username,
+        email: fa.email,
+        roles: fa.roles
+      }));
   }
 };
 

--- a/app/src/forms/admin/service.js
+++ b/app/src/forms/admin/service.js
@@ -7,6 +7,12 @@ const service = {
   // Forms
   //
 
+  /**
+   * @function listForms
+   * List all the forms in CHEFS
+   * @param {Object} params The query params. Specify 'active' bool to control active/deleted
+   * @returns {Promise} An objection query promise
+   */
   listForms: async (params) => {
     params = queryUtils.defaultActiveOnly(params);
     return Form.query()
@@ -18,12 +24,24 @@ const service = {
       .modify('orderNameAscending');
   },
 
+  /**
+   * @function readVersion
+   * Find a form version entry
+   * @param {String} formVersionId The version Id
+   * @returns {Promise} An objection query promise
+   */
   readVersion: (formVersionId) => {
     return FormVersion.query()
       .findById(formVersionId)
       .throwIfNotFound();
   },
 
+  /**
+   * @function readForm
+   * Find a form entry
+   * @param {String} formId The form Id
+   * @returns {Promise} An objection query promise
+   */
   readForm: async (formId) => {
     return Form.query()
       .findById(formId)
@@ -32,6 +50,12 @@ const service = {
       .throwIfNotFound();
   },
 
+  /**
+   * @function restoreForm
+   * Reactivate a soft-deleted form
+   * @param {String} formId The form Id
+   * @returns {Object} The form entry after the restore
+   */
   restoreForm: async (formId) => {
     let trx;
     try {
@@ -57,6 +81,12 @@ const service = {
   // Users
   //
 
+  /**
+   * @function getUsers
+   * Search for users
+   * @param {Object} params The query parameters
+   * @returns {Promise} An objection query promise
+   */
   getUsers: async (params) => {
     return User.query()
       .skipUndefined()
@@ -67,6 +97,12 @@ const service = {
       .modify('orderLastFirstAscending');
   },
 
+  /**
+   * @function getFormUserRoles
+   * For the given form, return users that have roles for that form
+   * @param {String} formId The form ID
+   * @returns {Promise} An objection query promise
+   */
   getFormUserRoles: async (formId) => {
     const formAccess = await UserFormAccess.query()
       .modify('filterFormId', formId)

--- a/app/tests/unit/routes/v1/admin.spec.js
+++ b/app/tests/unit/routes/v1/admin.spec.js
@@ -211,13 +211,13 @@ describe(`GET ${basePath}/users/userId`, () => {
 });
 
 
-describe(`GET ${basePath}/forms/formId/formusers`, () => {
+describe(`GET ${basePath}/forms/formId/formUsers`, () => {
 
   it('should return 200', async () => {
     // mock a success return value...
     service.getFormUserRoles = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/forms/formId/formusers`);
+    const response = await request(app).get(`${basePath}/forms/formId/formUsers`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -227,7 +227,7 @@ describe(`GET ${basePath}/forms/formId/formusers`, () => {
     // mock an authentication/permission issue...
     service.getFormUserRoles = jest.fn(() => { throw new Problem(401); });
 
-    const response = await request(app).get(`${basePath}/forms/formId/formusers`);
+    const response = await request(app).get(`${basePath}/forms/formId/formUsers`);
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -237,7 +237,7 @@ describe(`GET ${basePath}/forms/formId/formusers`, () => {
     // mock an unexpected error...
     service.getFormUserRoles = jest.fn(() => { throw new Error(); });
 
-    const response = await request(app).get(`${basePath}/forms/formId/formusers`);
+    const response = await request(app).get(`${basePath}/forms/formId/formUsers`);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();

--- a/app/tests/unit/routes/v1/admin.spec.js
+++ b/app/tests/unit/routes/v1/admin.spec.js
@@ -211,13 +211,13 @@ describe(`GET ${basePath}/users/userId`, () => {
 });
 
 
-describe(`GET ${basePath}/formusers`, () => {
+describe(`GET ${basePath}/forms/formId/formusers`, () => {
 
   it('should return 200', async () => {
     // mock a success return value...
     service.getFormUserRoles = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formusers`);
+    const response = await request(app).get(`${basePath}/forms/formId/formusers`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -227,7 +227,7 @@ describe(`GET ${basePath}/formusers`, () => {
     // mock an authentication/permission issue...
     service.getFormUserRoles = jest.fn(() => { throw new Problem(401); });
 
-    const response = await request(app).get(`${basePath}/formusers`);
+    const response = await request(app).get(`${basePath}/forms/formId/formusers`);
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -237,7 +237,7 @@ describe(`GET ${basePath}/formusers`, () => {
     // mock an unexpected error...
     service.getFormUserRoles = jest.fn(() => { throw new Error(); });
 
-    const response = await request(app).get(`${basePath}/formusers`);
+    const response = await request(app).get(`${basePath}/forms/formId/formusers`);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Original copy paste of the form user endpoint used here was a lot more than needed for Admin FE. FormId wasn't being provided which on large data seemed to be causing DB issues (should only ever call with an ID anyways).
Refactor API service call to simplify it a bunch. Refactor path to match other admin service routes.
Change FE to supply formId in call.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
