### PR TITLE
feat: move updated by to own column

### DIFF
--- a/app/frontend/src/components/forms/submission/StatusTable.vue
+++ b/app/frontend/src/components/forms/submission/StatusTable.vue
@@ -11,12 +11,7 @@
       class="status-table"
     >
       <template #[`item.createdAt`]="{ item }">
-        <v-tooltip bottom :disabled="item.code.toUpperCase() === 'SUBMITTED'">
-          <template v-slot:activator="{ on }">
-            <span v-on="on">{{ item.createdAt | formatDate }}</span>
-          </template>
-          <span>Status updated by {{ item.createdBy }}</span>
-        </v-tooltip>
+        <span>{{ item.createdAt | formatDate }}</span>
       </template>
 
       <template #[`item.user`]="{ item }">{{
@@ -42,7 +37,8 @@ export default {
     headers: [
       { text: 'Status', value: 'code' },
       { text: 'Date Status Changed', align: 'start', value: 'createdAt' },
-      { text: 'Assignee', value: 'user' }
+      { text: 'Assignee', value: 'user' },
+      { text: 'Updated By', value: 'createdBy' },
     ],
     statuses: [],
     loading: true,


### PR DESCRIPTION
# Description
Updating the status history table to move the status updated by tool tip into its own column.


![Screenshot 2021-12-07 at 4 47 35 PM](https://user-images.githubusercontent.com/35253/145128530-bab309cf-3090-46ac-a964-17cb0b6b707d.png)



[Jira Ticket](https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2300)
