### PR TITLE
feat: FORMS-805 reviewers can pick submission columns

### DIFF
--- a/app/frontend/src/components/designer/FormsTable.vue
+++ b/app/frontend/src/components/designer/FormsTable.vue
@@ -86,7 +86,7 @@
       </template>
       <template #[`item.actions`]="{ item }">
         <router-link
-          v-if="checkFormManage(item)"
+          v-if="checkFormManage(item.permissions)"
           :to="{ name: 'FormManage', query: { f: item.id } }"
         >
           <v-btn color="primary" text small>
@@ -98,7 +98,7 @@
         </router-link>
         <router-link
           data-cy="formSubmissionsLink"
-          v-if="checkSubmissionView(item)"
+          v-if="checkSubmissionView(item.permissions)"
           :to="{ name: 'FormSubmissions', query: { f: item.id } }"
         >
           <v-btn color="primary" text small>
@@ -131,11 +131,7 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import { IdentityProviders } from '@/utils/constants';
-import {
-  checkFormManage,
-  checkFormSubmit,
-  checkSubmissionView,
-} from '@/utils/permissionUtils';
+import { checkFormManage, checkSubmissionView } from '@/utils/permissionUtils';
 
 export default {
   name: 'FormsTable',
@@ -172,10 +168,12 @@ export default {
       ];
     },
     filteredFormList() {
-      // At this point, we're only showing forms you can manage or view submissions of here
-      // This may get reconceptualized in the future to different pages or something
+      // At this point, we're only showing forms you can manage or view
+      // submissions of here. This may get reconceptualized in the future to
+      // different pages or something
       return this.formList.filter(
-        (f) => checkFormManage(f) || checkSubmissionView(f)
+        (f) =>
+          checkFormManage(f.permissions) || checkSubmissionView(f.permissions)
       );
     },
     ID_PROVIDERS: () => IdentityProviders,
@@ -183,7 +181,6 @@ export default {
   methods: {
     ...mapActions('form', ['getFormsForCurrentUser']),
     checkFormManage: checkFormManage,
-    checkFormSubmit: checkFormSubmit,
     checkSubmissionView: checkSubmissionView,
     // show a description if is set in db
     onDescriptionClick(formId, formDescription) {

--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -11,8 +11,8 @@
       </div>
       <!-- buttons -->
       <div>
-        <span v-if="checkFormManage">
-          <v-tooltip bottom>
+        <span>
+          <v-tooltip bottom v-if="showSelectColumns">
             <template #activator="{ on, attrs }">
               <v-btn
                 @click="onShowColumnDialog"
@@ -29,7 +29,7 @@
               $t('trans.submissionsTable.selectColumns')
             }}</span>
           </v-tooltip>
-          <v-tooltip bottom>
+          <v-tooltip bottom v-if="showFormManage">
             <template #activator="{ on, attrs }">
               <router-link :to="{ name: 'FormManage', query: { f: formId } }">
                 <v-btn
@@ -48,7 +48,7 @@
               $t('trans.submissionsTable.manageForm')
             }}</span>
           </v-tooltip>
-          <v-tooltip bottom>
+          <v-tooltip bottom v-if="showSubmissionsExport">
             <template #activator="{ on, attrs }">
               <router-link
                 :to="{ name: 'SubmissionsExport', query: { f: formId } }"
@@ -329,7 +329,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
-import { FormManagePermissions } from '@/utils/constants';
+import { checkFormManage, checkSubmissionView } from '@/utils/permissionUtils';
 import moment from 'moment';
 import _ from 'lodash';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -416,8 +416,19 @@ export default {
       'totalSubmissions',
     ]),
     ...mapGetters('auth', ['user']),
