### PR TITLE
feat: FORMS-655 improve error messages for unavailable forms

### DIFF
--- a/app/frontend/src/components/bcgov/BCGovAlertBanner.vue
+++ b/app/frontend/src/components/bcgov/BCGovAlertBanner.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="ma-5">
+    <v-alert :class="notificationType.class" :icon="notificationType.icon">
+      <div v-html="message" />
+    </v-alert>
+  </div>
+</template>
+
+<script>
+import { NotificationTypes } from '@/utils/constants';
+
+export default {
+  computed: {
+    notificationType() {
+      switch (this.type) {
+        case NotificationTypes.ERROR.type:
+          return NotificationTypes.ERROR;
+        case NotificationTypes.INFO.type:
+          return NotificationTypes.INFO;
+        case NotificationTypes.SUCCESS.type:
+          return NotificationTypes.SUCCESS;
+        case NotificationTypes.WARNING.type:
+          return NotificationTypes.WARNING;
+        default:
+          return NotificationTypes.ERROR;
+      }
+    },
+  },
+
+  name: 'BCGovAlertBanner',
+
+  props: {
+    message: {
+      default: 'Error: Something went wrong.',
+      type: String,
+    },
+    type: {
+      default: 'error',
+      type: String,
+    },
+  },
+};
+</script>

--- a/app/frontend/src/components/designer/FormDesigner.vue
+++ b/app/frontend/src/components/designer/FormDesigner.vue
@@ -118,7 +118,7 @@ import { mapFields } from 'vuex-map-fields';
 import { compare, applyPatch, deepClone } from 'fast-json-patch';
 import templateExtensions from '@/plugins/templateExtensions';
 import { formService } from '@/services';
-import { IdentityMode, NotificationTypes } from '@/utils/constants';
+import { IdentityMode } from '@/utils/constants';
 import InformationLinkPreviewDialog from '@/components/infolinks/InformationLinkPreviewDialog.vue';
 import { generateIdps } from '@/utils/transformUtils';
 import FloatButton from '@/components/designer/FloatButton.vue';
@@ -215,9 +215,6 @@ export default {
       return IdentityMode;
     },
 
