### PR TITLE
feat: FORMS-882 add submissionId to exports

### DIFF
--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -200,7 +200,7 @@ const service = {
 
   _submissionsColumns: (form, params) => {
     // Custom columns not defined - return default column selection behavior
-    let columns = ['confirmationId', 'formName', 'version', 'createdAt', 'fullName', 'username', 'email'];
+    let columns = ['submissionId', 'confirmationId', 'formName', 'version', 'createdAt', 'fullName', 'username', 'email'];
     // if form has 'status updates' enabled in the form settings include these in export
     if (form.enableStatusUpdates) {
       columns = columns.concat(['status', 'assignee', 'assigneeEmail']);

--- a/app/tests/unit/forms/form/exportService.spec.js
+++ b/app/tests/unit/forms/form/exportService.spec.js
@@ -459,7 +459,7 @@ describe('_submissionsColumns', () => {
     enableCopyExistingSubmission: false,
   };
 
-  it('should return right number of columns, when no prefered columns passed as params.', async () => {
+  it('should return right columns, when no prefered columns passed as params.', async () => {
     const params = {
       type: 'submissions',
       format: 'json',
@@ -469,7 +469,8 @@ describe('_submissionsColumns', () => {
     };
 
     const submissions = exportService._submissionsColumns(form, params);
-    expect(submissions.length).toEqual(8);
+    expect(submissions.length).toEqual(9);
+    expect(submissions).toEqual(expect.arrayContaining(['submissionId', 'confirmationId', 'formName', 'version', 'createdAt', 'fullName', 'username', 'email', 'submission']));
   });
 
   it('should return right number of columns, when 1 prefered column (deleted) passed as params.', async () => {
@@ -483,7 +484,7 @@ describe('_submissionsColumns', () => {
     };
 
     const submissions = exportService._submissionsColumns(form, params);
-    expect(submissions.length).toEqual(9);
+    expect(submissions.length).toEqual(10);
   });
 
   it('should return right number of columns, when 1 prefered column (draft) passed as params.', async () => {
@@ -497,7 +498,7 @@ describe('_submissionsColumns', () => {
     };
 
     const submissions = exportService._submissionsColumns(form, params);
-    expect(submissions.length).toEqual(9);
+    expect(submissions.length).toEqual(10);
   });
 
   it('should return right number of columns, when 2 prefered column (draft & deleted) passed as params.', async () => {
@@ -511,7 +512,8 @@ describe('_submissionsColumns', () => {
     };
 
     const submissions = exportService._submissionsColumns(form, params);
-    expect(submissions.length).toEqual(10);
+
+    expect(submissions.length).toEqual(11);
   });
 
   it('should return right number of columns, when a garbage or NON-allowed column (testCol1 & testCol2) passed as params.', async () => {
@@ -525,7 +527,7 @@ describe('_submissionsColumns', () => {
     };
 
     const submissions = exportService._submissionsColumns(form, params);
-    expect(submissions.length).toEqual(8);
+    expect(submissions.length).toEqual(9);
   });
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We have a Fider request for the submission ID to be added to the JSON exports. We are already exporting the confirmation ID, which is 8 characters long and taken from the submission ID. The requested change is because the submission ID is essentially unique, but the confirmation ID is much more likely to have a collision. Users who are doing ETL with the exports would greatly prefer to have the more-unique key for the submission.

Since we’re adding the submission ID to the JSON export, it should also be added to the CSV export.

https://chefs-fider.apps.silver.devops.gov.bc.ca/posts/112/data-export-missing-formsubmissionid

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Luckily this is already in the view, so it's just a matter of adding it to the columns pulled by the model.