### PR TITLE
FORMS-715: Team Management Timeout bug

### DIFF
--- a/app/frontend/src/components/forms/manage/TeamManagement.vue
+++ b/app/frontend/src/components/forms/manage/TeamManagement.vue
@@ -176,7 +176,7 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import { mapFields } from 'vuex-map-fields';
-import { rbacService, roleService, userService } from '@/services';
+import { rbacService, roleService } from '@/services';
 import {
   IdentityMode,
   FormPermissions,
@@ -398,14 +398,10 @@ export default {
           formId: this.formId,
           roles: '*',
         });
-        this.formUsers = await Promise.all(
-          formUsersResponse.data.map(async (user) => {
-            const userId = user.userId;
-            const response = await userService.getUser(userId);
-            user.idp = response.data.idpCode;
-            return user;
-          })
-        );
+        this.formUsers = formUsersResponse?.data?.map((user) => {
+          user.idp = user.identityProviders.join(',');
+          return user;
+        });
       } catch (error) {
         this.addNotification({
           message: error.message,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Team management page in case when team has a lot of members generates time out. We use individual user info API calls to in a loop, so if users count gets big, API call stack exceed 10 seconds. Need to refactor code to make 1 call to get all users information

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
