### PR TITLE
feat: FORMS-725 get submission status with API key

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -1175,6 +1175,10 @@ paths:
     get:
       summary: Get the list of status history for a submission
       operationId: readSubmissionStatus
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
       tags:
         - Status
       parameters:
@@ -3083,23 +3087,23 @@ components:
       allOf:
         - type: array
           items:
-          - type: object
-            properties:
-              draft:
-                type: boolean
-                description: >-
-                  Used to indicate if submission came from a draft version of a
-                  form.
-                example: false
-              submission:
-                type: object
-                description: this object should contain one property named data as an array. This array named data should store all the multiple drafts as object in this array.
-                properties:
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/FormSubmissionObjectForMultipleUpload'
-                    description: this is an array of multiple objects, each object contain data of single the form submissions.
+            - type: object
+              properties:
+                draft:
+                  type: boolean
+                  description: >-
+                    Used to indicate if submission came from a draft version of a
+                    form.
+                  example: false
+                submission:
+                  type: object
+                  description: this object should contain one property named data as an array. This array named data should store all the multiple drafts as object in this array.
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/FormSubmissionObjectForMultipleUpload'
+                      description: this is an array of multiple objects, each object contain data of single the form submissions.
     FormSubmissionMultiple:
       allOf:
         - type: object
@@ -3202,7 +3206,7 @@ components:
             preferences:
               type: object
               description: form submissions export preferences
-              example: {minDate, maxDate}
+              example: { minDate, maxDate }
             fields:
               type: array
               description: List of form submission fields to be exported to CSV

--- a/app/src/forms/auth/middleware/apiAccess.js
+++ b/app/src/forms/auth/middleware/apiAccess.js
@@ -2,24 +2,37 @@ const Problem = require('api-problem');
 const basicAuth = require('express-basic-auth');
 const { validate: uuidValidate } = require('uuid');
 
