### PR TITLE
FORMS-881 - Not allow to save drafts if form validation fails

### DIFF
--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -37,7 +37,6 @@
           <FormViewerActions
             :block="block"
             :draftEnabled="form.enableSubmitterDraft"
-            :formIsValid="formIsValid"
             :formId="form.id"
             :isDraft="submissionRecord.draft"
             :permissions="permissions"
@@ -289,7 +288,6 @@ export default {
       formDataEntered: false,
       isLoading: true,
       showModal: false,
-      formIsValid: false,
     };
   },
   computed: {
@@ -544,10 +542,13 @@ export default {
       this.block = e;
     },
     formChange(e) {
+      // if draft check validation on render
+      if (this.submissionRecord.draft) {
+        this.$refs.chefForm.formio.checkValidity(null, true, null, false);
+      }
       if (e.changed != undefined && !e.changed.flags.fromSubmission) {
         this.formDataEntered = true;
       }
-      this.formIsValid = e.isValid;
     },
     jsonManager() {
       this.formElement = this.$refs.chefForm.formio;

--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -37,6 +37,7 @@
           <FormViewerActions
             :block="block"
             :draftEnabled="form.enableSubmitterDraft"
+            :formIsValid="formIsValid"
             :formId="form.id"
             :isDraft="submissionRecord.draft"
             :permissions="permissions"
@@ -288,6 +289,7 @@ export default {
       formDataEntered: false,
       isLoading: true,
       showModal: false,
+      formIsValid: false,
     };
   },
   computed: {
@@ -545,6 +547,7 @@ export default {
       if (e.changed != undefined && !e.changed.flags.fromSubmission) {
         this.formDataEntered = true;
       }
+      this.formIsValid = e.isValid;
     },
     jsonManager() {
       this.formElement = this.$refs.chefForm.formio;

--- a/app/frontend/src/components/designer/FormViewerActions.vue
+++ b/app/frontend/src/components/designer/FormViewerActions.vue
@@ -45,6 +45,7 @@
               @click="$emit('save-draft')"
               color="primary"
               icon
+              :disabled="!formIsValid"
               v-bind="attrs"
               v-on="on"
             >
@@ -115,6 +116,10 @@ export default {
       default: false,
     },
     draftEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    formIsValid: {
       type: Boolean,
       default: false,
     },

--- a/app/frontend/src/components/designer/FormViewerActions.vue
+++ b/app/frontend/src/components/designer/FormViewerActions.vue
@@ -45,7 +45,6 @@
               @click="$emit('save-draft')"
               color="primary"
               icon
-              :disabled="!formIsValid"
               v-bind="attrs"
               v-on="on"
             >
@@ -116,10 +115,6 @@ export default {
       default: false,
     },
     draftEnabled: {
-      type: Boolean,
-      default: false,
-    },
-    formIsValid: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
This fix is regarding reported bug https://bcdevex.atlassian.net/wiki/spaces/CCP/pages/1218969620/Invalid+data+remains+in+the+component+without+any+error+message+after+saving+and+then+reopening+a+draft

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
