### PR TITLE
fix alignment issue for the proactive publish toggle switch in Genera…

### DIFF
--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -568,18 +568,12 @@ a,
 }
 
 .info-helper {
-  padding-top: 2px;
-  float: right;
-  border-radius: 50%;
-  width: 16px;
-  height: 16px;
-  text-align: center;
-  border: 1px solid #003366;
-  font-size: 0.8rem;
-  line-height: 0.8rem;
+  color:gray;
+
 }
 
 .info-helper:hover {
-  background-color: #003366;
-  color: #bce8ff;
+
+  color: #01254a;
 }
+

--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -89,7 +89,7 @@
       :baseFABItemsBGColor="'#ffffff'"
       :baseFABIconColor="'#1976D2'"
       :baseFABBorderColor="'#C0C0C0'"
-      :fabZIndex=1000
+      :fabZIndex=1
       :size="'small'"
       fabItemsGap="7px"
       @undo="onUndoClick"
@@ -350,7 +350,8 @@ export default {
                   {
                     // Append the info el
                     let child = document.createElement('i');
-                    child.className = 'fa fa-info info-helper';
+
+                    child.setAttribute('class','fa fa-info-circle');
                     child.style.float='right';
                     child.addEventListener('click', this.showHelperClicked);
                     containerEl.children[i].appendChild(child);

--- a/app/frontend/src/components/infolinks/GeneralLayout.vue
+++ b/app/frontend/src/components/infolinks/GeneralLayout.vue
@@ -37,7 +37,7 @@
           <div>
             <v-btn data-cy="status_button" color="primary" text small :disabled="canDisabled(item.componentName)">
               <v-switch small color="success" :input-value="isComponentPublish(item.componentName,index)" v-model="publish[index]" @change="onSwitchChange(item.componentName,index)"></v-switch>
-              <span class="d-none d-sm-flex" style="font-size:16px;">{{ publish[index]?'PUBLISHED':'UNPUBLISHED'}}</span>
+              <span style="width:120px !important; font-size:16px;" class="d-none d-sm-flex" >{{ publish[index]?'PUBLISHED':'UNPUBLISHED'}}</span>
             </v-btn>
           </div>
         </div>
@@ -98,7 +98,7 @@ export default{
     },
     componentsList: {
       type:Array,
-      defualt:[]
+      default: () => []
     },
     groupName:String
   },

--- a/app/frontend/src/components/infolinks/InformationLinkDialog.vue
+++ b/app/frontend/src/components/infolinks/InformationLinkDialog.vue
@@ -2,7 +2,6 @@
   <v-row justify="center" class="mb-5" >
     <v-dialog
       v-model="dialog"
-      persistent
       width="70%"
     >
       <v-card>

--- a/app/frontend/src/components/infolinks/InformationLinkPreviewDialog.vue
+++ b/app/frontend/src/components/infolinks/InformationLinkPreviewDialog.vue
@@ -3,16 +3,13 @@
     <v-dialog
       v-model="dialog"
       width="70%"
-      persistent
     >
       <v-card class="pb-16">
         <v-container class="overflow-auto">
           <v-row >
             <v-col class="d-flex justify-space-between headerWrapper pa-4">
               <div class="align-self-center">{{component&&component.componentName}}</div>
-              <div class="align-self-center cursor"><font-awesome-icon icon="fa-solid fa-xmark" :size="'1x'" inverse @click="()=>{
-                this.$emit('close-dialog');
-              }"/></div>
+              <div class="align-self-center cursor"><font-awesome-icon icon="fa-solid fa-xmark" :size="'1x'" inverse @click="onCloseDialog"/></div>
             </v-col>
           </v-row>
           <v-row class="mt-6" v-if="component&&component.image">

--- a/app/frontend/src/store/modules/admin.js
+++ b/app/frontend/src/store/modules/admin.js
@@ -223,7 +223,6 @@ export default {
     async updateFCProactiveHelpStatus({ commit, dispatch },{componentId, publishStatus}) {
       try {
         // Get Common Components Help Information
-        commit('SET_FCPROACTIVEHELP',{});
         const response = await adminService.updateFCProactiveHelpStatus(componentId, publishStatus);
         commit('SET_FCPROACTIVEHELP',response.data);
       } catch(error) {

--- a/app/frontend/tests/unit/components/infolinks/GeneralLayout.spec.js
+++ b/app/frontend/tests/unit/components/infolinks/GeneralLayout.spec.js
@@ -15,7 +15,7 @@ describe('GeneralLayout.vue', () => {
       propsData: {
         componentsList: {
           type:Array,
-          defualt:[]
+          default:[]
         }
       },
       data() {
@@ -43,7 +43,7 @@ describe('GeneralLayout.vue', () => {
       propsData: {
         componentsList: {
           type:Array,
-          defualt:[]
+          default:[]
         }
       },
       data() {
@@ -67,7 +67,7 @@ describe('GeneralLayout.vue', () => {
       propsData: {
         componentsList: {
           type:Array,
-          defualt:[]
+          default:[]
         }
       },
       data() {
@@ -90,7 +90,7 @@ describe('GeneralLayout.vue', () => {
       propsData: {
         componentsList: {
           type:Array,
-          defualt:[]
+          default:[]
         }
       },
       data() {


### PR DESCRIPTION
…lLayout

- set side menu buttons in the form design page z-index to 1 so that the proactive help dialog box will display the menu buttons
- remove persistent from both InformationLinkDialog and InformationLinkPreviewDialog so users when users click outside the boxes, they will close
- fix alignment issue for the proactive publish toggle switch in GeneralLayout
- change proactive preview icon in FormDesign

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