-    checkFormManage() {
-      return this.permissions.some((p) => FormManagePermissions.includes(p));
+    showFormManage() {
+      return this.checkFormManage(this.permissions);
+    },
+    showSelectColumns() {
+      return (
+        this.checkFormManage(this.permissions) ||
+        this.checkSubmissionView(this.permissions)
+      );
+    },
+    showSubmissionsExport() {
+      // For now use form management to indicate that the user can export
+      // submissions. In the future it should be its own set of permissions.
+      return this.checkFormManage(this.permissions);
     },
     DEFAULT_HEADER() {
       let headers = [
@@ -627,6 +638,10 @@ export default {
       'updateFormPreferencesForCurrentUser',
     ]),
     ...mapActions('notifications', ['addNotification']),
+
+    checkFormManage: checkFormManage,
+    checkSubmissionView: checkSubmissionView,
+
     onShowColumnDialog() {
       this.SELECT_COLUMNS_HEADERS.sort(
         (a, b) =>

--- a/app/frontend/src/utils/permissionUtils.js
+++ b/app/frontend/src/utils/permissionUtils.js
@@ -29,34 +29,29 @@ export function checkFormSubmit(userForm) {
 
 /**
  * @function checkFormManage
- * Returns true or false if the user can manage the form
- * @param {Object} userForm The form object for the rbac user
+ * Returns true if the user can manage a form, false otherwise
+ * @param {Array} userForm A form's permissions array for the rbac user
  * @returns {boolean} TRUE if they can
  */
-export function checkFormManage(userForm) {
+export function checkFormManage(permissions) {
   return (
-    userForm &&
-    userForm.permissions &&
-    userForm.permissions.some((p) => FormManagePermissions.includes(p))
+    permissions && permissions.some((p) => FormManagePermissions.includes(p))
   );
 }
 
 /**
  * @function checkSubmissionView
- * Returns true or false if the user view submissions of this form
- * @param {Object} userForm The form object for the rbac user
+ * Returns true if the user can view submissions of a form, false otherwise
+ * @param {Array} permissions A form's permissions array for the rbac user
  * @returns {boolean} TRUE if they can
  */
-export function checkSubmissionView(userForm) {
+export function checkSubmissionView(permissions) {
   const perms = [
     FormPermissions.SUBMISSION_READ,
     FormPermissions.SUBMISSION_UPDATE,
   ];
-  return (
-    userForm &&
-    userForm.permissions &&
-    userForm.permissions.some((p) => perms.includes(p))
-  );
+
+  return permissions && permissions.some((p) => perms.includes(p));
 }
 
 /**

--- a/app/frontend/tests/unit/utils/permissionUtils.spec.js
+++ b/app/frontend/tests/unit/utils/permissionUtils.spec.js
@@ -1,6 +1,10 @@
 import { formService } from '@/services';
 import store from '@/store';
-import { FormPermissions, IdentityProviders, IdentityMode } from '@/utils/constants';
+import {
+  FormPermissions,
+  IdentityProviders,
+  IdentityMode,
+} from '@/utils/constants';
 import * as permissionUtils from '@/utils/permissionUtils';
 
 describe('checkFormSubmit', () => {
@@ -17,7 +21,9 @@ describe('checkFormSubmit', () => {
   });
 
   it('should be true when idps is public', () => {
-    expect(permissionUtils.checkFormSubmit({ idps: [IdentityProviders.PUBLIC] })).toBeTruthy();
+    expect(
+      permissionUtils.checkFormSubmit({ idps: [IdentityProviders.PUBLIC] })
+    ).toBeTruthy();
   });
 
   it('should be true when permissions is submission creator', () => {
@@ -30,62 +36,67 @@ describe('checkFormSubmit', () => {
 });
 
 describe('checkFormManage', () => {
-  it('should be false when userForm is undefined', () => {
+  it('should be false when permissions is undefined', () => {
     expect(permissionUtils.checkFormManage(undefined)).toBeFalsy();
   });
 
-  it('should be false when permissions is undefined', () => {
-    expect(permissionUtils.checkFormManage({})).toBeFalsy();
+  it('should be false when permissions is empty', () => {
+    expect(permissionUtils.checkFormManage([])).toBeFalsy();
+  });
+
+  it('should be false when no appropriate permission exists', () => {
+    let permissions = new Array(FormPermissions)
+      .filter((p) => p !== FormPermissions.FORM_UPDATE)
+      .filter((p) => p !== FormPermissions.FORM_DELETE)
+      .filter((p) => p !== FormPermissions.DESIGN_UPDATE)
+      .filter((p) => p !== FormPermissions.DESIGN_DELETE)
+      .filter((p) => p !== FormPermissions.TEAM_UPDATE);
+
+    expect(permissionUtils.checkFormManage(permissions)).not.toBeTruthy();
   });
 
   it('should be true when at least one appropriate permission exists', () => {
     expect(
-      permissionUtils.checkFormManage({
-        permissions: [FormPermissions.FORM_UPDATE],
-      })
+      permissionUtils.checkFormManage([FormPermissions.FORM_UPDATE])
     ).toBeTruthy();
     expect(
-      permissionUtils.checkFormManage({
-        permissions: [FormPermissions.FORM_DELETE],
-      })
+      permissionUtils.checkFormManage([FormPermissions.FORM_DELETE])
     ).toBeTruthy();
     expect(
-      permissionUtils.checkFormManage({
-        permissions: [FormPermissions.DESIGN_UPDATE],
-      })
+      permissionUtils.checkFormManage([FormPermissions.DESIGN_UPDATE])
     ).toBeTruthy();
     expect(
-      permissionUtils.checkFormManage({
-        permissions: [FormPermissions.DESIGN_DELETE],
-      })
+      permissionUtils.checkFormManage([FormPermissions.DESIGN_DELETE])
     ).toBeTruthy();
     expect(
-      permissionUtils.checkFormManage({
-        permissions: [FormPermissions.TEAM_UPDATE],
-      })
+      permissionUtils.checkFormManage([FormPermissions.TEAM_UPDATE])
     ).toBeTruthy();
   });
 });
 
 describe('checkSubmissionView', () => {
-  it('should be false when userForm is undefined', () => {
+  it('should be false when permissions is undefined', () => {
     expect(permissionUtils.checkSubmissionView(undefined)).toBeFalsy();
   });
 
-  it('should be false when permissions is undefined', () => {
-    expect(permissionUtils.checkSubmissionView({})).toBeFalsy();
+  it('should be false when permissions is empty', () => {
+    expect(permissionUtils.checkSubmissionView([])).toBeFalsy();
+  });
+
+  it('should be false when no appropriate permission exists', () => {
+    let permissions = new Array(FormPermissions)
+      .filter((p) => p !== FormPermissions.SUBMISSION_READ)
+      .filter((p) => p !== FormPermissions.SUBMISSION_UPDATE);
+
+    expect(permissionUtils.checkSubmissionView(permissions)).not.toBeTruthy();
   });
 
   it('should be true when at least one appropriate permission exists', () => {
     expect(
-      permissionUtils.checkSubmissionView({
-        permissions: [FormPermissions.SUBMISSION_READ],
-      })
+      permissionUtils.checkSubmissionView([FormPermissions.SUBMISSION_READ])
     ).toBeTruthy();
     expect(
-      permissionUtils.checkSubmissionView({
-        permissions: [FormPermissions.SUBMISSION_UPDATE],
-      })
+      permissionUtils.checkSubmissionView([FormPermissions.SUBMISSION_UPDATE])
     ).toBeTruthy();
   });
 });
@@ -93,7 +104,10 @@ describe('checkSubmissionView', () => {
 describe('preFlightAuth', () => {
   const mockNext = jest.fn();
   const dispatchSpy = jest.spyOn(store, 'dispatch');
-  const getSubmissionOptionsSpy = jest.spyOn(formService, 'getSubmissionOptions');
+  const getSubmissionOptionsSpy = jest.spyOn(
+    formService,
+    'getSubmissionOptions'
+  );
   const readFormOptionsSpy = jest.spyOn(formService, 'readFormOptions');
 
   beforeEach(() => {
@@ -116,7 +130,10 @@ describe('preFlightAuth', () => {
     await permissionUtils.preFlightAuth({}, mockNext);
     expect(mockNext).toHaveBeenCalledTimes(0);
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification', expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
     expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate');
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(0);
@@ -146,7 +163,10 @@ describe('preFlightAuth', () => {
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
     expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/alertNavigate', expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/alertNavigate',
+      expect.any(Object)
+    );
     expect(mockNext).toHaveBeenCalledTimes(0);
   });
 
@@ -174,7 +194,10 @@ describe('preFlightAuth', () => {
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
     expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/alertNavigate', expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/alertNavigate',
+      expect.any(Object)
+    );
     expect(mockNext).toHaveBeenCalledTimes(0);
   });
 
@@ -202,7 +225,10 @@ describe('preFlightAuth', () => {
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
     expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification', expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
     expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate');
     expect(mockNext).toHaveBeenCalledTimes(0);
   });
@@ -231,7 +257,10 @@ describe('preFlightAuth', () => {
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(1);
     expect(getSubmissionOptionsSpy).toHaveBeenCalledWith('s');
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification', expect.any(Object));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
     expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate');
     expect(mockNext).toHaveBeenCalledTimes(0);
   });
@@ -294,8 +323,14 @@ describe('preFlightAuth', () => {
 
     expect(mockNext).toHaveBeenCalledTimes(0);
     expect(dispatchSpy).toHaveBeenCalledTimes(2);
-    expect(dispatchSpy).toHaveBeenCalledWith('notifications/addNotification', expect.any(Object));
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/errorNavigate', expect.any(String));
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'notifications/addNotification',
+      expect.any(Object)
+    );
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/errorNavigate',
+      expect.any(String)
+    );
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(0);
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(1);
     expect(readFormOptionsSpy).toHaveBeenCalledWith('f');
@@ -336,7 +371,10 @@ describe('preFlightAuth', () => {
 
     expect(mockNext).toHaveBeenCalledTimes(0);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
-    expect(dispatchSpy).toHaveBeenCalledWith('auth/login', IdentityProviders.IDIR);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'auth/login',
+      IdentityProviders.IDIR
+    );
     expect(getSubmissionOptionsSpy).toHaveBeenCalledTimes(1);
     expect(getSubmissionOptionsSpy).toHaveBeenCalledWith('s');
     expect(readFormOptionsSpy).toHaveBeenCalledTimes(0);
@@ -384,7 +422,10 @@ describe('isFormPublic', () => {
   it('should be true when idps includes public', () => {
     expect(
       permissionUtils.isFormPublic({
-        identityProviders: [{ code: IdentityMode.LOGIN }, { code: IdentityMode.PUBLIC }],
+        identityProviders: [
+          { code: IdentityMode.LOGIN },
+          { code: IdentityMode.PUBLIC },
+        ],
       })
     ).toBeTruthy();
   });
@@ -392,7 +433,10 @@ describe('isFormPublic', () => {
   it('should be false when idps has something else', () => {
     expect(
       permissionUtils.isFormPublic({
-        identityProviders: [{ code: IdentityMode.TEAM }, { code: IdentityMode.LOGIN }],
+        identityProviders: [
+          { code: IdentityMode.TEAM },
+          { code: IdentityMode.LOGIN },
+        ],
       })
     ).toBeFalsy();
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

A user from NRM has asked if people with Reviewer status can also be able to select which columns appear in the submissions table. For example, an Owner has the following:
![image](https://github.com/bcgov/common-hosted-form-service/assets/35532993/c2cc4472-6ab2-4ea0-9560-4a0e4f853d5f)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- Changed the permissions utilities to take the permissions array rather than having to know how the permissions exist within the form. This made it easier to use the permissions utilities on the submissions table.