### PR TITLE
 Fix: GET /files API working for Objects and Arrays

### DIFF
--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -31,7 +31,6 @@ const service = {
   _findFileIds: (schema, data) => {
     const findFiles = (currentData) => {
       let fileIds = [];
-
       // Check if the current level is an array or an object
       if (Array.isArray(currentData)) {
         currentData.forEach((item) => {
@@ -48,7 +47,6 @@ const service = {
           }
         });
       }
-
       return fileIds;
     };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
A user reported that the GET /files API does not retrieve files that are uploaded in containers. Upon further investigation, this was also the case for many other components such as data grids, columns, wells, panels, and tables. The error was in checking the form schema's components array, which does not contain all these elements.

The fix now uses the form data instead and handles the case for both arrays and objects to successfully retrieve files from within any component.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request



<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
