### PR TITLE
Autocomplete Issues on Edge

### DIFF
--- a/app/frontend/src/components/forms/manage/AddTeamMember.vue
+++ b/app/frontend/src/components/forms/manage/AddTeamMember.vue
@@ -2,6 +2,7 @@
   <span>
     <span v-if="addingUsers" class="d-flex justify-end">
       <v-autocomplete
+        autocomplete="autocomplete_off"
         v-model="model"
         clearable
         dense

--- a/app/frontend/src/components/forms/submission/ManageSubmissionUsers.vue
+++ b/app/frontend/src/components/forms/submission/ManageSubmissionUsers.vue
@@ -25,6 +25,7 @@
             <v-col cols="9">
               <form autocomplete="off">
                 <v-autocomplete
+                  autocomplete="autocomplete_off"
                   v-model="userSearchSelection"
                   clearable
                   dense

--- a/app/frontend/src/components/forms/submission/StatusPanel.vue
+++ b/app/frontend/src/components/forms/submission/StatusPanel.vue
@@ -62,6 +62,7 @@
                   </v-tooltip>
                 </label>
                 <v-autocomplete
+                  autocomplete="autocomplete_off"
                   v-model="assignee"
                   clearable
                   dense


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Made changes to the v-autocomplete components to adhere to new Microsoft Edge browser permissions. This PR is removing the browser's autofill popups by default now.

Tested on FireFox, Chrome, Edge and Safari.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Changed all v-autocomplete components to add a property of `autocomplete="autocomplete_off"`. Edge requires that a random string is added as the value for the autocomplete property.

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
