### PR TITLE
fix: FORMS-912 increase rate limit and restore logging

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -8,7 +8,6 @@ const querystring = require('querystring');
 const keycloak = require('./src/components/keycloak');
 const log = require('./src/components/log')(module.filename);
 const httpLogger = require('./src/components/log').httpLogger;
-const rateLimiter = require('./src/forms/common/middleware');
 const v1Router = require('./src/routes/v1');
 
 const DataConnection = require('./src/db/dataConnection');
@@ -23,7 +22,6 @@ const state = {
 };
 let probeId;
 const app = express();
-app.use(config.get('server.basePath') + config.get('server.apiPath'), rateLimiter.apiKeyRateLimiter);
 app.use(compression());
 app.use(express.json({ limit: config.get('server.bodyLimit') }));
 app.use(express.urlencoded({ extended: true }));

--- a/app/config/default.json
+++ b/app/config/default.json
@@ -49,7 +49,7 @@
     "rateLimit": {
       "public": {
         "windowMs": "60000",
-        "max": "20"
+        "max": "60"
       }
     }
   },

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -3,6 +3,7 @@ const routes = require('express').Router();
 const apiAccess = require('../auth/middleware/apiAccess');
 const { currentUser, hasFormPermissions } = require('../auth/middleware/userAccess');
 const P = require('../common/constants').Permissions;
+const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
 const keycloak = require('../../components/keycloak');
 const controller = require('./controller');
@@ -17,15 +18,15 @@ routes.post('/', async (req, res, next) => {
   await controller.createForm(req, res, next);
 });
 
-routes.get('/:formId', apiAccess, hasFormPermissions(P.FORM_READ), async (req, res, next) => {
+routes.get('/:formId', rateLimiter, apiAccess, hasFormPermissions(P.FORM_READ), async (req, res, next) => {
   await controller.readForm(req, res, next);
 });
 
-routes.get('/:formId/export', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+routes.get('/:formId/export', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.export(req, res, next);
 });
 
-routes.post('/:formId/export/fields', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+routes.post('/:formId/export/fields', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.exportWithFields(req, res, next);
 });
 
@@ -41,89 +42,75 @@ routes.get('/:formId/options', async (req, res, next) => {
   await controller.readFormOptions(req, res, next);
 });
 
-routes.get('/:formId/version', apiAccess, hasFormPermissions(P.FORM_READ), async (req, res, next) => {
+routes.get('/:formId/version', rateLimiter, apiAccess, hasFormPermissions(P.FORM_READ), async (req, res, next) => {
   await controller.readPublishedForm(req, res, next);
 });
 
-routes.put('/:formId', apiAccess, hasFormPermissions([P.FORM_READ, P.FORM_UPDATE]), async (req, res, next) => {
+routes.put('/:formId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.FORM_UPDATE]), async (req, res, next) => {
   await controller.updateForm(req, res, next);
 });
 
-routes.delete('/:formId', apiAccess, hasFormPermissions([P.FORM_READ, P.FORM_DELETE]), async (req, res, next) => {
+routes.delete('/:formId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.FORM_DELETE]), async (req, res, next) => {
   await controller.deleteForm(req, res, next);
 });
 
-routes.get('/:formId/submissions', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+routes.get('/:formId/submissions', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.listFormSubmissions(req, res, next);
 });
 
-// routes.post('/:formId/versions', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
-//   next(new Problem(410, { detail: 'This method is deprecated, use /forms/id/drafts to create form versions.' }));
-// });
-
-routes.get('/:formId/versions/:formVersionId', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.readVersion(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId/fields', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId/fields', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.readVersionFields(req, res, next);
 });
-// routes.put('/:formId/versions/:formVersionId', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
-//   next(new Problem(410, { detail: 'This method is deprecated, use /forms/id/drafts to modify form versions.' }));
-// });
-routes.post('/:formId/versions/:formVersionId/publish', apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
+
+routes.post('/:formId/versions/:formVersionId/publish', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
   await controller.publishVersion(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId/submissions', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId/submissions', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.listSubmissions(req, res, next);
 });
 
-routes.post('/:formId/versions/:formVersionId/submissions', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]), async (req, res, next) => {
+routes.post('/:formId/versions/:formVersionId/submissions', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]), async (req, res, next) => {
   await controller.createSubmission(req, res, next);
 });
 
-routes.post('/:formId/versions/:formVersionId/multiSubmission', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]), async (req, res, next) => {
+routes.post('/:formId/versions/:formVersionId/multiSubmission', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]), async (req, res, next) => {
   await controller.createMultiSubmission(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId/submissions/discover', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId/submissions/discover', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), (req, res, next) => {
   controller.listSubmissionFields(req, res, next);
 });
 
-// routes.get('/:formId/versions/:formVersionId/submissions/:formSubmissionId', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
-//   next(new Problem(410, { detail: 'This method is deprecated, use /submissions to read a submission.' }));
-// });
-
-// routes.put('/:formId/versions/:formVersionId/submissions/:formSubmissionId', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
-//   next(new Problem(410, { detail: 'This method is deprecated, use /submissions to modify a submission.' }));
-// });
-
-routes.get('/:formId/drafts', apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_READ]), async (req, res, next) => {
+routes.get('/:formId/drafts', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_READ]), async (req, res, next) => {
   await controller.listDrafts(req, res, next);
 });
 
-routes.post('/:formId/drafts', apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
+routes.post('/:formId/drafts', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
   await controller.createDraft(req, res, next);
 });
 
-routes.get('/:formId/drafts/:formVersionDraftId', apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_READ]), async (req, res, next) => {
+routes.get('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_READ]), async (req, res, next) => {
   await controller.readDraft(req, res, next);
 });
 
-routes.put('/:formId/drafts/:formVersionDraftId', apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_UPDATE]), async (req, res, next) => {
+routes.put('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_UPDATE]), async (req, res, next) => {
   await controller.updateDraft(req, res, next);
 });
 
