### PR TITLE
fix: FORMS-920 allow bceid basic to view submissions

### DIFF
--- a/app/frontend/src/views/user/Submissions.vue
+++ b/app/frontend/src/views/user/Submissions.vue
@@ -21,7 +21,7 @@ export default {
 </script>
 
 <template>
-  <BaseSecure :idp="[IDP.IDIR, IDP.BCEIDBUSINESS]">
+  <BaseSecure :idp="[IDP.IDIR, IDP.BCEIDBASIC, IDP.BCEIDBUSINESS]">
     <MySubmissionsTable :form-id="f" />
   </BaseSecure>
 </template>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

After the Vue 3 upgrade it was reported by a user that when logged in as a BCeID user, the “View My Drafts/Submissions” page is no longer working and producing an error “403: Forbidden This page requires [ “idir”, “bceid-business” ] authentication. 

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

Looks like `views/form/Submissions.vue` was duplicated to `views/user/Submissions.vue` and brought along a restriction to `idir` and `bceid-business` where there was none before.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
