### PR TITLE
 Fix: GET /files API working for Objects and Arrays

### DIFF
--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -28,25 +28,30 @@ const { Permissions, Roles, Statuses } = require('../common/constants');
 const Rolenames = [Roles.OWNER, Roles.TEAM_MANAGER, Roles.FORM_DESIGNER, Roles.SUBMISSION_REVIEWER, Roles.FORM_SUBMITTER];
 
 const service = {
-  // Get the list of file IDs from the submission
   _findFileIds: (schema, data) => {
-    const findFiles = (components) => {
-      // Reduce the array of components to a flat array of file IDs
-      return components.reduce((fileIds, x) => {
-        if (x.type === 'simplefile' && data.submission.data[x.key]) {
-          // Add the file ID if it's a 'simplefile' and it exists in the data
-          const files = data.submission.data[x.key];
-          const ids = Array.isArray(files) ? files.map((file) => file.data.id) : [files.data.id];
-          return fileIds.concat(ids);
-        } else if (x.components) {
-          // If the component has nested components, recurse into them
-          return fileIds.concat(findFiles(x.components));
-        }
-        return fileIds;
-      }, []);
+    const findFiles = (currentData) => {
+      let fileIds = [];
+      // Check if the current level is an array or an object
+      if (Array.isArray(currentData)) {
+        currentData.forEach((item) => {
+          fileIds = fileIds.concat(findFiles(item));
+        });
+      } else if (typeof currentData === 'object' && currentData !== null) {
+        Object.keys(currentData).forEach((key) => {
+          if (key === 'data' && currentData[key] && currentData[key].id) {
+            // Add the file ID if it exists
+            fileIds.push(currentData[key].id);
+          } else {
+            // Recurse into nested objects
+            fileIds = fileIds.concat(findFiles(currentData[key]));
+          }
+        });
+      }
+      return fileIds;
     };
-    // Start the recursive search from the top-level components
-    return findFiles(schema.components);
+
+    // Start the search from the top-level submission data
+    return findFiles(data.submission.data);
   },
 
   listForms: async (params) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
A user reported that the GET /files API does not retrieve files that are uploaded in containers. Upon further investigation, this was also the case for many other components such as data grids, columns, wells, panels, and tables. The error was in checking the form schema's components array, which does not contain all these elements.

<!-- Describe your changes in detail -->
The fix now uses the form data instead and handles the case for both arrays and objects to successfully retrieve files from within any component.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request



<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
