### PR TITLE
fix: FORMS-907 rate limiting for api key calls

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -8,6 +8,7 @@ const querystring = require('querystring');
 const keycloak = require('./src/components/keycloak');
 const log = require('./src/components/log')(module.filename);
 const httpLogger = require('./src/components/log').httpLogger;
+const rateLimiter = require('./src/forms/common/middleware');
 const v1Router = require('./src/routes/v1');
 
 const DataConnection = require('./src/db/dataConnection');
@@ -22,6 +23,7 @@ const state = {
 };
 let probeId;
 const app = express();
+app.use(rateLimiter.apiKeyRateLimiter);
 app.use(compression());
 app.use(express.json({ limit: config.get('server.bodyLimit') }));
 app.use(express.urlencoded({ extended: true }));

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -48,8 +48,8 @@
     "port": "8080",
     "rateLimit": {
       "public": {
-        "windowMs": "900000",
-        "max": "100"
+        "windowMs": "60000",
+        "max": "20"
       }
     }
   },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -23,7 +23,7 @@
         "crypto": "^1.0.1",
         "express": "^4.18.2",
         "express-basic-auth": "^1.2.1",
-        "express-rate-limit": "^5.5.1",
+        "express-rate-limit": "^7.1.3",
         "express-winston": "^4.2.0",
         "falsey": "^1.0.0",
         "fast-json-patch": "^3.1.1",
@@ -6715,9 +6715,15 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.5.1.tgz",
-      "integrity": "sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.3.tgz",
+      "integrity": "sha512-BDes6WeNYSGRRGQU8QDNwUnwqaBro28HN/TTweM3RlxXRHDld8RLoH7tbfCxAc0hamQyn6aL0KrfR45+ZxknYg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
+      }
     },
     "node_modules/express-winston": {
       "version": "4.2.0",
@@ -17256,9 +17262,10 @@
       }
     },
     "express-rate-limit": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.5.1.tgz",
