### PR TITLE
chore: FORMS-726 add launchers and tasks to vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ yarn-error.log*
 
 # Editor directories and files
 .idea
-.vscode
 *.iml
 *.suo
 *.ntvs*
@@ -39,6 +38,11 @@ yarn-error.log*
 *.sln
 *.sw?
 *.mp4
+
+# Visual Studio Code -- generally ignore, but allow shared configuration
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
 
 # temp office files
 ~$*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "compounds": [
+    {
+      "configurations": ["CHEFS API", "CHEFS Frontend"],
+      "name": "CHEFS"
+    }
+  ],
+  "configurations": [
+    {
+      "cwd": "${workspaceFolder}/app",
+      "name": "CHEFS API",
+      "outputCapture": "std",
+      "request": "launch",
+      "runtimeArgs": ["run", "serve"],
+      "runtimeExecutable": "npm",
+      "type": "node"
+    },
+    {
+      "cwd": "${workspaceFolder}/app/frontend",
+      "env": {
+        "VUE_APP_TITLE": "Common Hosted Forms - Local"
+      },
+      "name": "CHEFS Frontend",
+      "outputCapture": "std",
+      "request": "launch",
+      "runtimeArgs": ["run", "serve"],
+      "runtimeExecutable": "npm",
+      "type": "node"
+    }
+  ],
+  "version": "0.2.0"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,44 @@
+{
+  "tasks": [
+    {
+      "dependsOn": ["Unit Tests - API", "Unit Tests - Frontend"],
+      "group": {
+        "isDefault": true,
+        "kind": "test"
+      },
+      "label": "All Tests",
+      "type": "shell"
+    },
+    {
+      "args": ["run", "all:reinstall"],
+      "command": "npm",
+      "label": "All - Reinstall",
+      "options": {
+        "cwd": "${workspaceFolder}/app"
+      },
+      "problemMatcher": [],
+      "type": "shell"
+    },
+    {
+      "args": ["run", "test"],
+      "command": "npm",
+      "group": "test",
+      "label": "Unit Tests - API",
+      "options": {
+        "cwd": "${workspaceFolder}/app"
+      },
+      "type": "shell"
+    },
+    {
+      "args": ["run", "test"],
+      "command": "npm",
+      "group": "test",
+      "label": "Unit Tests - Frontend",
+      "options": {
+        "cwd": "${workspaceFolder}/app/frontend"
+      },
+      "type": "shell"
+    }
+  ],
+  "version": "2.0.0"
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

As a developer who is working on the CHEFS code, I want to be able to:
- Start the API and Frontend code using VSCode rather than the command line
- Run the API in debug mode so that I can set breakpoints and variable watches
- Easily run the test suites using VSCode rather than the command line

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->
Chore (non-breaking change that has no effect on the CHEFS application)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
