### PR TITLE
fix: set default object field used for select

### DIFF
--- a/app/frontend/src/components/forms/RequestReceipt.vue
+++ b/app/frontend/src/components/forms/RequestReceipt.vue
@@ -124,9 +124,9 @@ export default {
             density="compact"
             variant="outlined"
             :items="[
-              { text: $t('trans.requestReceipt.low'), value: 'low' },
-              { text: $t('trans.requestReceipt.normal'), value: 'normal' },
-              { text: $t('trans.requestReceipt.high'), value: 'high' },
+              { title: $t('trans.requestReceipt.low'), value: 'low' },
+              { title: $t('trans.requestReceipt.normal'), value: 'normal' },
+              { title: $t('trans.requestReceipt.high'), value: 'high' },
             ]"
             :label="$t('trans.requestReceipt.emailPriority')"
             :lang="lang"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When sending an email for submission confirmation the priority was not displaying correctly:

![image](https://github.com/bcgov/common-hosted-form-service/assets/35532993/f7bea2c5-4e15-4c74-8359-474f21ca4f3d)

Looks like "text" was the default field displayed in v-select in vuetify v2, but in v3 it's "title":

![image](https://github.com/bcgov/common-hosted-form-service/assets/35532993/0a691711-6a1d-4acf-b161-797bcc64a39f)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
