### PR TITLE
fix: simplification of user form access view

### DIFF
--- a/app/src/db/migrations/20231017192656_037-user-form-permissions.js
+++ b/app/src/db/migrations/20231017192656_037-user-form-permissions.js
@@ -1,0 +1,177 @@
+// Having performance problems and these views seem to be a cause of it. The
+// EXPLAIN for user_form_access_vw says that the role table in
+// user_form_permissions_vw is the bottleneck. Since it isn't needed, just get
+// rid of it rather than try to optimize it.
+//
+// Note that we have to remove and recreate the dependent user_form_access_vw.
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return Promise.resolve()
+    .then(() => knex.schema.dropViewIfExists('user_form_access_vw'))
+    .then(() => knex.schema.dropViewIfExists('user_form_permissions_vw'))
+    .then(() => knex.schema.dropViewIfExists('user_form_roles_vw'))
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.user_form_roles_vw
+      AS SELECT fru."userId",
+          fru."formId",
+          array_agg(DISTINCT fru.role) AS roles
+         FROM form_role_user fru
+        GROUP BY fru."userId", fru."formId"
+      UNION
+       SELECT u2.id AS "userId",
+          f2.id AS "formId",
+          '{}'::character varying[] AS roles
+         FROM form_vw f2,
+          "user" u2
+        WHERE NOT EXISTS (
+          SELECT 1 FROM form_role_user fru2
+          WHERE fru2."formId" = f2.id AND fru2."userId" = u2.id);`)
+    )
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.user_form_permissions_vw
+        AS SELECT fru."userId",
+            fru."formId",
+            array_agg(DISTINCT p.code) AS permissions
+           FROM form_role_user fru
+             JOIN role_permission rp ON fru.role::text = rp.role::text
+             JOIN permission p ON rp.permission::text = p.code::text
+          GROUP BY fru."userId", fru."formId"
+        UNION
+         SELECT u2.id AS "userId",
+            f2.id AS "formId",
+            '{submission_create,form_read}'::character varying[] AS permissions
+           FROM form_vw f2,
+            "user" u2
+          WHERE NOT EXISTS (
+            SELECT 1 FROM form_role_user fru2
+            WHERE fru2."formId" = f2.id AND fru2."userId" = u2.id);`)
+    )
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.user_form_access_vw
+      AS SELECT r."userId",
+          u."idpUserId",
+          u.username,
+          u."fullName",
+          u."firstName",
+          u."lastName",
+          u.email,
+          r."formId",
+          f.name AS "formName",
+          f.labels,
+          u."idpCode" AS "user_idpCode",
+          f."identityProviders",
+          f."identityProviders" AS form_login_required,
+          f.idps,
+          f.active,
+          f."formVersionId",
+          f.version,
+          r.roles,
+          p.permissions,
+          f.published,
+          f."versionUpdatedAt",
+          f.description AS "formDescription"
+         FROM "user" u
+           JOIN user_form_roles_vw r ON u.id = r."userId"
+           JOIN user_form_permissions_vw p ON r."userId" = p."userId" AND r."formId" = p."formId"
+           JOIN form_vw f ON f.id = p."formId"
+        ORDER BY (lower(u."lastName"::text)), (lower(u."firstName"::text)), (lower(f.name::text));`)
+    );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return Promise.resolve()
+    .then(() => knex.schema.dropViewIfExists('user_form_access_vw'))
+    .then(() => knex.schema.dropViewIfExists('user_form_permissions_vw'))
+    .then(() => knex.schema.dropViewIfExists('user_form_roles_vw'))
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.user_form_roles_vw
+      AS SELECT fru."userId",
+          fru."formId",
+          array_agg(DISTINCT r.code) AS roles
+         FROM form_role_user fru
+           JOIN role r ON fru.role::text = r.code::text
+        GROUP BY fru."userId", fru."formId"
+      UNION
+       SELECT u2.id AS "userId",
+          f2.id AS "formId",
+          '{}'::character varying[] AS roles
+         FROM form_vw f2,
+          "user" u2
+        WHERE NOT (EXISTS ( SELECT fru2.id,
+                  fru2.role,
+                  fru2."formId",
+                  fru2."userId",
+                  fru2."createdBy",
+                  fru2."createdAt",
+                  fru2."updatedBy",
+                  fru2."updatedAt"
+                 FROM form_role_user fru2
+                WHERE fru2."formId" = f2.id AND fru2."userId" = u2.id));`)
+    )
+    .then(() =>
+      knex.schema.raw(`
+        CREATE OR REPLACE VIEW public.user_form_permissions_vw
+        AS SELECT fru."userId",
+            fru."formId",
+            array_agg(DISTINCT p.code) AS permissions
+           FROM form_role_user fru
+             JOIN role r ON fru.role::text = r.code::text
+             JOIN role_permission rp ON r.code::text = rp.role::text
+             JOIN permission p ON rp.permission::text = p.code::text
+          GROUP BY fru."userId", fru."formId"
+        UNION
+         SELECT u2.id AS "userId",
+            f2.id AS "formId",
+            '{submission_create,form_read}'::character varying[] AS permissions
+           FROM form_vw f2,
+            "user" u2
+          WHERE NOT (EXISTS ( SELECT fru2.id,
+                    fru2.role,
+                    fru2."formId",
+                    fru2."userId",
+                    fru2."createdBy",
+                    fru2."createdAt",
+                    fru2."updatedBy",
+                    fru2."updatedAt"
+                   FROM form_role_user fru2
+                  WHERE fru2."formId" = f2.id AND fru2."userId" = u2.id));`)
+    )
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.user_form_access_vw
+      AS SELECT r."userId",
+          u."idpUserId",
+          u.username,
+          u."fullName",
+          u."firstName",
+          u."lastName",
+          u.email,
+          r."formId",
+          f.name AS "formName",
+          f.labels,
+          u."idpCode" AS "user_idpCode",
+          f."identityProviders",
+          f."identityProviders" AS form_login_required,
+          f.idps,
+          f.active,
+          f."formVersionId",
+          f.version,
+          r.roles,
+          p.permissions,
+          f.published,
+          f."versionUpdatedAt",
+          f.description AS "formDescription"
+         FROM "user" u
+           JOIN user_form_roles_vw r ON u.id = r."userId"
+           JOIN user_form_permissions_vw p ON r."userId" = p."userId" AND r."formId" = p."formId"
+           JOIN form_vw f ON f.id = p."formId"
+        ORDER BY (lower(u."lastName"::text)), (lower(u."firstName"::text)), (lower(f.name::text));`)
+    );
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Very slow performance of the database indicates that the view `user_form_access_vw` is running very slowly. This view is composed of multiple other views, two of which combine every form versus every user. The EXPLAIN plan shows that the problem appears to be with the `role` table, which for some reason is taking up a lot of time. In this example it was 1.6s of the 1.8s query time (although when the problem is happening the queries are more like 30-60s):

<img width="1107" alt="image" src="https://github.com/bcgov/common-hosted-form-service/assets/35532993/bcd14f6a-f89b-4387-b4cc-378cb3d9bd28">

1. Analysis of the view showed that in two sub-views, the `role` table is joined but the joins are not necessary.
2. The sub-views both also have EXISTS clauses where the SELECT has multiple columns - these columns are not needed, something simple like `SELECT 1 FROM...`  is good enough.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Note that `user_form_access_vw` has to be dropped and recreated because it depends on the other views. There is no change to `user_form_access_vw`.