### PR TITLE
fix Select all checkbox in ColumnPreferences.vue

### DIFF
--- a/app/frontend/src/components/forms/ColumnPreferences.vue
+++ b/app/frontend/src/components/forms/ColumnPreferences.vue
@@ -169,7 +169,10 @@ export default {
         this.selectedAll=true;
         this.selectAllPointerEvent='none';
       }
-      this.selectedAll=false;
+      else {
+        this.selectedAll=false;
+      }
+      //
       return checker;
     },
 
@@ -248,7 +251,7 @@ export default {
       else {
         this.sortFields();
       }
-      //this.checkAllCheckboxesChecked();
+      this.checkAllCheckboxesChecked();
     },
     formFields(fields) {
       this.filteredFormFields=[...fields];

--- a/app/frontend/src/components/forms/ColumnPreferences.vue
+++ b/app/frontend/src/components/forms/ColumnPreferences.vue
@@ -169,6 +169,7 @@ export default {
         this.selectedAll=true;
         this.selectAllPointerEvent='none';
       }
+      this.selectedAll=false;
       return checker;
     },
 

--- a/app/frontend/src/components/forms/ExportSubmissions.vue
+++ b/app/frontend/src/components/forms/ExportSubmissions.vue
@@ -17,6 +17,7 @@
     </v-tooltip>
 
     <v-dialog
+      v-if="dialog"
       v-model="dialog"
       width="900"
       content-class="export-submissions-dlg"
@@ -179,11 +180,11 @@ export default {
     return {
       dateRange: false,
       dialog: false,
-      endDate: '',
+      endDate: moment(Date()).format('YYYY-MM-DD'),
       endDateMenu: false,
       dataFields:false,
       exportFormat: 'csv',
-      startDate: '',
+      startDate: moment(Date()).format('YYYY-MM-DD'),
       startDateMenu: false,
 
     };
@@ -254,7 +255,13 @@ export default {
   },
   watch:{
     startDate() {
-      this.endDate='';
+      this.endDate= moment(Date()).format('YYYY-MM-DD');
+    },
+    dateRange(value) {
+      if(!value) {
+        this.endDate= moment(Date()).format('YYYY-MM-DD');
+        this.startDate= moment(Date()).format('YYYY-MM-DD');
+      }
     }
   }
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
When users select all the fields' checkboxes, the "Select All" checkbox is checked. If the click cancel to close dialog box instead of the save button and the dialog box is re-opened, the Select All box is still checked but should not be checked. 


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
