### PR TITLE
perf: FORMS-695 increase memory for patroni pods

### DIFF
--- a/openshift/patroni.dc.yaml
+++ b/openshift/patroni.dc.yaml
@@ -368,12 +368,12 @@ parameters:
     description: Starting amount of memory the container can use.
     displayName: Memory Request
     required: true
-    value: 256Mi
+    value: 384Mi
   - name: MEMORY_LIMIT
     description: Maximum amount of memory the container can use.
     displayName: Memory Limit
     required: true
-    value: 512Mi
+    value: 768Mi
   - name: PVC_SIZE
     description: The size of the persistent volume to create.
     displayName: Persistent Volume Size


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Background: the database is crashing due to CHEFS using `user_form_access_vw` (possibly only for a subset of users, those with large numbers of forms?). The database is offline for around 250ms, and since it drops all connections the CHEFS pods have to re-establish them. 

To improve performance, increase the default memory `request` and `limit` for the Patroni database pods. This will allow more of the data to be kept in memory, making for faster queries.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->
Performance

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

<!--
## Further comments
-->

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
