### PR TITLE
 fix the loop hole in the multi-user

### DIFF
--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -427,7 +427,7 @@ export default {
     async deleteMultiSubs() {
       let submissionsIdsToDelete = this.selectedSubmissions.map(submission=>submission.submissionId);
       this.showDeleteDialog = false;
-      await this.deleteMultiSubmissions(submissionsIdsToDelete);
+      await this.deleteMultiSubmissions({submissionIds:submissionsIdsToDelete, formId:this.form.id});
       this.refreshSubmissions();
     },
 
@@ -495,7 +495,7 @@ export default {
     async restoreMultipleSubs() {
       let submissionsIdsToRestore = this.selectedSubmissions.map(submission=>submission.submissionId);
       this.showRestoreDialog = false;
-      await this.restoreMultiSubmissions(submissionsIdsToRestore);
+      await this.restoreMultiSubmissions({submissionIds:submissionsIdsToRestore, formId:this.form.id});
       this.refreshSubmissions();
       this.selectedSubmissions = [];
     },

--- a/app/frontend/src/services/formService.js
+++ b/app/frontend/src/services/formService.js
@@ -234,8 +234,8 @@ export default {
    * @param {array} submissionIds The form submission identifier
    * @returns {Promise} An axios response
    */
-  deleteMultipleSubmissions(submissionId, requestBody) {
-    return appAxios().delete(`${ApiRoutes.SUBMISSION}/${submissionId}/submissions`,requestBody);
+  deleteMultipleSubmissions(submissionId, formId, requestBody) {
+    return appAxios().delete(`${ApiRoutes.SUBMISSION}/${submissionId}/${formId}/submissions`,requestBody);
   },
 
   /**
@@ -255,9 +255,10 @@ export default {
    * @param {string} submissionId The form uuid
    * @returns {Promise} An axios response
    */
-  restoreMutipleSubmissions(submissionId, requestBody) {
-    return appAxios().put(`${ApiRoutes.SUBMISSION}/${submissionId}/submissions/restore`, requestBody);
+  restoreMutipleSubmissions(submissionId, formId, requestBody) {
+    return appAxios().put(`${ApiRoutes.SUBMISSION}/${submissionId}/${formId}/submissions/restore`, requestBody);
   },
+
 
   /**
    * @function updateSubmission

--- a/app/frontend/src/store/modules/form.js
+++ b/app/frontend/src/store/modules/form.js
@@ -350,9 +350,9 @@ export default {
     },
 
 
-    async deleteMultiSubmissions ({ dispatch }, submissionIds) {
+    async deleteMultiSubmissions ({ dispatch },{formId, submissionIds}) {
       try {
-        await formService.deleteMultipleSubmissions(submissionIds[0], { data: {submissionIds:submissionIds} });
+        await formService.deleteMultipleSubmissions(submissionIds[0], formId, { data: {submissionIds:submissionIds} });
         dispatch('notifications/addNotification', {
           message: 'Submissions deleted successfully.',
           ...NotificationTypes.SUCCESS,
@@ -365,10 +365,10 @@ export default {
       }
     },
 
-    async restoreMultiSubmissions({ dispatch }, submissionIds) {
+    async restoreMultiSubmissions({ dispatch }, {formId, submissionIds}) {
       try {
         // Get this submission
-        await formService.restoreMutipleSubmissions(submissionIds[0],{ submissionIds:submissionIds});
+        await formService.restoreMutipleSubmissions(submissionIds[0], formId, { submissionIds:submissionIds});
         dispatch('notifications/addNotification', {
           message: 'Submissions restored successfully.',
           ...NotificationTypes.SUCCESS,

--- a/app/frontend/tests/unit/services/formService.spec.js
+++ b/app/frontend/tests/unit/services/formService.spec.js
@@ -422,9 +422,11 @@ describe('Form Service', () => {
     });
   });
 
-  describe('submissions/${submissionId}/submissions', () => {
+  describe('submissions/${submissionId}/${formId}/submissions', () => {
     let submissionId = 'ac4ef441-43b1-414a-a0d4-1e2f67c2a745';
-    const endpoint = `${ApiRoutes.SUBMISSION}/${submissionId}/submissions`;
+    let formId = 'd15a8c14-c78a-42fa-8afd-b3f1fed59159';
+
+    const endpoint = `${ApiRoutes.SUBMISSION}/${submissionId}/${formId}/submissions`;
 
     it('calls delete endpoint', async () => {
       mockAxios.onDelete(endpoint).reply(200);
@@ -434,16 +436,17 @@ describe('Form Service', () => {
         '0715b1ac-4069-4778-a868-b4f71fdea18d'
       ];
 
-      const result = await formService.deleteMultipleSubmissions(submissionId,{data:{submissionIds}});
+      const result = await formService.deleteMultipleSubmissions(submissionId,formId,{data:{submissionIds}});
       expect(result).toBeTruthy();
       expect(mockAxios.history.delete).toHaveLength(1);
     });
   });
 
 
-  describe('submissions/${submissionId}/submissions/restore', () => {
+  describe('submissions/${submissionId}/${formId}/submissions/restore', () => {
     let submissionId = 'ac4ef441-43b1-414a-a0d4-1e2f67c2a745';
-    const endpoint = `${ApiRoutes.SUBMISSION}/${submissionId}/submissions/restore`;
+    let formId = 'd15a8c14-c78a-42fa-8afd-b3f1fed59159';
+    const endpoint = `${ApiRoutes.SUBMISSION}/${submissionId}/${formId}/submissions/restore`;
 
     it('calls restore multiple submission endpoint', async () => {
       mockAxios.onPut(endpoint).reply(200);
@@ -452,7 +455,7 @@ describe('Form Service', () => {
         '0715b1ac-4069-4778-a868-b4f71fdea18d'
       ];
 
-      const result = await formService.restoreMutipleSubmissions(submissionId,{submissionIds});
+      const result = await formService.restoreMutipleSubmissions(submissionId,formId,{submissionIds});
       expect(result).toBeTruthy();
       expect(mockAxios.history.put).toHaveLength(1);
     });

--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -136,6 +136,52 @@ const hasSubmissionPermissions = (permissions) => {
   };
 };
 
+const canDeleteAndRestoreMultiSubmissions = (permissions) => {
+  return async (req, _res, next) => {
+    if (!Array.isArray(permissions)) {
+      permissions = [permissions];
+    }
+
+    // Get the provided form ID whether in a param or query (precedence to param)
+    const formId = req.params.formId || req.query.formId;
+    if (!formId) {
+      return next(new Problem(401, { detail: 'FormId not found on request.' }));
+    }
+
+    // Get the provided list of submissions Id whether in a req body
+    const submissionIds = req.body&&req.body.submissionIds;
+    if (!Array.isArray(submissionIds)) {
+      // No submission provided to this route that secures based on form... that's a problem!
+      return next(new Problem(401, { detail: 'SubmissionIds not found on request.' }));
+    }
+
+    // Does the user have permissions for this submission due to their FORM permissions
+    if (req.currentUser) {
+      let formFromCurrentUser = req.currentUser.forms.find(f => f.formId === formId);
+      if (formFromCurrentUser) {
+        // Do they have the submission permissions being requested on this FORM
+        const intersection = permissions.filter(p => {
+          return formFromCurrentUser.permissions.includes(p);
+        });
+
+        if (intersection.length === permissions.length) {
+
+          // Get the submission results so we know what form this submission is for
+          const meta = await service.getMultipleSubmission(submissionIds);
+
+          let formIds =  [...new Set(meta&&meta.map(SubmissionMetadata=>SubmissionMetadata.formId))];
+          if (formIds&&formIds.length=== 1) {
+            return next();
+          }
+          else {
+            return next(new Problem(401, { detail: 'Current user does not have required permission(s) for some submissions in the submissionIds list.' }));
+          }
+        }
+      }
+    }
+  };
+};
+
 const hasFormRole = (formId, user, role) => {
   let hasRole = false;
   form_loop:
@@ -274,5 +320,5 @@ const hasRolePermissions = (removingUsers = false) => {
 };
 
 module.exports = {
-  currentUser, hasFormPermissions, hasSubmissionPermissions, hasFormRoles, hasFormRole, hasRolePermissions,
+  currentUser, hasFormPermissions, hasSubmissionPermissions, hasFormRoles, hasFormRole, hasRolePermissions, canDeleteAndRestoreMultiSubmissions,
 };

--- a/app/src/forms/auth/service.js
+++ b/app/src/forms/auth/service.js
@@ -260,7 +260,14 @@ const service = {
       submission: meta,
       form: form
     };
+  },
+
+  getMultipleSubmission: async (submissionIds) => {
+    return await SubmissionMetadata.query()
+      .whereIn('submissionId', submissionIds);
   }
+
+
   // ---------------------------------------------------------------------------------------------/Submission Data
 
 };

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -2,7 +2,7 @@ const routes = require('express').Router();
 
 const controller = require('./controller');
 const P = require('../common/constants').Permissions;
-const { currentUser, hasSubmissionPermissions } = require('../auth/middleware/userAccess');
+const { currentUser, hasSubmissionPermissions, canDeleteAndRestoreMultiSubmissions } = require('../auth/middleware/userAccess');
 
 routes.use(currentUser);
 
@@ -18,7 +18,7 @@ routes.delete('/:formSubmissionId', hasSubmissionPermissions(P.SUBMISSION_DELETE
   await controller.delete(req, res, next);
 });
 
-routes.put('/:formSubmissionId/submissions/restore', hasSubmissionPermissions(P.SUBMISSION_DELETE), async (req, res, next) => {
+routes.put('/:formSubmissionId/:formId/submissions/restore', hasSubmissionPermissions(P.SUBMISSION_DELETE), canDeleteAndRestoreMultiSubmissions(P.SUBMISSION_DELETE), async (req, res, next) => {
   await controller.restoreMutipleSubmissions(req, res, next);
 });
 
@@ -59,7 +59,7 @@ routes.post('/:formSubmissionId/template/render', hasSubmissionPermissions(P.SUB
   await controller.templateUploadAndRender(req, res, next);
 });
 
-routes.delete('/:formSubmissionId/submissions', hasSubmissionPermissions(P.SUBMISSION_DELETE), async (req, res, next) => {
+routes.delete('/:formSubmissionId/:formId/submissions', hasSubmissionPermissions(P.SUBMISSION_DELETE), canDeleteAndRestoreMultiSubmissions(P.SUBMISSION_DELETE), async (req, res, next) => {
   await controller.deleteMutipleSubmissions(req, res, next);
 });
 

--- a/app/tests/unit/routes/v1/submission.spec.js
+++ b/app/tests/unit/routes/v1/submission.spec.js
@@ -15,6 +15,12 @@ userAccess.hasSubmissionPermissions = jest.fn(() => {
     next();
   });
 });
+userAccess.canDeleteAndRestoreMultiSubmissions = jest.fn(() => {
+  return jest.fn((req, res, next) => {
+    next();
+  });
+});
+
 
 //
 // we will mock the underlying data service calls...
@@ -357,13 +363,13 @@ describe(`GET ${basePath}/ID/edits`, () => {
 });
 
 
-describe(`DELETE ${basePath}/ID/submissions`, () => {
+describe(`DELETE ${basePath}/ID/formId/submissions`, () => {
 
   it('should return 200', async () => {
     // mock a success return value...
     service.deleteMutipleSubmissions = jest.fn().mockReturnValue({});
 
-    const response = await request(app).delete(`${basePath}/:formSubmissionId/submissions`);
+    const response = await request(app).delete(`${basePath}/formSubmissionId/formId/submissions`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -373,7 +379,7 @@ describe(`DELETE ${basePath}/ID/submissions`, () => {
     // mock an authentication/permission issue...
     service.deleteMutipleSubmissions = jest.fn(() => { throw new Problem(401); });
 
-    const response = await request(app).delete(`${basePath}/:formSubmissionId/submissions`);
+    const response = await request(app).delete(`${basePath}/formSubmissionId/formId/submissions`);
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -383,7 +389,7 @@ describe(`DELETE ${basePath}/ID/submissions`, () => {
     // mock an unexpected error...
     service.deleteMutipleSubmissions = jest.fn(() => { throw new Error(); });
 
-    const response = await request(app).delete(`${basePath}/:formSubmissionId/submissions`);
+    const response = await request(app).delete(`${basePath}/formSubmissionId/formId/submissions`);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -391,13 +397,13 @@ describe(`DELETE ${basePath}/ID/submissions`, () => {
 });
 
 
-describe(`PUT ${basePath}/ID/submissions/restore`, () => {
+describe(`PUT ${basePath}/ID/formId/submissions/restore`, () => {
 
   it('should return 200', async () => {
     // mock a success return value...
     service.restoreMutipleSubmissions = jest.fn().mockReturnValue({});
 
-    const response = await request(app).put(`${basePath}/:formSubmissionId/submissions/restore`);
+    const response = await request(app).put(`${basePath}/formSubmissionId/formId/submissions/restore`);
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -407,7 +413,7 @@ describe(`PUT ${basePath}/ID/submissions/restore`, () => {
     // mock an authentication/permission issue...
     service.restoreMutipleSubmissions = jest.fn(() => { throw new Problem(401); });
 
-    const response = await request(app).put(`${basePath}/:formSubmissionId/submissions/restore`);
+    const response = await request(app).put(`${basePath}/:formSubmissionId/formId/submissions/restore`);
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -417,7 +423,7 @@ describe(`PUT ${basePath}/ID/submissions/restore`, () => {
     // mock an unexpected error...
     service.restoreMutipleSubmissions = jest.fn(() => { throw new Error(); });
 
-    const response = await request(app).put(`${basePath}/:formSubmissionId/submissions/restore`);
+    const response = await request(app).put(`${basePath}/:formSubmissionId/formId/submissions/restore`);
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Users can delete submissions they don't have access to by injecting the submissionIds into the array passed to the multiple submission delete API. This PR fixes that by adding a check to the route.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