-const service = require('../../form/service');
+const formService = require('../../form/service');
+const submissionService = require('../../submission/service');
 
 module.exports = async (req, res, next) => {
   // Check if authorization header is basic auth
   if (req.headers && req.headers.authorization && req.headers.authorization.startsWith('Basic ')) {
     // URL params should override query string params of the same attribute
     const params = { ...req.query, ...req.params };
+
+    // Basic auth is currently only used for form and submission endpoints. Use
+    // the formId if it exists, otherwise fetch the formId from the submission's
+    // form.
+    let formId;
+    if (params.formId) {
+      formId = params.formId;
+    } else if (params.formSubmissionId && uuidValidate(params.formSubmissionId)) {
+      const result = await submissionService.read(params.formSubmissionId);
+      formId = result?.form?.id;
+    }
+
     let secret = ''; // Must be initialized as a string
 
-    if (params.formId && uuidValidate(params.formId)) {
-      const result = await service.readApiKey(params.formId);
+    if (formId && uuidValidate(formId)) {
+      const result = await formService.readApiKey(formId);
       secret = result && result.secret ? result.secret : '';
     }
 
     const checkCredentials = basicAuth({
       // Must be a synchronous function
       authorizer: (username, password) => {
-        const userMatch = params.formId && basicAuth.safeCompare(username, params.formId);
+        const userMatch = formId && basicAuth.safeCompare(username, formId);
         const pwMatch = secret && basicAuth.safeCompare(password, secret);
 
         req.apiUser = userMatch & pwMatch; // Flag current request as an API entity

--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -86,6 +86,11 @@ const hasFormPermissions = (permissions) => {
 
 const hasSubmissionPermissions = (permissions) => {
   return async (req, _res, next) => {
+    // Skip permission checks if requesting as API entity
+    if (req.apiUser) {
+      return next();
+    }
+
     if (!Array.isArray(permissions)) {
       permissions = [permissions];
     }

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -1,3 +1,4 @@
+const apiAccess = require('../auth/middleware/apiAccess');
 const routes = require('express').Router();
 
 const controller = require('./controller');
@@ -38,7 +39,7 @@ routes.post('/:formSubmissionId/notes', hasSubmissionPermissions(P.SUBMISSION_UP
   await controller.addNote(req, res, next);
 });
 
-routes.get('/:formSubmissionId/status', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId/status', apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.getStatus(req, res, next);
 });
 

--- a/app/tests/unit/forms/auth/middleware/apiAccess.spec.js
+++ b/app/tests/unit/forms/auth/middleware/apiAccess.spec.js
@@ -1,9 +1,11 @@
 const apiAccess = require('../../../../../src/forms/auth/middleware/apiAccess');
 
-const service = require('../../../../../src/forms/form/service');
+const formService = require('../../../../../src/forms/form/service');
+const submissionService = require('../../../../../src/forms/submission/service');
 
 describe('apiAccess', () => {
   const formId = 'c6455376-382c-439d-a811-0381a012d696';
+  const formSubmissionId = '3ba5659c-1a3f-4e76-a0d4-ef00f5102387';
   const secret = 'dd7d1699-61ec-4037-aa33-727f8aa79c0a';
   const token = Buffer.from(`${formId}:${secret}`).toString('base64');
   const authHeader = `Basic ${token}`;
@@ -11,7 +13,7 @@ describe('apiAccess', () => {
   const baseRes = { status: () => ({ json: () => {} }) };
 
   const next = jest.fn();
-  const mockReadApiKey = jest.spyOn(service, 'readApiKey');
+  const mockReadApiKey = jest.spyOn(formService, 'readApiKey');
 
   beforeEach(() => {
     next.mockReset();
@@ -52,7 +54,7 @@ describe('apiAccess', () => {
     expect(mockReadApiKey).toHaveBeenCalledTimes(0);
   });
 
-  it('should not call readApiKey with no formId param', async () => {
+  it('should not call readApiKey with no formId or formSubmissionId param', async () => {
     const req = { headers: { authorization: authHeader } };
     const res = { ...baseRes };
     await apiAccess(req, res, next);
@@ -75,7 +77,48 @@ describe('apiAccess', () => {
     expect(mockReadApiKey).toHaveBeenCalledTimes(0);
   });
 
-  it('should flag apiUser as false with invalid credentials', async () => {
+  it('should not call readApiKey with invalid formSubmissionId param', async () => {
+    const req = {
+      headers: { authorization: authHeader },
+      params: { formSubmissionId: 'invalidForm' },
+    };
+    const res = { ...baseRes };
+    await apiAccess(req, res, next);
+
+    expect(req.apiUser).toBeFalsy();
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+  });
+
+  it('should flag apiUser as false with no API key result', async () => {
+    mockReadApiKey.mockResolvedValue();
+    const req = {
+      headers: { authorization: authHeader },
+      params: { formId: formId },
+    };
+    const res = { ...baseRes };
+    await apiAccess(req, res, next);
+
+    expect(req.apiUser).toBeFalsy();
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('should flag apiUser as false with no API key secret', async () => {
+    mockReadApiKey.mockResolvedValue({});
+    const req = {
+      headers: { authorization: authHeader },
+      params: { formId: formId },
+    };
+    const res = { ...baseRes };
+    await apiAccess(req, res, next);
+
+    expect(req.apiUser).toBeFalsy();
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('should flag apiUser as false with invalid formId credentials', async () => {
     mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
     const req = {
       headers: { authorization: authHeader },
@@ -87,6 +130,70 @@ describe('apiAccess', () => {
     expect(req.apiUser).toBeFalsy();
     expect(next).toHaveBeenCalledTimes(0);
     expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('should flag apiUser as false with invalid formSubmissionId credentials', async () => {
+    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
+    submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
+
+    const req = {
+      headers: { authorization: authHeader },
+      params: { formSubmissionId: formSubmissionId },
+    };
+    const res = { ...baseRes };
+    await apiAccess(req, res, next);
+
+    expect(req.apiUser).toBeFalsy();
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('should flag apiUser as false with no submission result', async () => {
+    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
+    submissionService.read = jest.fn().mockReturnValue();
+
+    const req = {
+      headers: { authorization: authHeader },
+      params: { formSubmissionId: formSubmissionId },
+    };
+    const res = { ...baseRes };
+    await apiAccess(req, res, next);
+
+    expect(req.apiUser).toBeFalsy();
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+  });
+
+  it('should flag apiUser as false with submission result without form', async () => {
+    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
+    submissionService.read = jest.fn().mockReturnValue({});
+
+    const req = {
+      headers: { authorization: authHeader },
+      params: { formSubmissionId: formSubmissionId },
+    };
+    const res = { ...baseRes };
+    await apiAccess(req, res, next);
+
+    expect(req.apiUser).toBeFalsy();
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+  });
+
+  it('should flag apiUser as false with submission result without form id', async () => {
+    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
+    submissionService.read = jest.fn().mockReturnValue({ form: {} });
+
+    const req = {
+      headers: { authorization: authHeader },
+      params: { formSubmissionId: formSubmissionId },
+    };
+    const res = { ...baseRes };
+    await apiAccess(req, res, next);
+
+    expect(req.apiUser).toBeFalsy();
+    expect(next).toHaveBeenCalledTimes(0);
+    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
   });
 
   it('should flag apiUser as true with valid credentials', async () => {

--- a/app/tests/unit/forms/auth/middleware/userAccess.spec.js
+++ b/app/tests/unit/forms/auth/middleware/userAccess.spec.js
@@ -81,7 +81,7 @@ describe('currentUser', () => {
     expect(service.login).toHaveBeenCalledWith(kauth.grant.access_token, { formId: 2 });
   });
 
-  it('user the query param if both if that is whats provided', async () => {
+  it('uses the query param if both if that is whats provided', async () => {
     const testReq = {
       query: {
         formId: 99,
@@ -334,9 +334,7 @@ describe('hasFormPermissions', () => {
     const mw = hasFormPermissions(['abc']);
     const nxt = jest.fn();
     const req = {
-      apiUser: {
-        formId: '123',
-      },
+      apiUser: 1,
     };
 
     mw(req, testRes, nxt);
@@ -349,6 +347,18 @@ describe('hasSubmissionPermissions', () => {
   it('returns a middleware function', () => {
     const mw = hasSubmissionPermissions(['abc']);
     expect(mw).toBeInstanceOf(Function);
+  });
+
+  it('moves on if a valid API key user has already been set', async () => {
+    const mw = hasSubmissionPermissions(['abc']);
+    const nxt = jest.fn();
+    const req = {
+      apiUser: 1,
+    };
+
+    mw(req, testRes, nxt);
+    expect(nxt).toHaveBeenCalledTimes(1);
+    expect(nxt).toHaveBeenCalledWith();
   });
 
   it('401s if the request has no formId', async () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

A developer using the API requested that they be able to retrieve a submission's status using the API key.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This wasn't as straightforward as simply allowing API access on the endpoint. The authorization code was entirely based on the `formId`, but this endpoint only includes a `submissionId` parameter. Updated the authorization to fetch the `formId` from the `submissionId` when needed. 