### PR TITLE
rename ViewAllSubmissions label in FormViewerAction.vue

### DIFF
--- a/app/frontend/src/components/designer/FormViewerActions.vue
+++ b/app/frontend/src/components/designer/FormViewerActions.vue
@@ -6,7 +6,7 @@
     <div v-if="formId">
       <v-btn outlined @click="goToAllSubmissionOrDraft">
         <span :lang="lang"
-          >{{ $t('trans.formViewerActions.viewAllSubmissions') }}
+          >{{ $t('trans.formViewerActions.viewMyDraftOrSubmissions') }}
         </span>
       </v-btn>
     </div>

--- a/app/frontend/src/internationalization/trans/chefs/ar/ar.json
+++ b/app/frontend/src/internationalization/trans/chefs/ar/ar.json
@@ -796,7 +796,7 @@
     "resetColumns": "إعادة تعيين الأعمدة"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "عرض جميع عمليات الإرسال",
+    "viewMyDraftOrSubmissions": "عرض المسودة / التقديمات الخاصة بي",
     "saveAsADraft": "احفظ كمسودة",
     "editThisDraft": "قم بتحرير هذه المسودة",
     "switchSingleSubmssn": "التبديل إلى الإرسال الفردي",

--- a/app/frontend/src/internationalization/trans/chefs/de/de.json
+++ b/app/frontend/src/internationalization/trans/chefs/de/de.json
@@ -796,7 +796,7 @@
     "resetColumns": "Spalten zurücksetzen"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Alle Einsendungen anzeigen",
+    "viewMyDraftOrSubmissions": "Meine Entwürfe/Einreichungen ansehen",
     "saveAsADraft": "Als einen Entwurf sichern",
     "editThisDraft": "Bearbeiten Sie diesen Entwurf",
     "switchSingleSubmssn": "Wechseln Sie zur Einzeleinreichung",

--- a/app/frontend/src/internationalization/trans/chefs/en/en.json
+++ b/app/frontend/src/internationalization/trans/chefs/en/en.json
@@ -796,7 +796,7 @@
     "resetColumns": "Reset Columns"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "View All Submissions",
+    "viewMyDraftOrSubmissions": "View My Drafts/Submissions",
     "saveAsADraft": "Save as a Draft",
     "editThisDraft": "Edit this Draft",
     "switchSingleSubmssn": "Switch to single submission",

--- a/app/frontend/src/internationalization/trans/chefs/es/es.json
+++ b/app/frontend/src/internationalization/trans/chefs/es/es.json
@@ -796,7 +796,7 @@
     "resetColumns": "Restablecer columnas"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Ver todas las presentaciones",
+    "viewMyDraftOrSubmissions": "Ver mis borradores/presentaciones",
     "saveAsADraft": "Guardar como borrador",
     "editThisDraft": "Editar este borrador",
     "switchSingleSubmssn": "Cambiar a envío único",

--- a/app/frontend/src/internationalization/trans/chefs/fa/fa.json
+++ b/app/frontend/src/internationalization/trans/chefs/fa/fa.json
@@ -796,7 +796,7 @@
     "resetColumns": "بازنشانی ستون ها"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "مشاهده همه موارد ارسالی",
+    "viewMyDraftOrSubmissions": "مشاهده پیش نویس/موارد ارسالی من",
     "saveAsADraft": "ذخیره به عنوان پیش نویس",
     "editThisDraft": "این پیش نویس را ویرایش کنید",
     "switchSingleSubmssn": "به ارسال تکی بروید",

--- a/app/frontend/src/internationalization/trans/chefs/fr/fr.json
+++ b/app/frontend/src/internationalization/trans/chefs/fr/fr.json
@@ -796,7 +796,7 @@
     "resetColumns": "Réinitialiser les colonnes"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Voir toutes les soumissions",
+    "viewMyDraftOrSubmissions": "Afficher mes brouillons/soumissions",
     "saveAsADraft": "Enregistrer en tant que projet",
     "editThisDraft": "Modifier ce brouillon",
     "switchSingleSubmssn": "Passer à la soumission unique",

--- a/app/frontend/src/internationalization/trans/chefs/hi/hi.json
+++ b/app/frontend/src/internationalization/trans/chefs/hi/hi.json
@@ -796,7 +796,7 @@
     "resetColumns": "कॉलम रीसेट करें"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "सभी प्रस्तुतियाँ देखें",
+    "viewMyDraftOrSubmissions": "मेरा ड्राफ्ट/प्रस्तुतियाँ देखें",
     "saveAsADraft": "एक मसौदे के रूप में सहेजो",
     "editThisDraft": "इस ड्राफ्ट को संपादित करें",
     "switchSingleSubmssn": "एकल सबमिशन पर स्विच करें",

--- a/app/frontend/src/internationalization/trans/chefs/it/it.json
+++ b/app/frontend/src/internationalization/trans/chefs/it/it.json
@@ -796,7 +796,7 @@
     "resetColumns": "Reimposta colonne"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Visualizza tutti gli invii",
+    "viewMyDraftOrSubmissions": "Visualizza le mie bozze/presentazioni",
     "saveAsADraft": "Salva come bozza",
     "editThisDraft": "Modifica questa bozza",
     "switchSingleSubmssn": "Passa all'invio singolo",

--- a/app/frontend/src/internationalization/trans/chefs/ja/ja.json
+++ b/app/frontend/src/internationalization/trans/chefs/ja/ja.json
@@ -796,7 +796,7 @@
     "resetColumns": "列をリセット"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "すべての提出物を表示",
+    "viewMyDraftOrSubmissions": "私のドラフト/提出物を表示する",
     "saveAsADraft": "下書きとして保存",
     "editThisDraft": "この下書きを編集する",
     "switchSingleSubmssn": "単一の提出に切り替える",

