### PR TITLE
 fix autosave not keeping state on page reload

### DIFF
--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -674,7 +674,6 @@ export default {
         showSubmissionConfirmation: this.showSubmissionConfirmation,
         submissionReceivedEmails: emailList,
       });
-      console.log('I am there --------->>>>> ', this.enableAutosave);
       // Navigate back to this page with ID updated
       this.$router.push({
         name: 'FormDesigner',

--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -127,7 +127,7 @@
         <v-switch
           color="success"
           label="AutoSave"
-          @change="autoSaveTogglePublish($event)"
+          v-model="enableAutosave"
         />
       </v-col>
     </v-row>
@@ -220,7 +220,11 @@ export default {
       default: false,
     },
     versionId: String,
-    newForm:Boolean
+    newForm:Boolean,
+    autosave:{
+      type:Boolean,
+      default:false
+    }
   },
   data() {
     return {
@@ -236,7 +240,7 @@ export default {
       },
       displayVersion: 1,
       reRenderFormIo: 0,
-      enableAutosave:false,
+      enableAutosave:this.autosave,
       saving: false,
       isSavedButtonClick: false,
       patch: {
@@ -540,10 +544,7 @@ export default {
 
       this.resetHistoryFlags();
     },
-    // use to turn off and on autosave
-    autoSaveTogglePublish(event) {
-      this.enableAutosave=event;
-    },
+
 
     //this method is used for autosave action
     async autosaveEventTrigger() {
@@ -673,6 +674,7 @@ export default {
         showSubmissionConfirmation: this.showSubmissionConfirmation,
         submissionReceivedEmails: emailList,
       });
+      console.log('I am there --------->>>>> ', this.enableAutosave);
       // Navigate back to this page with ID updated
       this.$router.push({
         name: 'FormDesigner',
@@ -681,6 +683,7 @@ export default {
           d: response.data.draft.id,
           sv: true,
           nf:this.newForm,
+          as:this.enableAutosave
         },
       });
     },
@@ -699,6 +702,7 @@ export default {
           d: data.id,
           sv: true,
           nf:this.newForm,
+          as:this.enableAutosave
         },
       });
     },
@@ -710,7 +714,7 @@ export default {
       // Update this route with saved flag
       this.$router.replace({
         name: 'FormDesigner',
-        query: { ...this.$route.query, sv: true,nf:this.newForm },
+        query: { ...this.$route.query, sv: true,nf:this.newForm, as:this.enableAutosave },
       });
 
     },

--- a/app/frontend/src/views/form/Design.vue
+++ b/app/frontend/src/views/form/Design.vue
@@ -7,6 +7,7 @@
       :saved="Boolean(sv)"
       :versionId="v"
       :newForm="Boolean(nf)"
+      :autosave="Boolean(as)"
     />
     <BaseDialog :value=Boolean(this.showDialog) type="SAVEDDELETE"
                 @close-dialog="closeDialog"
