### PR TITLE
Fixing Permissions and Edit Icon on Submissions

### DIFF
--- a/app/frontend/src/components/designer/FormViewerActions.vue
+++ b/app/frontend/src/components/designer/FormViewerActions.vue
@@ -27,7 +27,7 @@
       </span>
 
       <!-- Go to draft edit -->
-      <span v-if="showEditToggle" class="ml-2">
+      <span v-if="showEditToggle && isDraft" class="ml-2">
         <router-link
           :to="{
             name: 'UserFormDraftEdit',

--- a/app/src/forms/submission/service.js
+++ b/app/src/forms/submission/service.js
@@ -53,9 +53,6 @@ const service = {
     try {
       trx = etrx ? etrx : await FormSubmission.startTransaction();
 
-      // Patch the submission record with the updated changes
-      await FormSubmission.query(trx).patchAndFetchById(formSubmissionId, { draft: data.draft, submission: data.submission, updatedBy: currentUser.usernameIdp });
-
       if (!data.draft) {
         // Write a SUBMITTED status only if this is in REVISING state OR is a brand new submission
         const statuses = await FormSubmissionStatus.query()
@@ -68,6 +65,9 @@ const service = {
           emailService.submissionReceived(submissionMetaData.formId, formSubmissionId, data, referrer).catch(() => { });
         }
       }
+
+      // Patch the submission record with the updated changes
+      await FormSubmission.query(trx).patchAndFetchById(formSubmissionId, { draft: data.draft, submission: data.submission, updatedBy: currentUser.usernameIdp });
 
       if (!etrx) await trx.commit();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Fixing bug where edit icon stays visible after setting submission from Draft -> Submitted.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
1. Moved the query to set draft to false after the changeStatusState service call.
2. Added another check to make sure that the submission is a draft in the front end.

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