-      "integrity": "sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.3.tgz",
+      "integrity": "sha512-BDes6WeNYSGRRGQU8QDNwUnwqaBro28HN/TTweM3RlxXRHDld8RLoH7tbfCxAc0hamQyn6aL0KrfR45+ZxknYg==",
+      "requires": {}
     },
     "express-winston": {
       "version": "4.2.0",

--- a/app/package.json
+++ b/app/package.json
@@ -61,7 +61,7 @@
     "crypto": "^1.0.1",
     "express": "^4.18.2",
     "express-basic-auth": "^1.2.1",
-    "express-rate-limit": "^5.5.1",
+    "express-rate-limit": "^7.1.3",
     "express-winston": "^4.2.0",
     "falsey": "^1.0.0",
     "fast-json-patch": "^3.1.1",

--- a/app/src/forms/common/middleware/rateLimiter.js
+++ b/app/src/forms/common/middleware/rateLimiter.js
@@ -1,9 +1,13 @@
 const config = require('config');
 const rateLimit = require('express-rate-limit');
 
-const publicRateLimiter = rateLimit({
+const apiKeyRateLimiter = rateLimit({
+  limit: config.get('server.rateLimit.public.max'),
+
+  // Skip Bearer token auth so that CHEFS app users are not limited.
+  skip: (req) => req.headers && req.headers.authorization && req.headers.authorization.startsWith('Bearer '),
+
   windowMs: config.get('server.rateLimit.public.windowMs'),
-  max: config.get('server.rateLimit.public.max'),
 });
 
-module.exports.publicRateLimiter = publicRateLimiter;
+module.exports.apiKeyRateLimiter = apiKeyRateLimiter;

--- a/app/src/forms/file/routes.js
+++ b/app/src/forms/file/routes.js
@@ -3,13 +3,12 @@ const controller = require('./controller');
 
 const P = require('../common/constants').Permissions;
 const { currentFileRecord, hasFileCreate, hasFilePermissions } = require('./middleware/filePermissions');
-const middleware = require('../common/middleware');
 const fileUpload = require('./middleware/upload').fileUpload;
 const { currentUser } = require('../auth/middleware/userAccess');
 
 routes.use(currentUser);
 
-routes.post('/', middleware.publicRateLimiter, hasFileCreate, fileUpload.upload, async (req, res, next) => {
+routes.post('/', hasFileCreate, fileUpload.upload, async (req, res, next) => {
   await controller.create(req, res, next);
 });
 

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -1,6 +1,5 @@
 const config = require('config');
 const routes = require('express').Router();
-const middleware = require('../common/middleware');
 const apiAccess = require('../auth/middleware/apiAccess');
 const { currentUser, hasFormPermissions } = require('../auth/middleware/userAccess');
 const P = require('../common/constants').Permissions;
@@ -26,7 +25,7 @@ routes.get('/:formId/export', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBM
   await controller.export(req, res, next);
 });
 
-routes.post('/:formId/export/fields', middleware.publicRateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+routes.post('/:formId/export/fields', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.exportWithFields(req, res, next);
 });
 
@@ -54,7 +53,7 @@ routes.delete('/:formId', apiAccess, hasFormPermissions([P.FORM_READ, P.FORM_DEL
   await controller.deleteForm(req, res, next);
 });
 
-routes.get('/:formId/submissions', middleware.publicRateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+routes.get('/:formId/submissions', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.listFormSubmissions(req, res, next);
 });
 
@@ -84,15 +83,9 @@ routes.post('/:formId/versions/:formVersionId/submissions', apiAccess, hasFormPe
   await controller.createSubmission(req, res, next);
 });
 
-routes.post(
-  '/:formId/versions/:formVersionId/multiSubmission',
-  middleware.publicRateLimiter,
-  apiAccess,
-  hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]),
-  async (req, res, next) => {
-    await controller.createMultiSubmission(req, res, next);
-  }
-);
+routes.post('/:formId/versions/:formVersionId/multiSubmission', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]), async (req, res, next) => {
+  await controller.createMultiSubmission(req, res, next);
+});
 
 routes.get('/:formId/versions/:formVersionId/submissions/discover', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), (req, res, next) => {
   controller.listSubmissionFields(req, res, next);
@@ -150,7 +143,7 @@ routes.get('/formcomponents/proactivehelp/list', async (req, res, next) => {
   await controller.listFormComponentsProactiveHelp(req, res, next);
 });
 
-routes.get('/:formId/csvexport/fields', middleware.publicRateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
+routes.get('/:formId/csvexport/fields', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.readFieldsForCSVExport(req, res, next);
 });
 

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -54,7 +54,7 @@ routes.delete('/:formId', apiAccess, hasFormPermissions([P.FORM_READ, P.FORM_DEL
   await controller.deleteForm(req, res, next);
 });
 
-routes.get('/:formId/submissions', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+routes.get('/:formId/submissions', middleware.publicRateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.listFormSubmissions(req, res, next);
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We had a runaway process that was using an API Key to call an endpoint over a hundred times a minute. This was enough to take down the application due to how intensively the API calls hit the database (which is a different problem to solve). We should have rate limiting in place. Requirements:
- Rate limit all API endpoints using a global rate limiter
- The rate limiter should only be for API Key (basic auth) calls

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
1. The window was previously 15 minutes, but this would mean a higher allowed rate and a runaway process could run for much longer before it hit the limit. Reduced the window to one minute
2. With discussion with JEDI the limit is 20 calls / minute, but we may need to increase to help them scale (or implement an allow-list of trusted IPs or API Keys? Either one adds admin overhead for us and fragility when those change)
3. Removed the existing endpoint-specific rate limiting and made it global
4. Limiting is only for API Keys (Basic authentication) so CHEFS web app users will not be affected
5. Bumped the version of `express-rate-limit` which renames the `max` parameter to `limit`. I did not change the `server.rateLimit.public.max` key in default.json so that all devs don't have to update their config files
6. I tried to get test coverage for the `skip` code but couldn't figure it out
