### PR TITLE
Can't populate submission table until form fields are known

### DIFF
--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -175,9 +175,7 @@ export default {
         this.userFormPreferences.preferences.columnList
       ) {
         // Compare saved user prefs against the current form versions component names and remove any discrepancies
-        return this.userFormPreferences.preferences.columnList.filter(
-          (x) => this.formFields.indexOf(x) !== -1
-        );
+        return this.userFormPreferences.preferences.columnList.filter((x) => this.formFields.indexOf(x) !== -1);
       } else {
         return [];
       }
@@ -235,7 +233,7 @@ export default {
   },
 
   async mounted() {
-    // Get the form, latest version form fields, and fill the table
+    // Get the form, latest version form fields
     // These calls have to be waited on until the table can populate below
     await this.fetchForm(this.formId);
     await this.fetchFormFields({

--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -126,6 +126,11 @@ export default {
       'submissionList',
       'userFormPreferences',
     ]),
+
+    checkFormManage() {
+      return this.permissions.some((p) => FormManagePermissions.includes(p));
+    },
+
     headers() {
       let headers = [
         { text: 'Confirmation ID', align: 'start', value: 'confirmationId' },
@@ -175,7 +180,9 @@ export default {
         this.userFormPreferences.preferences.columnList
       ) {
         // Compare saved user prefs against the current form versions component names and remove any discrepancies
-        return this.userFormPreferences.preferences.columnList.filter(x => this.formFields.indexOf(x) !== -1);
+        return this.userFormPreferences.preferences.columnList.filter(
+          (x) => this.formFields.indexOf(x) !== -1
+        );
       } else {
         return [];
       }
@@ -189,10 +196,6 @@ export default {
       'getFormPermissionsForUser',
       'getFormPreferencesForCurrentUser',
     ]),
-
-    checkFormManage() {
-      return this.permissions.some((p) => FormManagePermissions.includes(p));
-    },
 
     async populateSubmissionsTable() {
       try {

--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -175,7 +175,7 @@ export default {
         this.userFormPreferences.preferences.columnList
       ) {
         // Compare saved user prefs against the current form versions component names and remove any discrepancies
-        return this.userFormPreferences.preferences.columnList.filter((x) => this.formFields.indexOf(x) !== -1);
+        return this.userFormPreferences.preferences.columnList.filter(x => this.formFields.indexOf(x) !== -1);
       } else {
         return [];
       }

--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -175,7 +175,9 @@ export default {
         this.userFormPreferences.preferences.columnList
       ) {
         // Compare saved user prefs against the current form versions component names and remove any discrepancies
-        return this.userFormPreferences.preferences.columnList.filter(x => this.formFields.indexOf(x) !== -1);
+        return this.userFormPreferences.preferences.columnList.filter(
+          (x) => this.formFields.indexOf(x) !== -1
+        );
       } else {
         return [];
       }
@@ -232,13 +234,13 @@ export default {
     },
   },
 
-  mounted() {
-    // Get the form and latest form fields
-    this.fetchForm(this.formId).then(() => {
-      this.fetchFormFields({
-        formId: this.formId,
-        formVersionId: this.form.versions[0].id,
-      });
+  async mounted() {
+    // Get the form, latest version form fields, and fill the table
+    // These calls have to be waited on until the table can populate below
+    await this.fetchForm(this.formId);
+    await this.fetchFormFields({
+      formId: this.formId,
+      formVersionId: this.form.versions[0].id,
     });
 
     // Get the permissions for this form

--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -232,18 +232,18 @@ export default {
     },
   },
 
-  async mounted() {
-    // Get the form, latest version form fields
-    // These calls have to be waited on until the table can populate below
-    await this.fetchForm(this.formId);
-    await this.fetchFormFields({
-      formId: this.formId,
-      formVersionId: this.form.versions[0].id,
+  mounted() {
+    Promise.all([
+      this.getFormPermissionsForUser(this.formId),
+      this.fetchForm(this.formId).then(() => {
+        this.fetchFormFields({
+          formId: this.formId,
+          formVersionId: this.form.versions[0].id,
+        });
+      }),
+    ]).then(() => {
+      this.populateSubmissionsTable();
     });
-
-    // Get the permissions for this form
-    this.getFormPermissionsForUser(this.formId);
-    this.populateSubmissionsTable();
   },
 };
 </script>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Fixes https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2675

Refer to comments here https://github.com/bcgov/common-hosted-form-service/pull/274#pullrequestreview-878089635
The populate form part is actually synchronously dependent on the formFields list after the change from that PR, so it has to await on that. Might be a better way to lay that out than the 2 awaits but it works.

Also fix https://apps.nrs.gov.bc.ca/int/jira/browse/SHOWCASE-2699
If computing something to determine a truthy value to use in the template, need to make it a computed value or invoke the method response. Can't do `v-if="methodName"` or that's truthy always.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
