### PR TITLE
Fixed submission export start and end date issue

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -10,10 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/bc-sans": "^1.0.1",
-        "@fortawesome/fontawesome-svg-core": "^6.1.1",
+        "@fortawesome/fontawesome-svg-core": "^6.2.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
-        "@fortawesome/free-solid-svg-icons": "^6.1.1",
-        "@fortawesome/vue-fontawesome": "^2.0.6",
+        "@fortawesome/free-solid-svg-icons": "^6.2.1",
+        "@fortawesome/vue-fontawesome": "^2.0.9",
         "@mdi/font": "^6.6.96",
         "axios": "^0.24.0",
         "bootstrap-scss": "^4.6.1",
@@ -1763,13 +1763,22 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
-      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
+      "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.1.1"
+        "@fortawesome/fontawesome-common-types": "6.2.1"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
+      "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -1787,23 +1796,32 @@
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
-      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.1.tgz",
+      "integrity": "sha512-oKuqrP5jbfEPJWTij4sM+/RvgX+RMFwx3QZCZcK9PrBDgxC35zuc7AOFsyMjMd/PIFPeB2JxyqDr5zs/DZFPPw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.1.1"
+        "@fortawesome/fontawesome-common-types": "6.2.1"
       },
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/@fortawesome/free-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
+      "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@fortawesome/vue-fontawesome": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.6.tgz",
-      "integrity": "sha512-V3vT3flY15AKbUS31aZOP12awQI3aAzkr2B1KnqcHLmwrmy51DW3pwyBczKdypV8QxBZ8U68Hl2XxK2nudTxpg==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.9.tgz",
+      "integrity": "sha512-tUmO92PFHbLOplitjHNBVGMJm6S57vp16tBXJVPKSI/6CfjrgLycqKxEpC6f7qsOqUdoXs5nIv4HLUfrOMHzuw==",
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "vue": "~2"
       }
     },
@@ -21205,11 +21223,18 @@
       "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
-      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
+      "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "6.1.1"
+        "@fortawesome/fontawesome-common-types": "6.2.1"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
+          "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ=="
+        }
       }
     },
     "@fortawesome/free-regular-svg-icons": {
@@ -21221,17 +21246,24 @@
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
-      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.1.tgz",
+      "integrity": "sha512-oKuqrP5jbfEPJWTij4sM+/RvgX+RMFwx3QZCZcK9PrBDgxC35zuc7AOFsyMjMd/PIFPeB2JxyqDr5zs/DZFPPw==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "6.1.1"
+        "@fortawesome/fontawesome-common-types": "6.2.1"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
+          "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ=="
+        }
       }
     },
     "@fortawesome/vue-fontawesome": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.6.tgz",
-      "integrity": "sha512-V3vT3flY15AKbUS31aZOP12awQI3aAzkr2B1KnqcHLmwrmy51DW3pwyBczKdypV8QxBZ8U68Hl2XxK2nudTxpg==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.9.tgz",
+      "integrity": "sha512-tUmO92PFHbLOplitjHNBVGMJm6S57vp16tBXJVPKSI/6CfjrgLycqKxEpC6f7qsOqUdoXs5nIv4HLUfrOMHzuw==",
       "requires": {}
     },
     "@hapi/address": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -24,10 +24,10 @@
   },
   "dependencies": {
     "@bcgov/bc-sans": "^1.0.1",
-    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
-    "@fortawesome/free-solid-svg-icons": "^6.1.1",
-    "@fortawesome/vue-fontawesome": "^2.0.6",
+    "@fortawesome/free-solid-svg-icons": "^6.2.1",
+    "@fortawesome/vue-fontawesome": "^2.0.9",
     "@mdi/font": "^6.6.96",
     "axios": "^0.24.0",
     "bootstrap-scss": "^4.6.1",

--- a/app/frontend/src/components/forms/ColumnPreferences.vue
+++ b/app/frontend/src/components/forms/ColumnPreferences.vue
@@ -67,7 +67,7 @@
           <v-btn data-cy="columnPreferencesSaveBtn" class="mb-5 mr-5" :style="saveButtonWrapper" color="primary" @click="saveColumns">
             <span>Save</span>
           </v-btn>
-          <v-btn class="mb-5" :style="cancelButtonWrapper" outlined @click="dialog = false">
+          <v-btn class="mb-5" :style="cancelButtonWrapper" outlined @click="()=>{dialog = false; this.onSearchInputChange='';}">
             <span>Cancel</span>
           </v-btn>
         </v-card-actions>
@@ -279,8 +279,10 @@ export default {
     formFields(fields) {
       this.filteredFormFields=[...fields];
       this.setSelectALLCheckboxVModel(fields,false);
-    }
-  }
+      this.sortFields();
+    },
+  },
+
 
 };
 </script>

--- a/app/frontend/src/components/forms/ExportSubmissions.vue
+++ b/app/frontend/src/components/forms/ExportSubmissions.vue
@@ -90,6 +90,7 @@
                     v-model="startDate"
                     data-test="picker-form-startDate"
                     @input="startDateMenu = false"
+                    :max="maxDate"
                   ></v-date-picker>
                 </v-menu>
               </v-col>
@@ -121,6 +122,7 @@
                     v-model="endDate"
                     data-test="picker-form-endDate"
                     @input="endDateMenu = false"
+                    :min="startDate"
                   ></v-date-picker>
                 </v-menu>
               </v-col>
@@ -192,6 +194,11 @@ export default {
     };
   },
   computed: {
+    maxDate() {
+      let momentObj = moment(Date());
+      let  momentString = momentObj.format('YYYY-MM-DD');
+      return momentString;
+    },
     ...mapGetters('form', ['form', 'userFormPreferences']),
     fileName() {
       return `${this.form.snake}_submissions.${this.exportFormat}`;
@@ -250,6 +257,11 @@ export default {
       }
     },
   },
+  watch:{
+    startDate() {
+      this.endDate='';
+    }
+  }
 };
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
- fixed submission export start and end date. User cannot select beyond the current day for start date and end date start from the start date selected.
- fixed export csv file not to show columns that are not selected.

<!-- Provide a general summary of your changes in the Title above -->
# Description
- fixed submission export start and end date. User cannot select beyond the current day for start date and end date start from the start date selected.
- fixed export csv file not to show columns that are not selected.
- 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
