### PR TITLE
fix: FORMS-911 allow Api Key to delete submissions

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -92,7 +92,8 @@ paths:
       tags:
         - Form
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - in: query
@@ -165,6 +166,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Form'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -201,6 +207,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Form'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -231,6 +242,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormBasic'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -351,13 +367,13 @@ paths:
         - in: query
           name: deleted
           schema:
-            type: Boolean
+            type: boolean
           description: (optional) This optional parameter should be set to true if deleted records (submissions) need to be fetched
           example: false
         - in: query
           name: drafts
           schema:
-            type: Boolean
+            type: boolean
           description: (optional) This optional parameter should be set to true if draft records (submissions) need to be fetched
           example: false
         - in: query
@@ -385,6 +401,10 @@ paths:
               schema:
                 type: object
               example: text/json; charset=utf-8
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
           content:
             text/csv:
               schema:
@@ -408,7 +428,7 @@ paths:
                 $ref: '#/components/schemas/Error'
   /forms/{formId}/export/fields:
     post:
-      summary: Export submissions for a form with the ability to select fields to export if CSV is selected. Use only in frontend (from an interface)
+      summary: Export submissions for a form with the ability to select fields to export if CSV is selected.
       operationId: exportWithFields
       security:
         - BasicAuth: []
@@ -433,6 +453,10 @@ paths:
               schema:
                 type: object
               example: text/json; charset=utf-8
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
           content:
             text/csv:
               schema:
@@ -495,6 +519,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormVersion'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -527,6 +556,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormVersionFields'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -558,6 +592,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Form'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -597,6 +636,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormVersionBasic'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -630,6 +674,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormDraft'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -674,6 +723,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormDraft'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -706,6 +760,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormDraft'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -746,6 +805,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormDraft'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -773,6 +837,11 @@ paths:
       responses:
         '204':
           description: OK
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -805,6 +874,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormVersionBasic'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -847,6 +921,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormSubmissionSummary'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -881,6 +960,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormSubmission'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -918,6 +1002,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormSubmission'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -956,6 +1045,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FormSubmissionResponseMultiple'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -1003,6 +1097,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FormSubmissionDiscover'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -1034,6 +1133,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SubmissionFormVersion'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -1077,6 +1181,10 @@ paths:
     delete:
       summary: (Soft) delete a form submission
       operationId: deleteSubmission
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
       tags:
         - Submission
       parameters:
@@ -1087,9 +1195,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FormSubmission'
+                $ref: '#/components/schemas/SubmissionFormVersionDeleted'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
         default:
           description: Unexpected error
           content:
@@ -1111,7 +1226,7 @@ paths:
             type: string
           required: true
           example: >-
-            https://survey.gov.bc.com/app/form/success?s=7d66664b-87c5-4df8-ba7c-a6fb7d62c379
+            https://submit.digital.gov.bc.ca/app/form/success?s=7d66664b-87c5-4df8-ba7c-a6fb7d62c379
       requestBody:
         required: true
         content:
@@ -1231,6 +1346,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/SubmissionStatusHistory'
+          headers:
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
@@ -1316,6 +1436,8 @@ paths:
               example: application/pdf
         '400':
           $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '422':
           $ref: '#/components/responses/UnprocessableEntity'
         default:
@@ -1466,7 +1588,8 @@ paths:
       tags:
         - Permission
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       responses:
         '200':
@@ -1491,7 +1614,8 @@ paths:
       tags:
         - Permission
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       requestBody:
         required: true
@@ -1523,7 +1647,8 @@ paths:
       tags:
         - Permission
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - in: path
@@ -1554,7 +1679,8 @@ paths:
       tags:
         - Permission
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - in: path
@@ -1614,7 +1740,8 @@ paths:
       tags:
         - Role
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       requestBody:
         required: true
@@ -1673,7 +1800,8 @@ paths:
       tags:
         - Role
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - in: path
@@ -2063,7 +2191,8 @@ paths:
       tags:
         - RBAC
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - in: query
@@ -2446,7 +2575,8 @@ paths:
       tags:
         - Admin
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - in: query
@@ -2479,7 +2609,8 @@ paths:
       tags:
         - Admin
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - $ref: '#/components/parameters/formIdParam'
@@ -2505,6 +2636,10 @@ paths:
       operationId: adminReadApiDetails
       tags:
         - Admin
+      security:
+        - BearerAuth: []
+          OpenID:
+            - admin
       parameters:
         - $ref: '#/components/parameters/formIdParam'
       responses:
@@ -2528,6 +2663,10 @@ paths:
       operationId: adminDeleteApiKey
       tags:
         - Admin
+      security:
+        - BearerAuth: []
+          OpenID:
+            - admin
       parameters:
         - $ref: '#/components/parameters/formIdParam'
       responses:
