### PR TITLE
improve confirmation dialog in Design.vue

### DIFF
--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -125,7 +125,7 @@
       </v-col>
     </v-row>
     <v-alert
-      :value="saved || saving"
+      :value="(saved || saving) && isSavedButtonClick"
       :class="
         saving
           ? NOTIFICATIONS_TYPES.INFO.class
@@ -535,6 +535,7 @@ export default {
 
     //this method is used for autosave action
     async autosaveEventTrigger() {
+      this.isSavedButtonClick=false;
       if(this.newForm) {
 
         await this.setShowWarningDialog(true);
@@ -550,7 +551,9 @@ export default {
     async submitFormButtonClick() {
       await this.setShowWarningDialog(false);
       await this.setCanLogout(true);
+      this.isSavedButtonClick=true;
       this.submitFormSchema();
+
     },
     getPatch(idx) {
       // Generate the form from the original schema
@@ -605,8 +608,8 @@ export default {
     // Saving the Schema
     // ---------------------------------------------------------------------------------------------------
     async submitFormSchema() {
+      this.saving = true;
       try {
-        this.saving = true;
         // Once the form is done disable the "leave site/page" messages so they can quit without getting whined at
         if (this.formId) {
           if (this.versionId) {

--- a/app/frontend/src/views/form/Design.vue
+++ b/app/frontend/src/views/form/Design.vue
@@ -14,19 +14,16 @@
                 @continue-dialog="navigateToRoute"
                 :showCloseButton=true>
       <template #title>Confirm</template>
-      <template #icon>
-        <v-icon large color="primary">warning</v-icon>
-      </template>
       <template #text>
         <div class="dialogMessageText">
-          Do you want to save this form?
+          Do you want to save this form before exit
         </div>
       </template>
       <template #button-text-continue>
-        <span>Save</span>
+        <span>Yes</span>
       </template>
       <template #button-text-delete>
-        <span>Delete</span>
+        <span>No</span>
       </template>
     </BaseDialog>
   </BaseSecure>
@@ -100,11 +97,3 @@ export default {
 
 };
 </script>
-<style lang="css" scoped>
-  .dialogMessageText {
-    color: #494949 !important;
-    font-size: 19px;
-    line-height: 30px;
-    padding: 0;
-  }
-</style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
- Change the wording of the confirmation dialog. Also, change the two buttons' texts to "Yes" and "No," respectively
- added isButtonClick to Alert Component in FormDesigner.vue. This ensures that the saved message will only show when form designers click on the save button

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [*] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [*] I have checked that unit tests pass locally with my changes
- [*] I have run the npm script lint on the frontend and backend
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] I have added necessary documentation (if appropriate)
- [*] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