--- a/app/frontend/src/internationalization/trans/chefs/ko/ko.json
+++ b/app/frontend/src/internationalization/trans/chefs/ko/ko.json
@@ -796,7 +796,7 @@
     "resetColumns": "열 재설정"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "모든 제출물 보기",
+    "viewMyDraftOrSubmissions": "내 초안/제출물 보기",
     "saveAsADraft": "초안으로 저장",
     "editThisDraft": "이 초안 편집",
     "switchSingleSubmssn": "단일 제출로 전환",

--- a/app/frontend/src/internationalization/trans/chefs/pa/pa.json
+++ b/app/frontend/src/internationalization/trans/chefs/pa/pa.json
@@ -796,7 +796,7 @@
     "resetColumns": "ਕਾਲਮ ਰੀਸੈਟ ਕਰੋ"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "ਸਾਰੀਆਂ ਬੇਨਤੀਆਂ ਦੇਖੋ",
+    "viewMyDraftOrSubmissions": "ਮੇਰਾ ਡਰਾਫਟ/ਸਬਮਿਸ਼ਨ ਦੇਖੋ",
     "saveAsADraft": "ਇੱਕ ਡਰਾਫਟ ਦੇ ਰੂਪ ਵਿੱਚ ਸੁਰੱਖਿਅਤ ਕਰੋ",
     "editThisDraft": "ਇਸ ਡਰਾਫਟ ਨੂੰ ਸੰਪਾਦਿਤ ਕਰੋ",
     "switchSingleSubmssn": "ਸਿੰਗਲ ਸਬਮਿਸ਼ਨ 'ਤੇ ਸਵਿਚ ਕਰੋ",

--- a/app/frontend/src/internationalization/trans/chefs/pt/pt.json
+++ b/app/frontend/src/internationalization/trans/chefs/pt/pt.json
@@ -796,7 +796,7 @@
     "resetColumns": "Redefinir colunas"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Ver todos os envios",
+    "viewMyDraftOrSubmissions": "Ver meus rascunhos/envios",
     "saveAsADraft": "Salve como um rascunho",
     "editThisDraft": "Editar este rascunho",
     "switchSingleSubmssn": "Alternar para envio único",

--- a/app/frontend/src/internationalization/trans/chefs/ru/ru.json
+++ b/app/frontend/src/internationalization/trans/chefs/ru/ru.json
@@ -795,7 +795,7 @@
     "resetColumns": "Сбросить столбцы"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Просмотреть все материалы",
+    "viewMyDraftOrSubmissions": "Просмотреть мои черновики/представленные материалы",
     "saveAsADraft": "Сохранить как черновик",
     "editThisDraft": "Изменить этот черновик",
     "switchSingleSubmssn": "Переключиться на одиночную отправку",

--- a/app/frontend/src/internationalization/trans/chefs/tl/tl.json
+++ b/app/frontend/src/internationalization/trans/chefs/tl/tl.json
@@ -796,7 +796,7 @@
     "resetColumns": "I-reset ang Mga Column"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Tingnan ang Lahat ng Pagsusumite",
+    "viewMyDraftOrSubmissions": "Tingnan ang Aking draft/mga isinumite",
     "saveAsADraft": "I-save bilang Draft",
     "editThisDraft": "I-edit ang Draft na ito",
     "switchSingleSubmssn": "Lumipat sa iisang pagsusumite",

--- a/app/frontend/src/internationalization/trans/chefs/uk/uk.json
+++ b/app/frontend/src/internationalization/trans/chefs/uk/uk.json
@@ -796,7 +796,7 @@
     "resetColumns": "Скинути стовпці"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Переглянути всі подання",
+    "viewMyDraftOrSubmissions": "Переглянути мої чернетки/подання",
     "saveAsADraft": "Зберегти як чернетку",
     "editThisDraft": "Відредагуйте цю чернетку",
     "switchSingleSubmssn": "Перейти до одноразової подачі",

--- a/app/frontend/src/internationalization/trans/chefs/vi/vi.json
+++ b/app/frontend/src/internationalization/trans/chefs/vi/vi.json
@@ -796,7 +796,7 @@
     "resetColumns": "Đặt lại cột"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "Xem tất cả bài dự thi",
+    "viewMyDraftOrSubmissions": "Xem bản nháp/bài nộp của tôi",
     "saveAsADraft": "Lưu dưới dạng Bản nháp",
     "editThisDraft": "Chỉnh sửa Bản nháp này",
     "switchSingleSubmssn": "Chuyển sang gửi một lần",

--- a/app/frontend/src/internationalization/trans/chefs/zh/zh.json
+++ b/app/frontend/src/internationalization/trans/chefs/zh/zh.json
@@ -796,7 +796,7 @@
     "resetColumns": "重置列"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "查看所有提交内容",
+    "viewMyDraftOrSubmissions": "查看我的草稿/提交内容",
     "saveAsADraft": "另存为草稿",
     "editThisDraft": "编辑本草稿",
     "switchSingleSubmssn": "切换到单一提交",

--- a/app/frontend/src/internationalization/trans/chefs/zhTW/zh-TW.json
+++ b/app/frontend/src/internationalization/trans/chefs/zhTW/zh-TW.json
@@ -796,7 +796,7 @@
     "resetColumns": "重置列"
   },
   "formViewerActions": {
-    "viewAllSubmissions": "查看所有提交內容",
+    "viewMyDraftOrSubmissions": "查看我的草稿/投稿內容",
     "saveAsADraft": "另存為草稿",
     "editThisDraft": "編輯本草稿",
     "switchSingleSubmssn": "切換到單一提交",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
As a form submitter, I want an applicable button label for "View all Submissions" to understand what I can expect after selecting the same.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