@@ -2548,7 +2687,8 @@ paths:
       tags:
         - Admin
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - $ref: '#/components/parameters/formIdParam'
@@ -2574,7 +2714,8 @@ paths:
       tags:
         - Admin
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - $ref: '#/components/parameters/formIdParam'
@@ -2602,7 +2743,8 @@ paths:
       tags:
         - Admin
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - $ref: '#/components/parameters/formIdParam'
@@ -2642,7 +2784,8 @@ paths:
       tags:
         - Admin
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       responses:
         '200':
@@ -2668,7 +2811,8 @@ paths:
       tags:
         - Admin
       security:
-        - OpenID:
+        - BearerAuth: []
+          OpenID:
             - admin
       parameters:
         - in: path
@@ -2694,6 +2838,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 components:
+  headers:
+    RateLimit:
+      schema:
+        type: string
+      description: >-
+        Indicates the remaining number of allowed API calls within the
+        remaining window. In the example, 18 more requests are allowed
+        within the 45 seconds that remain in the window. When the window resets
+        after 45 seconds then the "remaining" will be reset to "limit".
+      example: limit=20, remaining=18, reset=45
+    RateLimit-Policy:
+      schema:
+        type: string
+      description: >-
+        Indicates how many API calls can be made within a "window" of time.
+        Additional API calls within the window will result in HTTP 429
+        responses. In the example, 20 requests are allowed within a 60
+        second window.
+      example: 20;w=60
+    retry-after:
+      schema:
+        type: integer
+      description: >-
+        Only returned when the rate limit is exceeded (HTTP 429). Indicates the
+        number of seconds before the window resets, after which API calls will
+        again be allowed. In the example, 13 seconds remain before the window is
+        reset.
+      example: 13
   securitySchemes:
     BasicAuth:
       type: http
@@ -2858,27 +3030,13 @@ components:
     Form:
       allOf:
         - $ref: '#/components/schemas/FormBasic'
+        - $ref: '#/components/schemas/FormWithoutVersions'
         - type: object
           properties:
-            id:
-              type: string
-              example: aeb3b705-1de5-4f4e-a4e6-0716b7671034
-            active:
-              type: boolean
-              example: true
-            labels:
-              type: array
-              example:
-                - Survey
-              items:
-                type: string
             versions:
               type: array
               items:
                 $ref: '#/components/schemas/FormVersionBasic'
-            snake:
-              type: string
-              example: my-survey-form
         - $ref: '#/components/schemas/TimeStampUserData'
     FormApiKey:
       allOf:
@@ -2935,7 +3093,7 @@ components:
               example: true
               description: Allow form to send reminder email to all submitters
             schedule:
-              type: Object
+              type: object
               description: Contains schedule related data
               properties:
                 enabled:
@@ -2959,7 +3117,7 @@ components:
                   description: This contain a value that can be used with combination to another key i.e. keepOpenForTerm to calculate a period. Thats tells a form to be keep open for particular period.  40 Days, 3 Weeks, 1 Years etc.
                   example: '15'
                 repeatSubmission:
-                  type: Object
+                  type: object
                   properties:
                     enabled:
                       type: boolean
@@ -2978,14 +3136,14 @@ components:
                       description: This contain a value that can be used with combination to another key i.e. everyTerm to calculate a period. Thats tells a form to be schedule a form repetition after particular period.  40 Days, 3 Weeks, 1 Years etc.
                       example: '15'
                 allowLateSubmissions:
-                  type: Object
+                  type: object
                   properties:
                     enabled:
                       type: boolean
                       description: Used to indicate if late submission allowed on a form or not, Will be true if enabled
                       example: true
                     forNext:
-                      type: Object
+                      type: object
                       properties:
                         term:
                           type: string
@@ -3006,7 +3164,7 @@ components:
                   description: Contains closing date of form schedule system when type of ScheduleType set to closingDate.
                   example: '2022-12-22'
             subscribe:
-              type: Object
+              type: object
               description: Contains subscription related data - future storage of subscribed events
               properties:
                 enabled:
@@ -3021,7 +3179,7 @@ components:
       properties:
         name:
           type: string
-          example: My First Form
+          example: My Survey Form
         description:
           type: string
           example: I built this survey form. It is amazing.
@@ -3043,6 +3201,27 @@ components:
               description: ID of the FormVersion this submission is for.
               example: a675ab2a-1e88-4fb5-88f9-c7cb051a18b2
         - $ref: '#/components/schemas/FormSchema'
+        - $ref: '#/components/schemas/TimeStampUserData'
+    FormWithoutVersions:
+      allOf:
+        - $ref: '#/components/schemas/FormBasic'
+        - type: object
+          properties:
+            id:
+              type: string
+              example: aeb3b705-1de5-4f4e-a4e6-0716b7671034
+            active:
+              type: boolean
+              example: true
+            labels:
+              type: array
+              example:
+                - Survey
+              items:
+                type: string
+            snake:
+              type: string
+              example: my-survey-form
         - $ref: '#/components/schemas/TimeStampUserData'
     FormOptions:
       allOf:
@@ -3179,11 +3358,20 @@ components:
       properties:
         id:
           type: string
