### PR TITLE
Remove 401 error throw

### DIFF
--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -706,8 +706,6 @@ const service = {
         );
 
         axiosInstance.post(subscribe.endpointUrl, jsonData);
-
-        throw new Problem(401, jsonData);
       }
     } catch (err) {
       log.error(err.message, err, {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
I had been testing to ensure that throwing a 401 did not break the code but somehow forgot to remove the test
This does not break prod as the call out has happened before throwing the exception which is then immediately caught.

This does cause confusion when reading app logs



