### PR TITLE
feat: FORMS-657 Change timestamp display format in dashboards

### DIFF
--- a/app/frontend/src/components/forms/submission/MySubmissionsTable.vue
+++ b/app/frontend/src/components/forms/submission/MySubmissionsTable.vue
@@ -80,13 +80,13 @@
       no-data-text="You have no submissions"
     >
       <template #[`item.lastEdited`]="{ item }">
-        {{ item.lastEdited | formatDateLong(false) }}
+        {{ item.lastEdited | formatDateLong }}
       </template>
       <template #[`item.submittedDate`]="{ item }">
-        {{ item.submittedDate | formatDateLong(false) }}
+        {{ item.submittedDate | formatDateLong }}
       </template>
       <template #[`item.completedDate`]="{ item }">
-        {{ item.completedDate | formatDateLong(false) }}
+        {{ item.completedDate | formatDateLong }}
       </template>
       <template #[`item.actions`]="{ item }">
         <MySubmissionsActions
@@ -241,7 +241,8 @@ export default {
 
     // Status columns in the table
     getCurrentStatus(record) {
-      // Current status is most recent status (top in array, query returns in status created desc)
+      // Current status is most recent status (top in array, query returns in
+      // status created desc)
       const status =
         record.submissionStatus && record.submissionStatus[0]
           ? record.submissionStatus[0].code

--- a/app/frontend/src/filters/index.js
+++ b/app/frontend/src/filters/index.js
@@ -19,15 +19,13 @@ export function formatDate(value) {
 
 /**
  * @function formatDateLong
- * Converts a date to an 'MMMM D YYYY, h:mm:ss a' formatted string
+ * Converts a date to a 'YYYY-MM-DD hh:mm:ss a' formatted string
  * @param {Date} value A date object
  * @returns {String} A string representation of `value`
  */
-export function formatDateLong(value, withComma = true) {
+export function formatDateLong(value) {
   if (value) {
-    return moment(String(value)).format(
-      `MMMM D YYYY${withComma ? ',' : ''} h:mm:ss a`
-    );
+    return moment(String(value)).format('YYYY-MM-DD hh:mm:ss a');
   }
 }
 

--- a/app/frontend/tests/unit/filters/index.spec.js
+++ b/app/frontend/tests/unit/filters/index.spec.js
@@ -45,6 +45,30 @@ describe('formatDateLong', () => {
     const result = filters.formatDateLong(now);
 
     expect(result).toBeTruthy();
-    expect(result).toMatch(moment(String(now)).format('MMMM D YYYY, h:mm:ss a'));
+    expect(result).toMatch(moment(String(now)).format('YYYY-MM-DD hh:mm:ss a'));
+  });
+
+  it('returns a properly formatted date string in the am', () => {
+    const date = new Date(2023, 3, 5, 6, 7, 8); // months are origin 0
+    const result = filters.formatDateLong(date);
+
+    expect(result).toBeTruthy();
+    expect(result).toMatch('2023-04-05 06:07:08 a');
+  });
+
+  it('returns a properly formatted date string in the pm', () => {
+    const date = new Date(2023, 3, 5, 18, 7, 8); // months are origin 0
+    const result = filters.formatDateLong(date);
+
+    expect(result).toBeTruthy();
+    expect(result).toMatch('2023-04-05 06:07:08 p');
+  });
+
+  it('returns a properly formatted date with no leading zeroes', () => {
+    const date = new Date(2023, 9, 10, 10, 10, 10); // months are origin 0
+    const result = filters.formatDateLong(date);
+
+    expect(result).toBeTruthy();
+    expect(result).toMatch('2023-10-10 10:10:10 a');
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Change the timestamp format to have a shorter and consistent length in the tables. Using the format like "2023-02-13 09:02:01 a". This will not change the way that data from the forms is displayed, such as when adding those columns to the submissions table.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