-          example: aeb3b705-1de5-4f4e-a4e6-0716b7671034
+          example: c0822716-01f5-43e6-b4d4-ffcacd13aae3
         formVersionId:
           type: string
           description: ID of the FormVersion this submission is for.
-          example: a675ab2a-1e88-4fb5-88f9-c7cb051a18b2
+          example: b6908dd4-2f01-4e08-831d-921edae99ca3
+    FormSubmissionDeleted:
+      allOf:
+        - $ref: '#/components/schemas/FormSubmission'
+        - type: object
+          properties:
+            deleted:
+              type: boolean
+              description: Used to indicate a soft delete.
+              example: true
     FormSubmissionDiscover:
       type: object
       properties:
@@ -3239,11 +3427,11 @@ components:
         - type: object
           properties:
             format:
-              type: String
+              type: string
               description: Chosen file type for the submission data exported
               example: csv
             template:
-              type: String
+              type: string
               description: Chosen CSV format for the submission data exported
               example: multiRowEmptySpacesCSVExport
             version:
@@ -3251,7 +3439,7 @@ components:
               description: The version number of the form for the submission data exported
               example: 1
             type:
-              type: String
+              type: string
               description: default value is submissions and should be changed
               example: submissions
             preference:
@@ -3285,7 +3473,7 @@ components:
                 - oneRowPerLake.dataGrid.numberCaught,
                 - oneRowPerLake.dataGrid.numberKept
             emailExport:
-              type: Boolean
+              type: boolean
               description: This parameter should be set to true if the form submissions are large (e.g. above 500) or the form is big
               example: false
     FormSubmissionSummary:
@@ -3341,7 +3529,7 @@ components:
               example: aeb3b705-1de5-4f4e-a4e6-0716b7671034
             name:
               type: string
-              example: My First Form.
+              example: My Survey Form.
             users:
               type: array
               items:
@@ -3367,7 +3555,7 @@ components:
       properties:
         id:
           type: string
-          example: aeb3b705-1de5-4f4e-a4e6-0716b7671034
+          example: b6908dd4-2f01-4e08-831d-921edae99ca3
         formId:
           type: string
           format: uuid
@@ -3554,6 +3742,15 @@ components:
           $ref: '#/components/schemas/FormVersion'
         form:
           $ref: '#/components/schemas/Form'
+    SubmissionFormVersionDeleted:
+      type: object
+      properties:
+        submission:
+          $ref: '#/components/schemas/FormSubmissionDeleted'
+        version:
+          $ref: '#/components/schemas/FormVersion'
+        form:
+          $ref: '#/components/schemas/FormWithoutVersions'
     SubmissionFormVersionOptions:
       type: object
       properties:
@@ -3655,7 +3852,7 @@ components:
           example: jsmith@idir
         updatedAt:
           type: string
-          example: '2020-06-04T18:49:20.672Z'
+          example: '2020-06-05T11:27:15.853Z'
     User:
       allOf:
         - type: object
@@ -3683,7 +3880,7 @@ components:
               example: Smith
             email:
               type: string
-              example: jsmith@gov.bc.
+              example: jsmith@gov.bc.ca
             idpCode:
               type: string
               example: idir
@@ -4060,6 +4257,13 @@ components:
             $ref: '#/components/schemas/NotFound'
     TooManyRequests:
       description: BasicAuth request exceeds rate limiting
+      headers:
+        RateLimit:
+          $ref: '#/components/headers/RateLimit'
+        RateLimit-Policy:
+          $ref: '#/components/headers/RateLimit-Policy'
+        retry-after:
+          $ref: '#/components/headers/retry-after'
     UnauthorizedError:
       description: Invalid authorization credentials
     UnprocessableEntity:

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -16,7 +16,7 @@ routes.put('/:formSubmissionId', hasSubmissionPermissions(P.SUBMISSION_UPDATE), 
   await controller.update(req, res, next);
 });
 
-routes.delete('/:formSubmissionId', hasSubmissionPermissions(P.SUBMISSION_DELETE), async (req, res, next) => {
+routes.delete('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_DELETE), async (req, res, next) => {
   await controller.delete(req, res, next);
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

API Key users have the ability to GET submissions but they cannot (logically) DELETE them. For forms that have backend systems that are pulling the submission with GET, it’s desirable to be able to DELETE the submissions when they have been processed.

1. Update the DELETE endpoint in `app/src/forms/submissions/routes.js:18`
2. Update `app/src/docs/v1.api-spec.yaml` documentation to show that BasicAuth is now a possibility for the DELETE endpoint
3. Update `app/src/docs/v1.api-spec.yaml` documentation to add rate limiting headers to both the 200 response and the 429

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

While I was in the openapi docs:

1. Standardized how the "admin" endpoints display their authorization information (Bearer token plus "admin" role)
2. Added rate limiting headers to all Basic Auth endpoints for both the 20X and 429 responses
3. Fixed Boolean, Object, and String types, the spec says boolean, object, and string (lowercase)
4. Used different UUIDs for form id, form version id, and submission id to prevent confusion in the examples