-    NOTIFICATIONS_TYPES() {
-      return NotificationTypes;
-    },
     designerOptions() {
       return {
         sanitizeConfig: {

--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -44,11 +44,6 @@
               ? NOTIFICATIONS_TYPES.INFO.class
               : NOTIFICATIONS_TYPES.SUCCESS.class
           "
-          :color="
-            saving
-              ? NOTIFICATIONS_TYPES.INFO.color
-              : NOTIFICATIONS_TYPES.SUCCESS.color
-          "
           :icon="
             saving
               ? NOTIFICATIONS_TYPES.INFO.icon

--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -313,7 +313,8 @@ export default {
             !response.data.versions[0]
           ) {
             throw new Error(
-              `No published version found in response. FormID: ${this.formId}`
+              'The form owner has not published the form, and it is not ' +
+                'available for submissions.'
             );
           }
           this.form = response.data;
@@ -333,8 +334,7 @@ export default {
         if (this.authenticated) {
           this.isFormScheduleExpired = true;
           this.isLateSubmissionAllowed = false;
-          this.formScheduleExpireMessage =
-            'An error occurred fetching this form';
+          this.formScheduleExpireMessage = error.message;
           this.addNotification({
             message: 'An error occurred fetching this form',
             consoleError: `Error loading form schema ${this.versionId}: ${error}`,

--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -312,10 +312,16 @@ export default {
             !response.data.versions ||
             !response.data.versions[0]
           ) {
-            throw new Error(
-              'The form owner has not published the form, and it is not ' +
-                'available for submissions.'
-            );
+            this.$router.push({
+              name: 'Alert',
+              params: {
+                message:
+                  'The form owner has not published the form, and it is not ' +
+                  'available for submissions.',
+                type: 'info',
+              },
+            });
+            return;
           }
           this.form = response.data;
           this.version = response.data.versions[0].version;

--- a/app/frontend/src/components/forms/FormSubmission.vue
+++ b/app/frontend/src/components/forms/FormSubmission.vue
@@ -64,7 +64,6 @@
         <v-alert
           :value="!submissionReadOnly"
           :class="'d-print-none ' + NOTIFICATIONS_TYPES.INFO.class"
-          :color="NOTIFICATIONS_TYPES.INFO.color"
           :icon="NOTIFICATIONS_TYPES.INFO.icon"
           transition="scale-transition"
           >After editing, re-submit the form to save your changes.</v-alert

--- a/app/frontend/src/components/forms/manage/ShareForm.vue
+++ b/app/frontend/src/components/forms/manage/ShareForm.vue
@@ -26,7 +26,6 @@
           <v-alert
             :value="warning"
             :class="NOTIFICATIONS_TYPES.WARNING.class"
-            :color="NOTIFICATIONS_TYPES.WARNING.color"
             :icon="NOTIFICATIONS_TYPES.WARNING.icon"
             transition="scale-transition"
           >

--- a/app/frontend/src/router/index.js
+++ b/app/frontend/src/router/index.js
@@ -85,6 +85,20 @@ export default function getRouter(basePath = '/') {
         },
       },
       {
+        path: '/alert',
+        name: 'Alert',
+        component: () =>
+          import(
+            /* webpackChunkName: "alert" */
+            '@/components/bcgov/BCGovAlertBanner.vue'
+          ),
+        meta: {
+          formSubmitMode: true,
+          hasLogin: true,
+        },
+        props: createProps,
+      },
+      {
         path: '/error',
         name: 'Error',
         component: () =>

--- a/app/frontend/src/store/modules/auth.js
+++ b/app/frontend/src/store/modules/auth.js
@@ -95,6 +95,13 @@ export default {
       const router = getRouter(Vue.prototype.$config.basePath);
       router.replace({ name: 'Error', params: { msg: msg } });
     },
+    alertNavigate(_store, { type, message }) {
+      const router = getRouter(Vue.prototype.$config.basePath);
+      router.replace({
+        name: 'Alert',
+        params: { message: message, type: type },
+      });
+    },
     login({ commit, getters, rootGetters }, idpHint = undefined) {
       if (getters.keycloakReady) {
         // Use existing redirect uri if available

--- a/app/frontend/src/utils/permissionUtils.js
+++ b/app/frontend/src/utils/permissionUtils.js
@@ -59,6 +59,27 @@ export function checkSubmissionView(userForm) {
 }
 
 /**
+ * @function getErrorMessage
+ * Gets the message to display for preflight errors. Expand this to add
+ * friendlier messages for other errors.
+ * @param {Object} options - The Object containing preflight request details.
+ * @param {Error} error - The error that was produced.
+ * @returns {string|undefined} - The error message to display, or undefined to
+ *    use the default message.
+ */
+function getErrorMessage(options, error) {
+  let errorMessage = undefined;
+
+  if (options.formId && error.response && error.response.status === 404) {
+    errorMessage =
+      'The form is currently unavailable. This may be due to an incorrect ' +
+      'link, or the form may have been deleted by its owner.';
+  }
+
+  return errorMessage;
+}
+
+/**
  * @function preFlightAuth
  * Determines whether to enter a route based on user authentication state and idpHint
  * @param {Object} options Object containing either a formId or submissionId attribute
@@ -91,7 +112,8 @@ export async function preFlightAuth(options = {}, next) {
       message: 'An error occurred while loading this form.',
       consoleError: `Error while loading ${JSON.stringify(options)}: ${error}`,
     });
-    store.dispatch('auth/errorNavigate'); // Halt user with error page
+    // Halt user with error page
+    store.dispatch('auth/errorNavigate', getErrorMessage(options, error));
     return; // Short circuit this function - no point executing further logic
   }
 

--- a/app/frontend/tests/unit/components/bcgov/BCGovAlertBanner.spec.js
+++ b/app/frontend/tests/unit/components/bcgov/BCGovAlertBanner.spec.js
@@ -1,0 +1,122 @@
+import { NotificationTypes } from '@/utils/constants';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+import BCGovAlertBanner from '@/components/bcgov/BCGovAlertBanner.vue';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('BCGovAlertBanner.vue', () => {
+  let store;
+
+  beforeEach(() => {
+    store = new Vuex.Store();
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        authenticated: () => true,
+        keycloakReady: () => true,
+      },
+      actions: {
+        logout: () => jest.fn(),
+      },
+    });
+  });
+
+  it('renders without error', async () => {
+    const wrapper = shallowMount(BCGovAlertBanner, {
+      localVue,
+      store,
+    });
+    await localVue.nextTick();
+
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.class);
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.icon);
+    expect(wrapper.text()).toContain('Error');
+  });
+
+  it('renders with a custom error message', async () => {
+    const message = 'This is a custom error message for testing.';
+    const wrapper = shallowMount(BCGovAlertBanner, {
+      localVue,
+      propsData: { message: message },
+      store,
+    });
+    await localVue.nextTick();
+
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.class);
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.icon);
+    expect(wrapper.text()).toMatch(message);
+  });
+
+  it('renders with an info message', async () => {
+    const message = 'This is a custom info message for testing.';
+    const wrapper = shallowMount(BCGovAlertBanner, {
+      localVue,
+      propsData: { message: message, type: 'info' },
+      store,
+    });
+    await localVue.nextTick();
+
+    expect(wrapper.html()).toContain(NotificationTypes.INFO.class);
+    expect(wrapper.html()).toContain(NotificationTypes.INFO.icon);
+    expect(wrapper.text()).toMatch(message);
+  });
+
+  it('renders with a success message', async () => {
+    const message = 'This is a custom success message for testing.';
+    const wrapper = shallowMount(BCGovAlertBanner, {
+      localVue,
+      propsData: { message: message, type: 'success' },
+      store,
+    });
+    await localVue.nextTick();
+
+    expect(wrapper.html()).toContain(NotificationTypes.SUCCESS.class);
+    expect(wrapper.html()).toContain(NotificationTypes.SUCCESS.icon);
+    expect(wrapper.text()).toMatch(message);
+  });
+
+  it('renders with a warning message', async () => {
+    const message = 'This is a custom warning message for testing.';
+    const wrapper = shallowMount(BCGovAlertBanner, {
+      localVue,
+      propsData: { message: message, type: 'warning' },
+      store,
+    });
+    await localVue.nextTick();
+
+    expect(wrapper.html()).toContain(NotificationTypes.WARNING.class);
+    expect(wrapper.html()).toContain(NotificationTypes.WARNING.icon);
+    expect(wrapper.text()).toMatch(message);
+  });
+
+  it('renders ok with the default if type is wrong', async () => {
+    const message = 'This is a custom warning message for testing.';
+    const wrapper = shallowMount(BCGovAlertBanner, {
+      localVue,
+      propsData: { message: message, type: 'BROKEN' },
+      store,
+    });
+    await localVue.nextTick();
+
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.class);
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.icon);
+    expect(wrapper.text()).toMatch(message);
+  });
+
+  it('renders html without escaping it', async () => {
+    const message = 'This is a <a href="a">custom<a/> warning message.';
+    const wrapper = shallowMount(BCGovAlertBanner, {
+      localVue,
+      propsData: { message: message, type: 'BROKEN' },
+      store,
+    });
+    await localVue.nextTick();
+
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.class);
+    expect(wrapper.html()).toContain(NotificationTypes.ERROR.icon);
+    expect(wrapper.text()).not.toContain('href');
+  });
+});

--- a/app/frontend/tests/unit/router/index.spec.js
+++ b/app/frontend/tests/unit/router/index.spec.js
@@ -5,14 +5,17 @@ describe('Router', () => {
   const routes = router.options.routes;
 
   it('has the correct number of routes', () => {
-    expect(routes).toHaveLength(8);
+    expect(routes).toHaveLength(9);
   });
 
   it('has the expected routes', () => {
     const routeSet = new Set(routes);
     expect(routeSet).toContainEqual(expect.objectContaining({ name: 'About' }));
+    expect(routeSet).toContainEqual(expect.objectContaining({ name: 'Alert' }));
     expect(routeSet).toContainEqual(expect.objectContaining({ name: 'Error' }));
     expect(routeSet).toContainEqual(expect.objectContaining({ name: 'Login' }));
-    expect(routeSet).toContainEqual(expect.objectContaining({ name: 'NotFound' }));
+    expect(routeSet).toContainEqual(
+      expect.objectContaining({ name: 'NotFound' })
+    );
   });
 });

--- a/app/frontend/tests/unit/store/modules/notifications.actions.spec.js
+++ b/app/frontend/tests/unit/store/modules/notifications.actions.spec.js
@@ -1,8 +1,9 @@
 import store from '@/store/modules/notifications';
+import { NotificationTypes } from '@/utils/constants';
 
 describe('notifications actions', () => {
   const mockStore = {
-    commit: jest.fn()
+    commit: jest.fn(),
   };
   const mockConsoleError = jest.spyOn(console, 'error');
 
@@ -27,13 +28,44 @@ describe('notifications actions', () => {
       type: 'error',
       class: 'alert-error',
       icon: 'error',
-      ...obj
+      ...obj,
+    });
+  });
+
+  it('addNotification as warning should commit to PUSH', () => {
+    const obj = {
+      message: 'foo',
+      consoleError: 'bar',
+      ...NotificationTypes.WARNING,
+    };
+    store.actions.addNotification(mockStore, obj);
+    expect(mockConsoleError).toHaveBeenCalledTimes(1);
+    expect(mockStore.commit).toHaveBeenCalledTimes(1);
+    expect(mockStore.commit).toHaveBeenCalledWith('PUSH', {
+      type: 'warning',
+      class: 'warning-error',
+      icon: 'warning',
+      ...obj,
+    });
+  });
+
+  it('addNotification without consoleError should commit to PUSH', () => {
+    const obj = {
+      message: 'foo',
+    };
+    store.actions.addNotification(mockStore, obj);
+    expect(mockStore.commit).toHaveBeenCalledTimes(1);
+    expect(mockStore.commit).toHaveBeenCalledWith('PUSH', {
+      type: 'error',
+      class: 'alert-error',
+      icon: 'error',
+      ...obj,
     });
   });
 
   it('deleteNotification should commit to DELETE', () => {
     const obj = {
-      id: 1
+      id: 1,
     };
     store.actions.deleteNotification(mockStore, obj);
     expect(mockStore.commit).toHaveBeenCalledTimes(1);

--- a/app/frontend/tests/unit/utils/permissionUtils.spec.js
+++ b/app/frontend/tests/unit/utils/permissionUtils.spec.js
@@ -1,6 +1,10 @@
 import { formService } from '@/services';
 import store from '@/store';
-import { FormPermissions, IdentityProviders, IdentityMode } from '@/utils/constants';
+import {
+  FormPermissions,
+  IdentityProviders,
+  IdentityMode,
+} from '@/utils/constants';
 import * as permissionUtils from '@/utils/permissionUtils';
 
 describe('checkFormSubmit', () => {
@@ -17,11 +21,17 @@ describe('checkFormSubmit', () => {
   });
 
   it('should be true when idps is public', () => {
-    expect(permissionUtils.checkFormSubmit({ idps: [IdentityProviders.PUBLIC] })).toBeTruthy();
+    expect(
+      permissionUtils.checkFormSubmit({ idps: [IdentityProviders.PUBLIC] })
+    ).toBeTruthy();
   });
 
   it('should be true when permissions is submission creator', () => {
-    expect(permissionUtils.checkFormSubmit({ permissions: [FormPermissions.SUBMISSION_CREATE] })).toBeTruthy();
+    expect(
+      permissionUtils.checkFormSubmit({
+        permissions: [FormPermissions.SUBMISSION_CREATE],
+      })
+    ).toBeTruthy();
   });
 });
 
@@ -35,11 +45,31 @@ describe('checkFormManage', () => {
   });
 
   it('should be true when at least one appropriate permission exists', () => {
-    expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.FORM_UPDATE] })).toBeTruthy();
-    expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.FORM_DELETE] })).toBeTruthy();
-    expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.DESIGN_UPDATE] })).toBeTruthy();
-    expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.DESIGN_DELETE] })).toBeTruthy();
-    expect(permissionUtils.checkFormManage({ permissions: [FormPermissions.TEAM_UPDATE] })).toBeTruthy();
+    expect(
+      permissionUtils.checkFormManage({
+        permissions: [FormPermissions.FORM_UPDATE],
+      })
+    ).toBeTruthy();
+    expect(
+      permissionUtils.checkFormManage({
+        permissions: [FormPermissions.FORM_DELETE],
+      })
+    ).toBeTruthy();
+    expect(
+      permissionUtils.checkFormManage({
+        permissions: [FormPermissions.DESIGN_UPDATE],
+      })
+    ).toBeTruthy();
+    expect(
+      permissionUtils.checkFormManage({
+        permissions: [FormPermissions.DESIGN_DELETE],
+      })
+    ).toBeTruthy();
+    expect(
+      permissionUtils.checkFormManage({
+        permissions: [FormPermissions.TEAM_UPDATE],
+      })
+    ).toBeTruthy();
   });
 });
 
@@ -53,15 +83,26 @@ describe('checkSubmissionView', () => {
   });
 
   it('should be true when at least one appropriate permission exists', () => {
-    expect(permissionUtils.checkSubmissionView({ permissions: [FormPermissions.SUBMISSION_READ] })).toBeTruthy();
-    expect(permissionUtils.checkSubmissionView({ permissions: [FormPermissions.SUBMISSION_UPDATE] })).toBeTruthy();
+    expect(
+      permissionUtils.checkSubmissionView({
+        permissions: [FormPermissions.SUBMISSION_READ],
+      })
+    ).toBeTruthy();
+    expect(
+      permissionUtils.checkSubmissionView({
+        permissions: [FormPermissions.SUBMISSION_UPDATE],
+      })
+    ).toBeTruthy();
   });
 });
 
 describe('preFlightAuth', () => {
   const mockNext = jest.fn();
   const dispatchSpy = jest.spyOn(store, 'dispatch');
-  const getSubmissionOptionsSpy = jest.spyOn(formService, 'getSubmissionOptions');
+  const getSubmissionOptionsSpy = jest.spyOn(
+    formService,
+    'getSubmissionOptions'
+  );
   const readFormOptionsSpy = jest.spyOn(formService, 'readFormOptions');
 
   beforeEach(() => {
@@ -84,8 +125,11 @@ describe('preFlightAuth', () => {
     await permissionUtils.preFlightAuth({}, mockNext);
     expect(mockNext).toHaveBeenCalledTimes(0);
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification', expect.any(Object));
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate', expect.undefined);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
+    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate');
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(0);
   });
@@ -95,14 +139,14 @@ describe('preFlightAuth', () => {
       namespaced: true,
       getters: {
         authenticated: () => true,
-        identityProvider: () => IdentityMode.PUBLIC
-      }
+        identityProvider: () => IdentityMode.PUBLIC,
+      },
     });
 
     readFormOptionsSpy.mockImplementation(() => {
       const error = new Error('Not Found');
       error.response = {
-        status: 404
+        status: 404,
       };
 
       throw error;
@@ -113,11 +157,42 @@ describe('preFlightAuth', () => {
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
     expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
-    expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification',
-      expect.any(Object));
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate',
-      expect.any(String));
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/alertNavigate',
+      expect.any(Object)
+    );
+    expect(mockNext).toHaveBeenCalledTimes(0);
+  });
+
+  it('should create custom error message if form is 422', async () => {
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        authenticated: () => true,
+        identityProvider: () => IdentityMode.PUBLIC,
+      },
+    });
+
+    readFormOptionsSpy.mockImplementation(() => {
+      const error = new Error('Not Found');
+      error.response = {
+        status: 422,
+      };
+
+      throw error;
+    });
+
+    await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
+
+    expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
+    expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
+    expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/alertNavigate',
+      expect.any(Object)
+    );
     expect(mockNext).toHaveBeenCalledTimes(0);
   });
 
@@ -126,14 +201,14 @@ describe('preFlightAuth', () => {
       namespaced: true,
       getters: {
         authenticated: () => true,
-        identityProvider: () => IdentityMode.PUBLIC
-      }
+        identityProvider: () => IdentityMode.PUBLIC,
+      },
     });
 
     readFormOptionsSpy.mockImplementation(() => {
       const error = new Error('Not Found');
       error.response = {
-        status: 500
+        status: 500,
       };
 
       throw error;
@@ -145,10 +220,11 @@ describe('preFlightAuth', () => {
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
     expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification',
-      expect.any(Object));
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate',
-      expect.undefined);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
+    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate');
     expect(mockNext).toHaveBeenCalledTimes(0);
   });
 
@@ -157,14 +233,14 @@ describe('preFlightAuth', () => {
       namespaced: true,
       getters: {
         authenticated: () => true,
-        identityProvider: () => IdentityMode.PUBLIC
-      }
+        identityProvider: () => IdentityMode.PUBLIC,
+      },
     });
 
     readFormOptionsSpy.mockImplementation(() => {
       const error = new Error('Not Found');
       error.response = {
-        status: 404
+        status: 404,
       };
 
       throw error;
@@ -176,10 +252,11 @@ describe('preFlightAuth', () => {
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(1);
     expect(getSubmissionOptionsSpy).toHaveBeenCalledWith('s');
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification',
-      expect.any(Object));
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate',
-      expect.undefined);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
+    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate');
     expect(mockNext).toHaveBeenCalledTimes(0);
   });
 
@@ -188,10 +265,12 @@ describe('preFlightAuth', () => {
       namespaced: true,
       getters: {
         authenticated: () => true,
-        identityProvider: () => IdentityMode.PUBLIC
-      }
+        identityProvider: () => IdentityMode.PUBLIC,
+      },
     });
-    readFormOptionsSpy.mockResolvedValue({ data: { idpHints: [IdentityMode.PUBLIC] } });
+    readFormOptionsSpy.mockResolvedValue({
+      data: { idpHints: [IdentityMode.PUBLIC] },
+    });
 
     await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
 
@@ -207,10 +286,12 @@ describe('preFlightAuth', () => {
       namespaced: true,
       getters: {
         authenticated: () => true,
-        identityProvider: () => IdentityProviders.IDIR
-      }
+        identityProvider: () => IdentityProviders.IDIR,
+      },
     });
-    readFormOptionsSpy.mockResolvedValue({ data: { idpHints: [IdentityProviders.IDIR] } });
+    readFormOptionsSpy.mockResolvedValue({
+      data: { idpHints: [IdentityProviders.IDIR] },
+    });
 
     await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
 
@@ -226,17 +307,25 @@ describe('preFlightAuth', () => {
       namespaced: true,
       getters: {
         authenticated: () => true,
-        identityProvider: () => IdentityProviders.IDIR
-      }
+        identityProvider: () => IdentityProviders.IDIR,
+      },
     });
-    readFormOptionsSpy.mockResolvedValue({ data: { idpHints: [IdentityProviders.BCEIDBASIC] } });
+    readFormOptionsSpy.mockResolvedValue({
+      data: { idpHints: [IdentityProviders.BCEIDBASIC] },
+    });
 
     await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
 
     expect(mockNext).toHaveBeenCalledTimes(0);
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification', expect.any(Object));
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate', expect.any(String));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/errorNavigate',
+      expect.any(String)
+    );
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
     expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
@@ -246,10 +335,12 @@ describe('preFlightAuth', () => {
     store.registerModule('auth', {
       namespaced: true,
       getters: {
-        authenticated: () => false
-      }
+        authenticated: () => false,
+      },
     });
-    getSubmissionOptionsSpy.mockResolvedValue({ data: { form: { idpHints: [IdentityMode.PUBLIC] } } });
+    getSubmissionOptionsSpy.mockResolvedValue({
+      data: { form: { idpHints: [IdentityMode.PUBLIC] } },
+    });
 
     await permissionUtils.preFlightAuth({ submissionId: 's' }, mockNext);
 
@@ -264,16 +355,21 @@ describe('preFlightAuth', () => {
     store.registerModule('auth', {
       namespaced: true,
       getters: {
-        authenticated: () => false
-      }
+        authenticated: () => false,
+      },
     });
-    getSubmissionOptionsSpy.mockResolvedValue({ data: { form: { idpHints: [IdentityProviders.IDIR] } } });
+    getSubmissionOptionsSpy.mockResolvedValue({
+      data: { form: { idpHints: [IdentityProviders.IDIR] } },
+    });
 
     await permissionUtils.preFlightAuth({ submissionId: 's' }, mockNext);
 
     expect(mockNext).toHaveBeenCalledTimes(0);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/login', IdentityProviders.IDIR);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/login',
+      IdentityProviders.IDIR
+    );
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(1);
     expect(getSubmissionOptionsSpy).toHaveBeenCalledWith('s');
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(0);
@@ -283,10 +379,12 @@ describe('preFlightAuth', () => {
     store.registerModule('auth', {
       namespaced: true,
       getters: {
-        authenticated: () => false
-      }
+        authenticated: () => false,
+      },
     });
-    getSubmissionOptionsSpy.mockResolvedValue({ data: { form: { idpHints: ['idp'] } } });
+    getSubmissionOptionsSpy.mockResolvedValue({
+      data: { form: { idpHints: ['idp'] } },
+    });
 
     await permissionUtils.preFlightAuth({ submissionId: 's' }, mockNext);
 
@@ -309,14 +407,32 @@ describe('isFormPublic', () => {
   });
 
   it('should be true when idps is public', () => {
-    expect(permissionUtils.isFormPublic({ identityProviders: [{ code: IdentityMode.PUBLIC }] })).toBeTruthy();
+    expect(
+      permissionUtils.isFormPublic({
+        identityProviders: [{ code: IdentityMode.PUBLIC }],
+      })
+    ).toBeTruthy();
   });
 
   it('should be true when idps includes public', () => {
-    expect(permissionUtils.isFormPublic({ identityProviders: [{ code: IdentityMode.LOGIN }, { code: IdentityMode.PUBLIC }] })).toBeTruthy();
+    expect(
+      permissionUtils.isFormPublic({
+        identityProviders: [
+          { code: IdentityMode.LOGIN },
+          { code: IdentityMode.PUBLIC },
+        ],
+      })
+    ).toBeTruthy();
   });
 
   it('should be false when idps has something else', () => {
-    expect(permissionUtils.isFormPublic({ identityProviders: [{ code: IdentityMode.TEAM }, { code: IdentityMode.LOGIN }] })).toBeFalsy();
+    expect(
+      permissionUtils.isFormPublic({
+        identityProviders: [
+          { code: IdentityMode.TEAM },
+          { code: IdentityMode.LOGIN },
+        ],
+      })
+    ).toBeFalsy();
   });
 });

--- a/app/frontend/tests/unit/utils/permissionUtils.spec.js
+++ b/app/frontend/tests/unit/utils/permissionUtils.spec.js
@@ -85,9 +85,102 @@ describe('preFlightAuth', () => {
     expect(mockNext).toHaveBeenCalledTimes(0);
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
     expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification', expect.any(Object));
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate');
+    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate', expect.undefined);
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should create custom error message if form is 404', async () => {
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        authenticated: () => true,
+        identityProvider: () => IdentityMode.PUBLIC
+      }
+    });
+
+    readFormOptionsSpy.mockImplementation(() => {
+      const error = new Error('Not Found');
+      error.response = {
+        status: 404
+      };
+
+      throw error;
+    });
+
+    await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
+
+    expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
+    expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
+    expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification',
+      expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate',
+      expect.any(String));
+    expect(mockNext).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not create custom error message if form is 500', async () => {
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        authenticated: () => true,
+        identityProvider: () => IdentityMode.PUBLIC
+      }
+    });
+
+    readFormOptionsSpy.mockImplementation(() => {
+      const error = new Error('Not Found');
+      error.response = {
+        status: 500
+      };
+
+      throw error;
+    });
+
+    await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
+
+    expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
+    expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
+    expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification',
+      expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate',
+      expect.undefined);
+    expect(mockNext).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not create custom error message if sub is missing', async () => {
+    store.registerModule('auth', {
+      namespaced: true,
+      getters: {
+        authenticated: () => true,
+        identityProvider: () => IdentityMode.PUBLIC
+      }
+    });
+
+    readFormOptionsSpy.mockImplementation(() => {
+      const error = new Error('Not Found');
+      error.response = {
+        status: 404
+      };
+
+      throw error;
+    });
+
+    await permissionUtils.preFlightAuth({ submissionId: 's' }, mockNext);
+
+    expect(readFormOptionsSpy).toHaveBeenCalledTimes(0);
+    expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(1);
+    expect(getSubmissionOptionsSpy).toHaveBeenCalledWith('s');
+    expect(dispatchSpy).toHaveBeenCalledTimes(2);
+    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification',
+      expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate',
+      expect.undefined);
+    expect(mockNext).toHaveBeenCalledTimes(0);
   });
 
   it('should call readFormOptions and next callback if authenticated and public', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

The current error messages don't provide enough detail to tell if CHEFS as a whole is down, or if there are problems specific to a single form. Improve the error messages for the scenarios:

- the form exists but there is no published version
- the form ID is correctly formatted but doesn't exist, or the form has been deleted
- the form ID is incorrectly formatted (and can't possibly exist)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Changes made:
- Added a new Vue Component BCGovAlertBanner that implements the [Design System spec](https://developer.gov.bc.ca/Design-System/Alert-Banners).
- Expanded error messages to give better feedback to the user.
- Changed error display for known situations to not display the "An error has occurred..." notification popup.

Also:
- Removed the import of NotificationTypes in FormDesigner.vue since it wasn't used.
- Removed the use of NotificationType.color from multiple components, since this property doesn't exist.
- Added some unit tests for the notification actions.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
