### PR TITLE
fix: FORMS-927 admin show deleted forms checkbox

### DIFF
--- a/app/frontend/src/components/admin/AdminFormsTable.vue
+++ b/app/frontend/src/components/admin/AdminFormsTable.vue
@@ -8,8 +8,8 @@ import { useFormStore } from '~/store/form';
 export default {
   data() {
     return {
-      activeOnly: false,
-      loading: true,
+      showDeleted: false,
+      loading: false,
       search: '',
     };
   },
@@ -18,7 +18,7 @@ export default {
     ...mapState(useFormStore, ['isRTL', 'lang']),
     calcHeaders() {
       return this.headers.filter(
-        (x) => x.key !== 'updatedAt' || this.activeOnly
+        (x) => x.key !== 'updatedAt' || !this.showDeleted
       );
     },
     headers() {
@@ -48,15 +48,19 @@ export default {
       ];
     },
   },
+  watch: {
+    showDeleted() {
+      this.refreshForms();
+    },
+  },
   async mounted() {
-    await this.getForms();
-    this.loading = false;
+    this.refreshForms();
   },
   methods: {
     ...mapActions(useAdminStore, ['getForms']),
     async refreshForms() {
       this.loading = true;
-      await this.getForms(!this.activeOnly);
+      await this.getForms(!this.showDeleted);
       this.loading = false;
     },
   },
@@ -68,11 +72,11 @@ export default {
     <v-row no-gutters>
       <v-col cols="12" sm="8">
         <v-checkbox
-          v-model="activeOnly"
+          v-model="showDeleted"
           class="pl-3"
+          data-test="checkbox-show-deleted"
           :class="isRTL ? 'float-right' : 'float-left'"
           :label="$t('trans.adminFormsTable.showDeletedForms')"
-          @click="refreshForms"
         >
           <template #label>
             <span :class="{ 'mr-2': isRTL }" :lang="lang">

--- a/app/frontend/tests/unit/components/admin/AdministerFormsTable.spec.js
+++ b/app/frontend/tests/unit/components/admin/AdministerFormsTable.spec.js
@@ -1,0 +1,82 @@
+import { createTestingPinia } from '@pinia/testing';
+import { mount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { expect } from 'vitest';
+import { nextTick } from 'vue';
+
+import AdministerFormsTable from '~/components/admin/AdminFormsTable.vue';
+import { useAdminStore } from '~/store/admin';
+
+describe('AdministerFormsTable.vue', () => {
+  const CHECKBOX_SHOW_DELETED = '[data-test="checkbox-show-deleted"]';
+  const ROUTER_LINK = {
+    name: 'RouterLink',
+    template: '<div class="router-link-stub"><slot /></div>',
+  };
+
+  const pinia = createTestingPinia();
+  setActivePinia(pinia);
+
+  it('shows active forms by default', async () => {
+    // Arrange
+    const store = useAdminStore();
+    mount(AdministerFormsTable, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RouterLink: ROUTER_LINK,
+        },
+      },
+    });
+
+    // Assert
+    expect(store.getForms).toHaveBeenCalledTimes(1);
+    expect(store.getForms).toHaveBeenLastCalledWith(true);
+  });
+
+  it('loads deleted forms after click', async () => {
+    // Arrange
+    const store = useAdminStore();
+    const wrapper = mount(AdministerFormsTable, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RouterLink: ROUTER_LINK,
+        },
+      },
+    });
+
+    // Act
+    const showDeleted = wrapper.findComponent(CHECKBOX_SHOW_DELETED);
+    showDeleted.setValue(true);
+    await nextTick();
+
+    // Assert
+    expect(store.getForms).toHaveBeenCalledTimes(2);
+    expect(store.getForms).toHaveBeenLastCalledWith(false);
+  });
+
+  it('loads active forms after two clicks', async () => {
+    // Arrange
+    const store = useAdminStore();
+    const wrapper = mount(AdministerFormsTable, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RouterLink: ROUTER_LINK,
+        },
+      },
+    });
+
+    // Act
+    const showDeleted = wrapper.findComponent(CHECKBOX_SHOW_DELETED);
+    showDeleted.setValue(true);
+    await nextTick();
+    showDeleted.setValue(false);
+    await nextTick();
+
+    // Assert
+    expect(store.getForms).toHaveBeenCalledTimes(3);
+    expect(store.getForms).toHaveBeenLastCalledWith(true);
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The “Show Deleted” checkbox on the Admin page’s list of forms is not working. It’s being assigned a value of false but the results being displayed are for true. So then when it is checked, the results are for true again (but page looks like false) and then when it’s unchecked the results are for false (but page looks like true). So the first click nothing changes in the data, but after that the logic for it is backwards.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

The actual fix was that the `@click` event was firing before the model was updated. We shouldn't really be doing two things when the state of the component changes - instead just set the data and put a watcher on that data.

The name of the field in the component is “activeOnly” while the text on the page for it is “Show Deleted”. This flipped logic is a little confusing, so I changed the data field to be “showDeleted” (with the same initial state, which was incorrect before!) and then flipped the logic everywhere else.

Changed the mounted code to call the same code we have for refreshing - let's just maintain one call to `getForms`.