@@ -44,7 +45,8 @@ export default {
     f: String,
     sv: Boolean,
     v: String,
-    nf:Boolean
+    nf:Boolean,
+    as:Boolean
   },
   data() {
     return {
@@ -71,7 +73,25 @@ export default {
     },
     deleteDialog() {
       this.deleteCurrentForm();
-      this.navigateToRoute();
+      this.onDeleteDialogCheck();
+    },
+    async onDeleteDialogCheck() {
+
+      this.showDialog=false;
+      await this.setShowWarningDialog(false);
+      await this.setCanLogout(true);
+      //checks if form designers is trying to log out without
+      //clicking on the save button
+      if(this.isLogoutButtonClicked){
+        this.logoutWithUrl();
+      }
+      if(this.toRouterPathName==='FormManage') {
+
+        this.$router.push({name:'UserForms'});
+      }
+      else {
+        this.$router.push({name:this.toRouterPathName.trim()});
+      }
     },
     async navigateToRoute() {
       this.showDialog=false;
@@ -90,6 +110,7 @@ export default {
     // it will ask form designers if they want to delete or
     //or keep the forms
     if(_to.name!==_from.name) {
+
       this.toRouterPathName = _to.name;
       this.showWarningDialog? this.showDialog=true: next();
     }

--- a/tests/functional/cypress/specs/designer-undo.spec.js
+++ b/tests/functional/cypress/specs/designer-undo.spec.js
@@ -103,8 +103,9 @@ describe('Form Designer', () => {
   });
 
 
-  it('form should autosave and should not be deleted when click keep button on confimation dialog', () => {
+  it('form should autosave and should not be deleted when click Yes button on confimation dialog', () => {
     cy.intercept('GET', `/${depEnv}/api/v1/forms/*`).as('getForm');
+    cy.get('.v-input__slot').contains('AutoSave').click()
     cy.get('button').contains('Basic Fields').click();
     cy.get('div.formio-builder-form').then($el => {
       const bounds = $el[0].getBoundingClientRect();
@@ -115,18 +116,20 @@ describe('Form Designer', () => {
       cy.get('button').contains('Save').click();
     });
     cy.wait('@getForm').then(()=>{
+      cy.get('.v-input__slot').contains('AutoSave').click();
       let routerLink =cy.get('[data-cy=aboutLinks]');
       expect(routerLink).to.not.be.null;
       routerLink.trigger('click');
-      cy.contains('Confirm Navigation').should('be.visible');
-      cy.contains('Keep').should('be.visible');
-      cy.contains('Keep').trigger('click');
+      cy.contains('Confirm').should('be.visible');
+      cy.contains('Yes').should('be.visible');
+      cy.contains('Yes').trigger('click');
       cy.location('pathname').should('eq', `/${depEnv}/`);
     })
   });
 
-  it('form should autosave and should delet when click Delete button on confimation dialog', () => {
+  it('form should autosave and should delet when click No button on confimation dialog', () => {
     cy.intercept('GET', `/${depEnv}/api/v1/forms/*`).as('getForm');
+    cy.get('.v-input__slot').contains('AutoSave').click()
     cy.get('button').contains('Basic Fields').click();
     cy.get('div.formio-builder-form').then($el => {
       const bounds = $el[0].getBoundingClientRect();
@@ -140,15 +143,16 @@ describe('Form Designer', () => {
       let routerLink =cy.get('[data-cy=aboutLinks]');
       expect(routerLink).to.not.be.null;
       routerLink.trigger('click');
-      cy.contains('Confirm Navigation').should('be.visible');
-      cy.contains('Delete').should('be.visible');
-      cy.contains('Delete').trigger('click');
+      cy.contains('Confirm').should('be.visible');
+      cy.contains('No').should('be.visible');
+      cy.contains('No').trigger('click');
       cy.location('pathname').should('eq', `/${depEnv}/`);
     })
   });
 
   it('form should autosave and should not show confirmation dialog if save button is clicked', () => {
     cy.intercept('GET', `/${depEnv}/api/v1/forms/*`).as('getForm');
+    cy.get('.v-input__slot').contains('AutoSave').click()
     cy.get('button').contains('Basic Fields').click();
     cy.get('div.formio-builder-form').then($el => {
       const bounds = $el[0].getBoundingClientRect();
@@ -167,7 +171,7 @@ describe('Form Designer', () => {
       let routerLink =cy.get('[data-cy=aboutLinks]');
       expect(routerLink).to.not.be.null;
       routerLink.trigger('click');
-      cy.contains('Confirm Navigation').should('not.exist');
+      cy.contains('Confirm').should('not.exist');
       cy.location('pathname').should('eq', `/${depEnv}/`);
     })
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
- fix autosave not keeping state on page reload
- Fix when the user clicks on the manage icon on the form design page and then clicks delete on the confirmation page, it should go to the "UserForms" route instead of the "FormManage" route

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