-routes.delete('/:formId/drafts/:formVersionDraftId', apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_DELETE]), async (req, res, next) => {
+routes.delete('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_DELETE]), async (req, res, next) => {
   await controller.deleteDraft(req, res, next);
 });
 
-routes.post('/:formId/drafts/:formVersionDraftId/publish', apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
+routes.post('/:formId/drafts/:formVersionDraftId/publish', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
   await controller.publishDraft(req, res, next);
 });
 
-routes.get('/:formId/statusCodes', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
+routes.get('/:formId/statusCodes', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.getStatusCodes(req, res, next);
 });
 
@@ -143,7 +130,7 @@ routes.get('/formcomponents/proactivehelp/list', async (req, res, next) => {
   await controller.listFormComponentsProactiveHelp(req, res, next);
 });
 
-routes.get('/:formId/csvexport/fields', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
+routes.get('/:formId/csvexport/fields', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.readFieldsForCSVExport(req, res, next);
 });
 

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -4,10 +4,11 @@ const routes = require('express').Router();
 const controller = require('./controller');
 const P = require('../common/constants').Permissions;
 const { currentUser, hasSubmissionPermissions, filterMultipleSubmissions } = require('../auth/middleware/userAccess');
+const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
 routes.use(currentUser);
 
-routes.get('/:formSubmissionId', apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.read(req, res, next);
 });
 
@@ -39,7 +40,7 @@ routes.post('/:formSubmissionId/notes', hasSubmissionPermissions(P.SUBMISSION_UP
   await controller.addNote(req, res, next);
 });
 
-routes.get('/:formSubmissionId/status', apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId/status', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.getStatus(req, res, next);
 });
 

