### PR TITLE
Stopping CHES Call when no email provided on Submit

### DIFF
--- a/app/src/forms/email/emailService.js
+++ b/app/src/forms/email/emailService.js
@@ -287,8 +287,10 @@ const service = {
   submissionReceived: async (formId, submissionId, body, referer) => {
     try {
       const { configData, contexts } = await buildEmailTemplate(formId, submissionId, EmailTypes.SUBMISSION_RECEIVED, referer, { body });
-      if (contexts[0].to.length > 0) {
+      if (contexts[0].to.length) {
         return service._sendEmailTemplate(configData, contexts);
+      } else {
+        return {};
       }
     } catch (e) {
       log.error(e.message, {

--- a/app/src/forms/email/emailService.js
+++ b/app/src/forms/email/emailService.js
@@ -287,8 +287,9 @@ const service = {
   submissionReceived: async (formId, submissionId, body, referer) => {
     try {
       const { configData, contexts } = await buildEmailTemplate(formId, submissionId, EmailTypes.SUBMISSION_RECEIVED, referer, { body });
-
-      return service._sendEmailTemplate(configData, contexts);
+      if (contexts[0].to.length > 0) {
+        return service._sendEmailTemplate(configData, contexts);
+      }
     } catch (e) {
       log.error(e.message, {
         function: EmailTypes.SUBMISSION_RECEIVED,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Stopping the CHES call when there are no emails provided.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Made changes to the emailService so that it checks the contexts variable for any emails to send to.
<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have checked that unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
