### PR TITLE
Hotfix: add optional chaining for geting latest schema

### DIFF
--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -284,7 +284,7 @@ const service = {
       .modify('filterVersion', version)
       .modify('orderVersionDescending')
       .first()
-      .then((row) => row.schema);
+      .then((row) => row?.schema);
   },
   fieldsForCSVExport: async (formId, params = {}) => {
     const form = await service._getForm(formId);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Add optional chaining for getting latest schema to ovoid 500 if row is null

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
