### PR TITLE
Change the constrain for file_storage to include exports types

### DIFF
--- a/app/src/db/migrations/20230705190020_change_file_storage_constrains.js
+++ b/app/src/db/migrations/20230705190020_change_file_storage_constrains.js
@@ -1,0 +1,19 @@
+exports.up = function (knex) {
+  return Promise.resolve()
+    .then(() => knex.schema.raw(`ALTER TABLE file_storage DROP CONSTRAINT file_storage_storage_check`))
+    .then(() =>
+      knex.schema.raw(`ALTER TABLE file_storage ADD CONSTRAINT
+          file_storage_storage_check CHECK
+            ((storage = ANY (ARRAY['uploads'::text, 'localStorage'::text, 'objectStorage'::text, 'exports'::text])))`)
+    );
+};
+
+exports.down = function (knex) {
+  return Promise.resolve()
+    .then(() => knex.schema.raw(`ALTER TABLE file_storage DROP CONSTRAINT file_storage_storage_check`))
+    .then(() =>
+      knex.schema.raw(`ALTER TABLE file_storage ADD CONSTRAINT
+          file_storage_storage_check CHECK
+            ((storage = ANY (ARRAY['uploads'::text, 'localStorage'::text, 'objectStorage'::text, 'exports'::text])))`)
+    );
+};

--- a/app/src/forms/common/constants.js
+++ b/app/src/forms/common/constants.js
@@ -56,7 +56,7 @@ module.exports = Object.freeze({
     UPLOADS: 'uploads',
     LOCAL_STORAGE: 'localStorage',
     OBJECT_STORAGE: 'objectStorage',
-    LOCAL_STORES: ['uploads', 'localStorage'],
+    LOCAL_STORES: ['uploads', 'localStorage', 'exports'],
   },
   Restricted: {
     IDP: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
`file_storage` table has a constrain for `storage` field to be `localStorage`, `uploads` or `objectStorage`. This PR is to add `exports` for big form export files

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
