### PR TITLE
Duplicate confirmation ID issue-pop pre-exist submission info

### DIFF
--- a/app/frontend/src/components/designer/FormViewerMultiUpload.vue
+++ b/app/frontend/src/components/designer/FormViewerMultiUpload.vue
@@ -282,7 +282,7 @@ export default {
       try {
         let reader = new FileReader();
         reader.onload = (e) => {
-          this.Json = JSON.parse(e.target.result);
+          this.Json = this.popFormLevelInfo(JSON.parse(e.target.result));
         };
         reader.onloadend = this.preValidateSubmission;
         reader.readAsText(this.file);

--- a/app/frontend/src/components/designer/FormViewerMultiUpload.vue
+++ b/app/frontend/src/components/designer/FormViewerMultiUpload.vue
@@ -294,6 +294,40 @@ export default {
         });
       }
     },
+    popFormLevelInfo(jsonPayload = []) {
+      /** This function is purely made to remove un-necessery information
+       * from the json payload of submissions. It will also help to remove crucial data
+       * to be removed from the payload that should not be going to DB like confirmationId,
+       * formName,version,createdAt,fullName,username,email,status,assignee,assigneeEmail and
+       * lateEntry
+       * Example: Sometime end user use the export json file as a bulk
+       * upload payload that contains formId, confirmationId and User
+       * details as well so we need to remove those details from the payload.
+       *
+       */
+      if (jsonPayload.length) {
+        jsonPayload.forEach(function (submission) {
+          delete submission.submit;
+          delete submission.lateEntry;
+
+          const propsToRemove = new Set([
+            'confirmationId',
+            'formName',
+            'version',
+            'createdAt',
+            'fullName',
+            'username',
+            'email',
+            'status',
+            'assignee',
+            'assigneeEmail',
+          ]);
+
+          propsToRemove.forEach((key) => delete submission.form[key]);
+        });
+      }
+      return jsonPayload;
+    },
     async preValidateSubmission() {
       try {
         if (!Array.isArray(this.Json)) {

--- a/app/frontend/src/components/designer/FormViewerMultiUpload.vue
+++ b/app/frontend/src/components/designer/FormViewerMultiUpload.vue
@@ -309,21 +309,21 @@ export default {
         jsonPayload.forEach(function (submission) {
           delete submission.submit;
           delete submission.lateEntry;
-
-          const propsToRemove = new Set([
-            'confirmationId',
-            'formName',
-            'version',
-            'createdAt',
-            'fullName',
-            'username',
-            'email',
-            'status',
-            'assignee',
-            'assigneeEmail',
-          ]);
-
-          propsToRemove.forEach((key) => delete submission.form[key]);
+          if (Object.prototype.hasOwnProperty.call(submission, 'form')) {
+            const propsToRemove = [
+              'confirmationId',
+              'formName',
+              'version',
+              'createdAt',
+              'fullName',
+              'username',
+              'email',
+              'status',
+              'assignee',
+              'assigneeEmail',
+            ];
+            propsToRemove.forEach((key) => delete submission.form[key]);
+          }
         });
       }
       return jsonPayload;

--- a/app/frontend/tests/unit/components/designer/MultiUpload.spec.js
+++ b/app/frontend/tests/unit/components/designer/MultiUpload.spec.js
@@ -303,4 +303,43 @@ describe('FormViewerMultiUpload.vue', () => {
       expect(notifactionActions.addNotification).not.toHaveBeenCalled();
     });
   });
+
+  describe('popFormLevelInfo', () => {
+    it('should remove all the form level properties', () => {
+      const wrapper = shallowMount(FormViewerMultiUpload, {
+        localVue,
+        propsData: props,
+        store,
+        i18n,
+      });
+      const givenArrayOfSubmission = [
+        {
+          form: {
+            confirmationId: '3A31A078',
+            formName: 'FormTest',
+            version: 4,
+            createdAt: '2023-08-31T16:50:33.571Z',
+            fullName: 'John DOe',
+            username: 'JOHNDOE',
+            email: 'john.doe@example.ca',
+            status: 'SUBMITTED',
+            assignee: null,
+            assigneeEmail: null,
+          },
+          lateEntry: false,
+          simplenumber: 4444,
+        },
+      ];
+      const expectedArrayOfSubmission = [
+        {
+          form: {},
+          simplenumber: 4444,
+        },
+      ];
+  
+      const response = wrapper.vm.popFormLevelInfo(givenArrayOfSubmission);
+
+      expect(response).toEqual(expectedArrayOfSubmission);
+    });
+  });
 });

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -796,10 +796,11 @@ const service = {
       jsonPayload.forEach(function (submission) {
         delete submission.submit;
         delete submission.lateEntry;
+        if (Object.prototype.hasOwnProperty.call(submission, 'form')) {
+          const propsToRemove = ['confirmationId', 'formName', 'version', 'createdAt', 'fullName', 'username', 'email', 'status', 'assignee', 'assigneeEmail'];
 
-        const propsToRemove = new Set(['confirmationId', 'formName', 'version', 'createdAt', 'fullName', 'username', 'email', 'status', 'assignee', 'assigneeEmail']);
-
-        propsToRemove.forEach((key) => delete submission.form[key]);
+          propsToRemove.forEach((key) => delete submission.form[key]);
+        }
       });
     }
     return jsonPayload;

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -479,7 +479,7 @@ const service = {
         let recordsToInsert = [];
         let submissionId;
         // let's create multiple submissions with same metadata
-        submissionDataArray.map((singleData) => {
+        service.popFormLevelInfo(submissionDataArray).map((singleData) => {
           submissionId = uuidv4();
           recordsToInsert.push({
             ...recordWithoutData,
@@ -780,6 +780,29 @@ const service = {
       if (trx) await trx.rollback();
       throw err;
     }
+  },
+  popFormLevelInfo: (jsonPayload = []) => {
+    /** This function is purely made to remove un-necessery information
+     * from the json payload of submissions. It will also help to remove crucial data
+     * to be removed from the payload that should not be going to DB like confirmationId,
+     * formName,version,createdAt,fullName,username,email,status,assignee,assigneeEmail and
+     * lateEntry
+     * Example: Sometime end user use the export json file as a bulk
+     * upload payload that contains formId, confirmationId and User
+     * details as well so we need to remove those details from the payload.
+     *
+     */
+    if (jsonPayload.length) {
+      jsonPayload.forEach(function (submission) {
+        delete submission.submit;
+        delete submission.lateEntry;
+
+        const propsToRemove = new Set(['confirmationId', 'formName', 'version', 'createdAt', 'fullName', 'username', 'email', 'status', 'assignee', 'assigneeEmail']);
+
+        propsToRemove.forEach((key) => delete submission.form[key]);
+      });
+    }
+    return jsonPayload;
   },
 };
 

--- a/app/tests/unit/forms/form/service.spec.js
+++ b/app/tests/unit/forms/form/service.spec.js
@@ -364,3 +364,35 @@ describe('readVersionFields', () => {
     expect(fields.length).toEqual(1);
   });
 });
+
+describe('popFormLevelInfo', () => {
+  it('should remove all the form level properties', () => {
+    const givenArrayOfSubmission = [
+      {
+        form: {
+          confirmationId: '3A31A078',
+          formName: 'FormTest',
+          version: 4,
+          createdAt: '2023-08-31T16:50:33.571Z',
+          fullName: 'John DOe',
+          username: 'JOHNDOE',
+          email: 'john.doe@example.ca',
+          status: 'SUBMITTED',
+          assignee: null,
+          assigneeEmail: null,
+        },
+        lateEntry: false,
+        simplenumber: 4444,
+      },
+    ];
+    const expectedArrayOfSubmission = [
+      {
+        form: {},
+        simplenumber: 4444,
+      },
+    ];
+
+    const response = service.popFormLevelInfo(givenArrayOfSubmission);
+    expect(response).toEqual(expectedArrayOfSubmission);
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Using bulk submission BE accepts all the existing form submission information that leads to duplication of confirmation ID issue. To fix this issue we clean up Submission payload before saving into database means if a form submission sent to BE and having some preexist submission information like 'confirmationId','formName','version','createdAt','fullName','username','email','status','assignee','assigneeEmail' as a form object in it then we need to remove it. So that a clean fresh submission get submitted.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