--- a/app/tests/unit/routes/v1/form.spec.js
+++ b/app/tests/unit/routes/v1/form.spec.js
@@ -125,7 +125,7 @@ describe(`GET ${basePath}/formId`, () => {
     // mock a success return value...
     service.readForm = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId`);
+    const response = await request(app).get(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -137,7 +137,7 @@ describe(`GET ${basePath}/formId`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId`);
+    const response = await request(app).get(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -149,7 +149,7 @@ describe(`GET ${basePath}/formId`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId`);
+    const response = await request(app).get(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -161,7 +161,7 @@ describe(`PUT ${basePath}/formId`, () => {
     // mock a success return value...
     service.updateForm = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).put(`${basePath}/formId`);
+    const response = await request(app).put(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -173,7 +173,7 @@ describe(`PUT ${basePath}/formId`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).put(`${basePath}/formId`);
+    const response = await request(app).put(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -185,7 +185,7 @@ describe(`PUT ${basePath}/formId`, () => {
       throw new Error();
     });
 
-    const response = await request(app).put(`${basePath}/formId`);
+    const response = await request(app).put(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -197,7 +197,7 @@ describe(`DELETE ${basePath}/formId`, () => {
     // mock a success return value...
     service.deleteForm = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).delete(`${basePath}/formId`);
+    const response = await request(app).delete(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(204);
     expect(response.body).toBeTruthy();
@@ -209,7 +209,7 @@ describe(`DELETE ${basePath}/formId`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).delete(`${basePath}/formId`);
+    const response = await request(app).delete(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -221,7 +221,7 @@ describe(`DELETE ${basePath}/formId`, () => {
       throw new Error();
     });
 
-    const response = await request(app).delete(`${basePath}/formId`);
+    const response = await request(app).delete(`${basePath}/formId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -239,7 +239,7 @@ describe(`GET ${basePath}/formId/export`, () => {
       },
     });
 
-    const response = await request(app).get(`${basePath}/formId/export`);
+    const response = await request(app).get(`${basePath}/formId/export`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -251,7 +251,7 @@ describe(`GET ${basePath}/formId/export`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/export`);
+    const response = await request(app).get(`${basePath}/formId/export`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -263,7 +263,7 @@ describe(`GET ${basePath}/formId/export`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/export`);
+    const response = await request(app).get(`${basePath}/formId/export`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -275,7 +275,7 @@ describe(`GET ${basePath}/formId/version`, () => {
     // mock a success return value...
     service.readPublishedForm = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/version`);
+    const response = await request(app).get(`${basePath}/formId/version`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -287,7 +287,7 @@ describe(`GET ${basePath}/formId/version`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/version`);
+    const response = await request(app).get(`${basePath}/formId/version`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -299,7 +299,7 @@ describe(`GET ${basePath}/formId/version`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/version`);
+    const response = await request(app).get(`${basePath}/formId/version`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -311,7 +311,7 @@ describe(`GET ${basePath}/formId/submissions`, () => {
     // mock a success return value...
     service.listFormSubmissions = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/submissions`);
+    const response = await request(app).get(`${basePath}/formId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -323,7 +323,7 @@ describe(`GET ${basePath}/formId/submissions`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/submissions`);
+    const response = await request(app).get(`${basePath}/formId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -335,30 +335,19 @@ describe(`GET ${basePath}/formId/submissions`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/submissions`);
+    const response = await request(app).get(`${basePath}/formId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
   });
 });
 
-// describe(`POST ${basePath}/formId/versions`, () => {
-
-//   it('should return 410', async () => {
-//     const response = await request(app).post(`${basePath}/formId/versions`);
-
-//     expect(response.statusCode).toBe(410);
-//     expect(response.body).toBeTruthy();
-//   });
-
-// });
-
 describe(`GET ${basePath}/formId/versions/formVersionId`, () => {
   it('should return 200', async () => {
     // mock a success return value...
     service.readVersion = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -370,7 +359,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -382,7 +371,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -394,7 +383,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId/fields`, () => {
     // mock a success return value...
     service.readVersionFields = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -406,7 +395,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId/fields`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -418,30 +407,19 @@ describe(`GET ${basePath}/formId/versions/formVersionId/fields`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
   });
 });
 
-// describe(`PUT ${basePath}/formId/versions/formVersionId`, () => {
-
-//   it('should return 410', async () => {
-//     const response = await request(app).put(`${basePath}/formId/versions/formVersionId`);
-
-//     expect(response.statusCode).toBe(410);
-//     expect(response.body).toBeTruthy();
-//   });
-
-// });
-
 describe(`POST ${basePath}/formId/versions/formVersionId/publish`, () => {
   it('should return 200', async () => {
     // mock a success return value...
     service.publishVersion = jest.fn().mockReturnValue({});
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/publish`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/publish`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -453,7 +431,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/publish`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/publish`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/publish`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -465,7 +443,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/publish`, () => {
       throw new Error();
     });
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/publish`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/publish`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -477,7 +455,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId/submissions`, () => {
     // mock a success return value...
     service.listSubmissions = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -489,7 +467,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId/submissions`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -501,7 +479,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId/submissions`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -516,7 +494,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     emailService.submissionReceived = jest.fn(() => Promise.resolve({}));
     fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(emailService.submissionReceived).toHaveBeenCalledTimes(1);
     expect(fileService.moveSubmissionFiles).toHaveBeenCalledTimes(1);
@@ -530,7 +508,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     emailService.submissionReceived = jest.fn(() => Promise.resolve({}));
     fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).send({ draft: true });
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).send({ draft: true }).set('Authorization', 'Bearer: abc123');
 
     expect(emailService.submissionReceived).toHaveBeenCalledTimes(0);
     expect(fileService.moveSubmissionFiles).toHaveBeenCalledTimes(1);
@@ -544,7 +522,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     emailService.submissionReceived = jest.fn(() => Promise.resolve({}));
     fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).send({ draft: false });
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).send({ draft: false }).set('Authorization', 'Bearer: abc123');
 
     expect(emailService.submissionReceived).toHaveBeenCalledTimes(1);
     expect(fileService.moveSubmissionFiles).toHaveBeenCalledTimes(1);
@@ -560,7 +538,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     emailService.submissionReceived = jest.fn().mockReturnValue(true);
     fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -574,7 +552,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     emailService.submissionReceived = jest.fn().mockReturnValue(true);
     fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -585,7 +563,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     emailService.submissionReceived = jest.fn(() => Promise.reject({}));
     fileService.moveSubmissionFiles = jest.fn(() => Promise.resolve({}));
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
@@ -596,7 +574,7 @@ describe(`POST ${basePath}/formId/versions/formVersionId/submissions`, () => {
     emailService.submissionReceived = jest.fn(() => Promise.resolve({}));
     fileService.moveSubmissionFiles = jest.fn(() => Promise.reject({}));
 
-    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`);
+    const response = await request(app).post(`${basePath}/formId/versions/formVersionId/submissions`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
@@ -609,7 +587,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId/submissions/discover`, (
     service.listSubmissionFields = jest.fn().mockReturnValue([]);
     service.readVersionFields = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`).query({ fields: 'foo,bar' });
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`).query({ fields: 'foo,bar' }).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -622,7 +600,8 @@ describe(`GET ${basePath}/formId/versions/formVersionId/submissions/discover`, (
 
     const response = await request(app)
       .get(`${basePath}/formId/versions/formVersionId/submissions/discover`)
-      .query({ fields: ['foo', 'bar'] });
+      .query({ fields: ['foo', 'bar'] })
+      .set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -634,7 +613,7 @@ describe(`GET ${basePath}/formId/versions/formVersionId/submissions/discover`, (
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -646,41 +625,19 @@ describe(`GET ${basePath}/formId/versions/formVersionId/submissions/discover`, (
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`);
+    const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/discover`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
   });
 });
 
-// describe(`GET ${basePath}/formId/versions/formVersionId/submissions/formSubmissionId`, () => {
-
-//   it('should return 410', async () => {
-//     const response = await request(app).get(`${basePath}/formId/versions/formVersionId/submissions/formSubmissionId`);
-
-//     expect(response.statusCode).toBe(410);
-//     expect(response.body).toBeTruthy();
-//   });
-
-// });
-
-// describe(`PUT ${basePath}/formId/versions/formVersionId/submissions/formSubmissionId`, () => {
-
-//   it('should return 410', async () => {
-//     const response = await request(app).put(`${basePath}/formId/versions/formVersionId/submissions/formSubmissionId`);
-
-//     expect(response.statusCode).toBe(410);
-//     expect(response.body).toBeTruthy();
-//   });
-
-// });
-
 describe(`GET ${basePath}/formId/drafts`, () => {
   it('should return 200', async () => {
     // mock a success return value...
     service.listDrafts = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/drafts`);
+    const response = await request(app).get(`${basePath}/formId/drafts`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -692,7 +649,7 @@ describe(`GET ${basePath}/formId/drafts`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/drafts`);
+    const response = await request(app).get(`${basePath}/formId/drafts`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -704,7 +661,7 @@ describe(`GET ${basePath}/formId/drafts`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/drafts`);
+    const response = await request(app).get(`${basePath}/formId/drafts`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -716,7 +673,7 @@ describe(`POST ${basePath}/formId/drafts`, () => {
     // mock a success return value...
     service.createDraft = jest.fn().mockReturnValue({});
 
-    const response = await request(app).post(`${basePath}/formId/drafts`);
+    const response = await request(app).post(`${basePath}/formId/drafts`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(201);
     expect(response.body).toBeTruthy();
@@ -728,7 +685,7 @@ describe(`POST ${basePath}/formId/drafts`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).post(`${basePath}/formId/drafts`);
+    const response = await request(app).post(`${basePath}/formId/drafts`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -740,7 +697,7 @@ describe(`POST ${basePath}/formId/drafts`, () => {
       throw new Error();
     });
 
-    const response = await request(app).post(`${basePath}/formId/drafts`);
+    const response = await request(app).post(`${basePath}/formId/drafts`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -752,7 +709,7 @@ describe(`GET ${basePath}/formId/drafts/formVersionDraftId`, () => {
     // mock a success return value...
     service.readDraft = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).get(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -764,7 +721,7 @@ describe(`GET ${basePath}/formId/drafts/formVersionDraftId`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).get(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -776,7 +733,7 @@ describe(`GET ${basePath}/formId/drafts/formVersionDraftId`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).get(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -788,7 +745,7 @@ describe(`PUT ${basePath}/formId/drafts/formVersionDraftId`, () => {
     // mock a success return value...
     service.updateDraft = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).put(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).put(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -800,7 +757,7 @@ describe(`PUT ${basePath}/formId/drafts/formVersionDraftId`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).put(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).put(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -812,7 +769,7 @@ describe(`PUT ${basePath}/formId/drafts/formVersionDraftId`, () => {
       throw new Error();
     });
 
-    const response = await request(app).put(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).put(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -824,7 +781,7 @@ describe(`DELETE ${basePath}/formId/drafts/formVersionDraftId`, () => {
     // mock a success return value...
     service.deleteDraft = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).delete(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).delete(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(204);
     expect(response.body).toBeTruthy();
@@ -836,7 +793,7 @@ describe(`DELETE ${basePath}/formId/drafts/formVersionDraftId`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).delete(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).delete(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -848,7 +805,7 @@ describe(`DELETE ${basePath}/formId/drafts/formVersionDraftId`, () => {
       throw new Error();
     });
 
-    const response = await request(app).delete(`${basePath}/formId/drafts/formVersionDraftId`);
+    const response = await request(app).delete(`${basePath}/formId/drafts/formVersionDraftId`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -860,7 +817,7 @@ describe(`POST ${basePath}/formId/drafts/formVersionDraftId/publish`, () => {
     // mock a success return value...
     service.publishDraft = jest.fn().mockReturnValue({});
 
-    const response = await request(app).post(`${basePath}/formId/drafts/formVersionDraftId/publish`);
+    const response = await request(app).post(`${basePath}/formId/drafts/formVersionDraftId/publish`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -872,7 +829,7 @@ describe(`POST ${basePath}/formId/drafts/formVersionDraftId/publish`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).post(`${basePath}/formId/drafts/formVersionDraftId/publish`);
+    const response = await request(app).post(`${basePath}/formId/drafts/formVersionDraftId/publish`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -884,7 +841,7 @@ describe(`POST ${basePath}/formId/drafts/formVersionDraftId/publish`, () => {
       throw new Error();
     });
 
-    const response = await request(app).post(`${basePath}/formId/drafts/formVersionDraftId/publish`);
+    const response = await request(app).post(`${basePath}/formId/drafts/formVersionDraftId/publish`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -896,7 +853,7 @@ describe(`GET ${basePath}/formId/statusCodes`, () => {
     // mock a success return value...
     service.getStatusCodes = jest.fn().mockReturnValue([]);
 
-    const response = await request(app).get(`${basePath}/formId/statusCodes`);
+    const response = await request(app).get(`${basePath}/formId/statusCodes`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -908,7 +865,7 @@ describe(`GET ${basePath}/formId/statusCodes`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/statusCodes`);
+    const response = await request(app).get(`${basePath}/formId/statusCodes`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -920,7 +877,7 @@ describe(`GET ${basePath}/formId/statusCodes`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/statusCodes`);
+    const response = await request(app).get(`${basePath}/formId/statusCodes`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -1062,7 +1019,7 @@ describe(`GET ${basePath}/formId/csvexport/fields`, () => {
     // mock a success return value...
     exportService.fieldsForCSVExport = jest.fn().mockReturnValue(formFields);
 
-    const response = await request(app).get(`${basePath}/formId/csvexport/fields`);
+    const response = await request(app).get(`${basePath}/formId/csvexport/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -1074,7 +1031,7 @@ describe(`GET ${basePath}/formId/csvexport/fields`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/formId/csvexport/fields`);
+    const response = await request(app).get(`${basePath}/formId/csvexport/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -1086,14 +1043,14 @@ describe(`GET ${basePath}/formId/csvexport/fields`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/formId/csvexport/fields`);
+    const response = await request(app).get(`${basePath}/formId/csvexport/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
   });
 });
 
-describe(`GET ${basePath}/formId/export/fields`, () => {
+describe(`POST ${basePath}/formId/export/fields`, () => {
   it('should return 200', async () => {
     // mock a success return value...
     exportService.export = jest.fn().mockReturnValue({
@@ -1104,7 +1061,7 @@ describe(`GET ${basePath}/formId/export/fields`, () => {
       },
     });
 
-    const response = await request(app).post(`${basePath}/formId/export/fields`);
+    const response = await request(app).post(`${basePath}/formId/export/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -1116,7 +1073,7 @@ describe(`GET ${basePath}/formId/export/fields`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).post(`${basePath}/formId/export/fields`);
+    const response = await request(app).post(`${basePath}/formId/export/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -1128,7 +1085,7 @@ describe(`GET ${basePath}/formId/export/fields`, () => {
       throw new Error();
     });
 
-    const response = await request(app).post(`${basePath}/formId/export/fields`);
+    const response = await request(app).post(`${basePath}/formId/export/fields`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();

--- a/app/tests/unit/routes/v1/submission.spec.js
+++ b/app/tests/unit/routes/v1/submission.spec.js
@@ -45,7 +45,7 @@ describe(`GET ${basePath}/ID`, () => {
     // mock a success return value...
     service.read = jest.fn().mockReturnValue({});
 
-    const response = await request(app).get(`${basePath}/ID`);
+    const response = await request(app).get(`${basePath}/ID`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -57,7 +57,7 @@ describe(`GET ${basePath}/ID`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/ID`);
+    const response = await request(app).get(`${basePath}/ID`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -69,7 +69,7 @@ describe(`GET ${basePath}/ID`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/ID`);
+    const response = await request(app).get(`${basePath}/ID`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();
@@ -279,7 +279,7 @@ describe(`GET ${basePath}/ID/status`, () => {
     // mock a success return value...
     service.getStatus = jest.fn().mockReturnValue({});
 
-    const response = await request(app).get(`${basePath}/ID/status`);
+    const response = await request(app).get(`${basePath}/ID/status`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toBeTruthy();
@@ -291,7 +291,7 @@ describe(`GET ${basePath}/ID/status`, () => {
       throw new Problem(401);
     });
 
-    const response = await request(app).get(`${basePath}/ID/status`);
+    const response = await request(app).get(`${basePath}/ID/status`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(401);
     expect(response.body).toBeTruthy();
@@ -303,7 +303,7 @@ describe(`GET ${basePath}/ID/status`, () => {
       throw new Error();
     });
 
-    const response = await request(app).get(`${basePath}/ID/status`);
+    const response = await request(app).get(`${basePath}/ID/status`).set('Authorization', 'Bearer: abc123');
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toBeTruthy();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

JEDI is hitting the rate limit, so bump it up from 20 to 60.

Also, by moving the rate limiting to the app as a whole, it had two effects:
1. The static code analysis (CodeQL and GitHub Security) can’t detect that the rate limiting is being applied
2. The 429 errors are not logged - missed this in the testing, but it’s important

So moved it back to the routes from app.js

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Bad news is that moving the rate limiting to the routes will cause the rate limiting to be used by the tests - this was breaking the tests once they started returning 429 instead of the expected response. Made the tests for endpoints that allow API Keys to only use Bearer tokens.

Good news - now I know how to test the rate limiting. No time for it now, but will do ASAP as tech debt.