### PR TITLE
feat: FORMS-830 add basic auth for get submission

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -346,7 +346,7 @@ paths:
           name: deleted
           schema:
             type: Boolean
-          description: (optional) This optional parameter should be set to true if deleted records (submissions) need to be fetched 
+          description: (optional) This optional parameter should be set to true if deleted records (submissions) need to be fetched
           example: false
         - in: query
           name: drafts
@@ -979,6 +979,10 @@ paths:
     get:
       summary: Get a form submission
       operationId: readSubmission
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
       tags:
         - Submission
       parameters:

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -7,7 +7,7 @@ const { currentUser, hasSubmissionPermissions, filterMultipleSubmissions } = req
 
 routes.use(currentUser);
 
-routes.get('/:formSubmissionId', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId', apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.read(req, res, next);
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The GET /submissions/{formSubmissionId} endpoint currently does not allow basic auth using the form API key. Open this up for JEDI users for use with their new event subscription feature (and for other users and use cases too!)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Note: we don't have a good way of testing these kinds of changes. I have tested with Postman but that doesn't help in the future to identify regression problems. We should look at maybe a suite of Postman/newman tests for this sort of thing?