### PR TITLE
prevents export with no submissions

### DIFF
--- a/app/frontend/src/components/base/BaseNotificationBar.vue
+++ b/app/frontend/src/components/base/BaseNotificationBar.vue
@@ -22,13 +22,23 @@ export default {
   },
   created() {
     if (this.notification.consoleError) {
-      // eslint-disable-next-line no-console
-      console.error(
-        i18n.t(
-          this.notification.consoleError.text,
-          this.notification.consoleError.options
-        )
-      );
+      if (typeof this.notification.consoleError === 'string') {
+        // eslint-disable-next-line no-console
+        console.error(this.notification.consoleError);
+      } else if (this.notification.consoleError.text) {
+        if (this.notification.consoleError.options) {
+          // eslint-disable-next-line no-console
+          console.error(
+            i18n.t(
+              this.notification.consoleError.text,
+              this.notification.consoleError.options
+            )
+          );
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(i18n.t(this.notification.consoleError.text));
+        }
+      }
     }
   },
   mounted() {

--- a/app/frontend/src/components/forms/ExportSubmissions.vue
+++ b/app/frontend/src/components/forms/ExportSubmissions.vue
@@ -199,11 +199,13 @@ export default {
           {
             minDate: from,
             maxDate: to,
-            // deleted: true,
-            // drafts: true
           },
           fieldToExport,
-          emailExport
+          emailExport,
+          {
+            deleted: false,
+            drafts: false,
+          }
         );
 
         if (response && response.data && !emailExport) {
@@ -224,8 +226,13 @@ export default {
           throw new Error(i18n.t('trans.exportSubmissions.noResponseDataErr'));
         }
       } catch (error) {
+        const data = error?.response?.data
+          ? JSON.parse(await error.response.data.text())
+          : undefined;
         this.addNotification({
-          text: i18n.t('trans.exportSubmissions.apiCallErrorMsg'),
+          text: data?.detail
+            ? data.detail
+            : i18n.t('trans.exportSubmissions.apiCallErrorMsg'),
           consoleError:
             i18n.t('trans.exportSubmissions.apiCallConsErrorMsg') +
             `${this.form.id}: ${error}`,

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -7,10 +7,15 @@ module.exports = {
   export: async (req, res, next) => {
     try {
       const result = await exportService.export(req.params.formId, req.query, req.currentUser, req.headers.referer);
-      ['Content-Disposition', 'Content-Type'].forEach((h) => {
-        res.setHeader(h, result.headers[h.toLowerCase()]);
-      });
-      return res.send(result.data);
+      if (result.data.length === 0) {
+        res.setHeader('Content-Type', 'application/json');
+        res.status(400).send(JSON.stringify({ detail: 'There are no submissions to export.' }));
+      } else {
+        ['Content-Disposition', 'Content-Type'].forEach((h) => {
+          res.setHeader(h, result.headers[h.toLowerCase()]);
+        });
+        return res.send(result.data);
+      }
     } catch (error) {
       next(error);
     }
@@ -19,10 +24,15 @@ module.exports = {
   exportWithFields: async (req, res, next) => {
     try {
       const result = await exportService.export(req.params.formId, req.body, req.currentUser, req.headers.referer);
-      ['Content-Disposition', 'Content-Type'].forEach((h) => {
-        res.setHeader(h, result.headers[h.toLowerCase()]);
-      });
-      return res.send(result.data);
+      if (result.data.length === 0) {
+        res.setHeader('Content-Type', 'application/json');
+        res.status(400).send(JSON.stringify({ detail: 'There are no submissions to export.' }));
+      } else {
+        ['Content-Disposition', 'Content-Type'].forEach((h) => {
+          res.setHeader(h, result.headers[h.toLowerCase()]);
+        });
+        return res.send(result.data);
+      }
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -430,6 +430,9 @@ const service = {
   fieldsForCSVExport: async (formId, params = {}) => {
     const form = await service._getForm(formId);
     const data = await service._getData(params.type, params.version, form, params);
+    // If there are no submissions then we don't need to format the data
+    if ((Array.isArray(data) && data.length === 0) || (typeof data === 'object' && Object.keys(data).length === 0)) return { data: [] };
+
     const formatted = data.map((obj) => {
       const { submission, ...form } = obj;
       return Object.assign({ form: form }, submission);
@@ -447,6 +450,8 @@ const service = {
     const exportTemplate = params.template ? params.template : 'multiRowEmptySpacesCSVExport';
     const form = await service._getForm(formId);
     const data = await service._getData(exportType, params.version, form, params);
+    // If there are no submissions then we don't need to format the data
+    if ((Array.isArray(data) && data.length === 0) || (typeof data === 'object' && Object.keys(data).length === 0)) return { data: [] };
     const result = await service._formatData(exportFormat, exportType, exportTemplate, form, data, params.fields, params.version, params.emailExport, currentUser, referer);
     return { data: result.data, headers: result.headers };
   },

--- a/app/tests/unit/forms/form/controller.spec.js
+++ b/app/tests/unit/forms/form/controller.spec.js
@@ -11,7 +11,9 @@ const req = {
   },
   body: {},
   currentUser: {},
-  headers: {},
+  headers: {
+    referer: '',
+  },
 };
 
 describe('form controller', () => {
@@ -42,5 +44,20 @@ describe('form controller', () => {
 
     await controller.readFieldsForCSVExport(req, {}, jest.fn());
     expect(exportService.fieldsForCSVExport).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not continue with export if there are no submissions', async () => {
+    const exportServiceSpy = jest.spyOn(exportService, 'export');
+    const formatDataSpy = jest.spyOn(exportService, '_formatData');
+    exportService._exportType = jest.fn().mockReturnValue('submissions');
+    exportService._exportFormat = jest.fn().mockReturnValue('json');
+    exportService._getForm = jest.fn().mockReturnValue({ id: '1111' });
+    exportService._getSubmissions = jest.fn().mockReturnValue([]);
+
+    await controller.export(req, {}, jest.fn());
+    expect(exportServiceSpy).toHaveBeenCalledTimes(1);
+    expect(exportService._getForm).toHaveBeenCalledTimes(1);
+    expect(exportService._getSubmissions).toHaveBeenCalledTimes(1);
+    expect(formatDataSpy).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
If a reviewer is trying to export submissions with no submissions, it gives an infinite spinner. This will return an error to the user indicating that there are no submissions if there are no submissions. A valid submission is a form that is not in the draft state or deleted state.

resolves: https://bcdevex.atlassian.net/browse/FORMS-857

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
