### PR TITLE
fix: FORMS-899 revert timeout and simplify views

### DIFF
--- a/app/frontend/src/services/interceptors.js
+++ b/app/frontend/src/services/interceptors.js
@@ -7,8 +7,7 @@ import Vue from 'vue';
  * @param {integer} [timeout=10000] Number of milliseconds before timing out the request
  * @returns {object} An axios instance
  */
-export function appAxios(timeout = 60000) {
-  // 2023-10-13 urgent increase to fix outage
+export function appAxios(timeout = 10000) {
   const axiosOptions = { timeout: timeout };
   if (Vue.prototype.$config) {
     const config = Vue.prototype.$config;

--- a/app/src/db/migrations/20231019153505_038-view-simplification.js
+++ b/app/src/db/migrations/20231019153505_038-view-simplification.js
@@ -1,0 +1,157 @@
+// Having performance problems and these views seem to be a cause of it.
+// 1. Remove the sorting in the public_form_access_vw.
+// 2. Remove the sorting in the form_vw.
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return Promise.resolve()
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.public_form_access_vw
+      AS SELECT NULL::text AS "userId",
+          NULL::text AS "idpUserId",
+          'public'::text AS username,
+          'public'::text AS "fullName",
+          NULL::text AS "firstName",
+          NULL::text AS "lastName",
+          NULL::text AS email,
+          f.id AS "formId",
+          f.name AS "formName",
+          f.labels,
+          f."identityProviders",
+          f.idps,
+          f.active,
+          f."formVersionId",
+          f.version,
+          '{}'::character varying[] AS roles,
+          '{submission_create,form_read}'::character varying[] AS permissions
+         FROM form_vw f
+        WHERE 'public'::text = ANY (f.idps::text[])`)
+    )
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.form_vw
+      AS SELECT DISTINCT ON ((lower(f.name::text)), fv.version, f.id) f.id,
+          f.name,
+          f.active,
+          f.description,
+          f.labels,
+          f."createdAt",
+          f."createdBy",
+          f."updatedAt",
+          f."updatedBy",
+          fv.id AS "formVersionId",
+          fv.version,
+              CASE
+                  WHEN count(fip.code) = 0 THEN '{}'::character varying[]
+                  ELSE array_agg(DISTINCT fip.code)
+              END AS "identityProviders",
+              CASE
+                  WHEN count(ip.idp) = 0 THEN '{}'::character varying[]
+                  ELSE array_agg(DISTINCT ip.idp)
+              END AS idps,
+          fv.published,
+          fv."updatedAt" AS "versionUpdatedAt",
+          f."allowSubmitterToUploadFile"
+         FROM form f
+           LEFT JOIN LATERAL ( SELECT v.id,
+                  v."formId",
+                  v.version,
+                  v.schema,
+                  v."createdBy",
+                  v."createdAt",
+                  v."updatedBy",
+                  v."updatedAt",
+                  v.published
+                 FROM form_version v
+                WHERE v."formId" = f.id
+                ORDER BY (
+                      CASE
+                          WHEN v.published THEN 1
+                          ELSE 0
+                      END) DESC, v.version DESC
+               LIMIT 1) fv ON true
+           LEFT JOIN form_identity_provider fip ON f.id = fip."formId"
+           LEFT JOIN identity_provider ip ON fip.code::text = ip.code::text
+        GROUP BY f.id, f.name, f.active, f.description, f.labels, f."createdAt", f."createdBy", f."updatedAt", f."updatedBy", fv.id, fv.version, fv.published, fv."updatedAt"`)
+    );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return Promise.resolve()
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.form_vw
+      AS SELECT DISTINCT ON ((lower(f.name::text)), fv.version, f.id) f.id,
+          f.name,
+          f.active,
+          f.description,
+          f.labels,
+          f."createdAt",
+          f."createdBy",
+          f."updatedAt",
+          f."updatedBy",
+          fv.id AS "formVersionId",
+          fv.version,
+              CASE
+                  WHEN count(fip.code) = 0 THEN '{}'::character varying[]
+                  ELSE array_agg(DISTINCT fip.code)
+              END AS "identityProviders",
+              CASE
+                  WHEN count(ip.idp) = 0 THEN '{}'::character varying[]
+                  ELSE array_agg(DISTINCT ip.idp)
+              END AS idps,
+          fv.published,
+          fv."updatedAt" AS "versionUpdatedAt",
+          f."allowSubmitterToUploadFile"
+         FROM form f
+           LEFT JOIN LATERAL ( SELECT v.id,
+                  v."formId",
+                  v.version,
+                  v.schema,
+                  v."createdBy",
+                  v."createdAt",
+                  v."updatedBy",
+                  v."updatedAt",
+                  v.published
+                 FROM form_version v
+                WHERE v."formId" = f.id
+                ORDER BY (
+                      CASE
+                          WHEN v.published THEN 1
+                          ELSE 0
+                      END) DESC, v.version DESC
+               LIMIT 1) fv ON true
+           LEFT JOIN form_identity_provider fip ON f.id = fip."formId"
+           LEFT JOIN identity_provider ip ON fip.code::text = ip.code::text
+        GROUP BY f.id, f.name, f.active, f.description, f.labels, f."createdAt", f."createdBy", f."updatedAt", f."updatedBy", fv.id, fv.version, fv.published, fv."updatedAt"
+        ORDER BY (lower(f.name::text)), fv.version DESC, f.id;`)
+    )
+    .then(() =>
+      knex.schema.raw(`CREATE OR REPLACE VIEW public.public_form_access_vw
+      AS SELECT NULL::text AS "userId",
+          NULL::text AS "idpUserId",
+          'public'::text AS username,
+          'public'::text AS "fullName",
+          NULL::text AS "firstName",
+          NULL::text AS "lastName",
+          NULL::text AS email,
+          f.id AS "formId",
+          f.name AS "formName",
+          f.labels,
+          f."identityProviders",
+          f.idps,
+          f.active,
+          f."formVersionId",
+          f.version,
+          '{}'::character varying[] AS roles,
+          '{submission_create,form_read}'::character varying[] AS permissions
+         FROM form_vw f
+        WHERE 'public'::text = ANY (f.idps::text[])
+        ORDER BY (lower(f.name::text));`)
+    );
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

On 2023-10-13 the database started having performance problems. The frontend timeout was changed from 10s to 60s to keep CHEFS usable during the problem analysis. The problem analysis identified many places were improvements could be made.

1. Revert the frontend timeout from 60s to 10s.
2. Change the public_form_access_vw to remove the ORDER BY at the end. When this view is called by the API it is explicitly sorted, so the double sort is not needed.
3. Change the form_vw to remove the ORDER BY at the end. This view is only used by other views, so there is no need to sort it.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
