### PR TITLE
fix: FORMS-904 user insert race condition

### DIFF
--- a/app/src/forms/auth/service.js
+++ b/app/src/forms/auth/service.js
@@ -6,7 +6,7 @@ const { queryUtils } = require('../common/utils');
 const FORM_SUBMITTER = require('../common/constants').Permissions.FORM_SUBMITTER;
 
 const service = {
-  _createUser: async (data) => {
+  createUser: async (data) => {
     let trx;
     try {
       trx = await User.startTransaction();
@@ -25,7 +25,7 @@ const service = {
 
       await User.query(trx).insert(obj).onConflict('keycloakId').ignore();
       await trx.commit();
-      const result = await service._readUser(obj.keycloakId);
+      const result = await service.readUser(obj.keycloakId);
       return result;
     } catch (err) {
       if (trx) await trx.rollback();
@@ -33,11 +33,11 @@ const service = {
     }
   },
 
-  _readUser: async (keycloakId) => {
-    return User.query().modify('filterKeycloakId', keycloakId).throwIfNotFound();
+  readUser: async (keycloakId) => {
+    return User.query().modify('filterKeycloakId', keycloakId).first().throwIfNotFound();
   },
 
-  _updateUser: async (id, data) => {
+  updateUser: async (id, data) => {
     let trx;
     try {
       trx = await User.startTransaction();
@@ -55,7 +55,7 @@ const service = {
 
       await User.query(trx).patchAndFetchById(id, update);
       await trx.commit();
-      const result = await service._readUser(update.keycloakId);
+      const result = await service.readUser(update.keycloakId);
       return result;
     } catch (err) {
       if (trx) await trx.rollback();
@@ -117,10 +117,10 @@ const service = {
 
     if (!user) {
       // add to the system.
-      user = await service._createUser(obj);
+      user = await service.createUser(obj);
     } else {
       // what if name or email changed?
-      user = await service._updateUser(user.id, obj);
+      user = await service.updateUser(user.id, obj);
     }
 
     // return with the db id...


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Users are reporting that they are occasionally receiving errors with the app. I think it would be best to fix existing errors in the application so that we can rule them out as being the cause of the problem.

When a user (IDIR or BCeID) logs in for the first time, the app is trying to create the “User” object twice. The second create will fail with a database exception, and this seems to have a cascading effect on the connection pool that causes other requests to fail (?).

```
ERROR: duplicate key value violates unique constraint "user_keycloakid_unique"
DETAIL: Key ("keycloakId")=(aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa) already exists.
UniqueViolationError: insert into "user" ("createdAt", "email", "firstName", "fullName", "id", "idpCode", "idpUserId", "keycloakId", "username") values ($1, $2, $3, $4, $5, $6, $7, $8, $9) returning "id" - duplicate key value violates unique constraint "user_keycloakid_unique"
    at wrapError (/opt/app-root/src/app/node_modules/db-errors/lib/dbErrors.js:19:14)
    at handleExecuteError (/opt/app-root/src/app/node_modules/objection/lib/queryBuilder/QueryBuilder.js:1123:32)
    at QueryBuilder.execute (/opt/app-root/src/app/node_modules/objection/lib/queryBuilder/QueryBuilder.js:449:20)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.createUser (/opt/app-root/src/app/src/forms/auth/service.js:26:7)
    at async Object.getUserId (/opt/app-root/src/app/src/forms/auth/service.js:121:14)
    at async Object.login (/opt/app-root/src/app/src/forms/auth/service.js:207:18)
    at async setUser (/opt/app-root/src/app/src/forms/auth/middleware/userAccess.js:25:23)
```

When this happens the timestamp on the error log is very soon after the “createdAt” timestamp that’s in the table.

Reproduce: create a BCeID form and a BCeID user. Make sure the user is not in the DB, if it is then delete it. Using a new incognito window go to the form link and log in. The network failures are for: rbac/current and forms/*guid*/options.

Looks like a race condition in app/src/forms/auth/service.js between getting the user and creating it: 

```
    // if this user does not exists, add...
    let user = await User.query().first().where('idpUserId', obj.idpUserId);

    if (!user) {
      // add to the system.
      user = await service.createUser(obj);
    }
```

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- They key to the fix was to ignore the exceptions based on the keycloakId constraint, and to fetch using the keycloakId and not the user table's id. This way if you have two inserts at the same time (which would have different ids), then the second one will fail to insert but still retrieve the correct user.
- I was working on tests but was bumping into limitations with the database mocking (or my knowledge of it!). Need to get this in ASAP though as we're having DB load problems again.