### PR TITLE
feat: FORMS-937 allow basicauth for template rendering

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -1396,11 +1396,26 @@ paths:
                 $ref: '#/components/schemas/Error'
   /submissions/{formSubmissionId}/template/render:
     post:
-      summary: Generate document from inline Template
+      summary: Generate a document from a document template
       description: >-
-        This endpoint accepts a document template and a set (or multiple sets)
-        of substitution variables and merges them into the document.
+        Merges data from a form submission into a document template.
+
+        #### Common Document Generation Service (CDOGS)
+
+        This endpoint is a passthrough to CDOGS. Instead of using *BasicAuth* to
+        call this endpoint, it is highly recommended that you [directly call
+        CDOGS](https://bcgov.github.io/common-service-showcase/services/cdogs.html).
+        Benefits of calling CDOGS directly from your application:
+          - avoid CHEFS API rate limiting restrictions
+          - avoid CHEFS API timeout restrictions (for large documents)
+          - better performance (direct call instead of passthrough)
+          - ability to use the CDOGS template cache
+          - direct support from the CDOGS team for your specific Client ID
       operationId: uploadTemplateAndRenderReport
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
       tags:
         - Template
       parameters:
@@ -1414,7 +1429,7 @@ paths:
               $ref: '#/components/schemas/TemplateRenderObject'
       responses:
         '200':
-          description: Returns the supplied document with variables merged in
+          description: Returns the document template with merged variables
           content:
             application/octet-stream:
               schema:
@@ -1434,12 +1449,18 @@ paths:
                 type: string
               description: The MIME-type of the binary file payload
               example: application/pdf
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
         '422':
           $ref: '#/components/responses/UnprocessableEntity'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
         default:
           description: Unexpected error
           content:
@@ -3081,7 +3102,7 @@ components:
             showSubmissionConfirmation:
               type: boolean
               example: true
-            sendSubmissionReceivedEmail: 
+            sendSubmissionReceivedEmail:
               type: boolean
               example: true
               description: Used to indicate if team should be notified upon submission
@@ -3837,17 +3858,37 @@ components:
             convertTo:
               type: string
               description: >-
-                The desired file extension of the generated document, used for
-                converting to other types of document. If not supplied, will
-                just use the original contentFileType.
+                The desired file type of the generated document. If not
+                supplied, will use the original contentFileType.
               example: pdf
             reportName:
               type: string
               description: >-
-                The desired file name of the generated document, can accept
-                template substitution fields from the contexts. If not supplied,
-                will use a random UUID.  Extension will be from convertTo.
-              example: abc_123_{d.firstName}_{d.lastName}
+                The desired file name of the generated document. Can perform
+                template substitution using the form data. If not supplied, will
+                use a random UUID.
+              example: abc_123_{d.firstName}_{d.lastName}.pdf
+        template:
+          type: object
+          description: Object containing the document template
+          properties:
+            content:
+              type: string
+              description: >-
+                The document template encoded as a `base64` string. The example
+                is the encoded value of the text file
+                `Hello {d.firstName} {d.lastName}!`.
+              example: 'SGVsbG8ge2QuZmlyc3ROYW1lfSB7ZC5sYXN0TmFtZX0hCg=='
+            encodingType:
+              type: string
+              description: >-
+                The encoding of the `content` property: use `base64`.
+              example: base64
+            fileType:
+              type: string
+              description: >-
+                The original file type of the `content` document template.
+              example: txt
     TimeStampUserData:
       type: object
       properties:

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -56,7 +56,7 @@ routes.get('/:formSubmissionId/edits', hasSubmissionPermissions(P.SUBMISSION_REA
   await controller.listEdits(req, res, next);
 });
 
-routes.post('/:formSubmissionId/template/render', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.post('/:formSubmissionId/template/render', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.templateUploadAndRender(req, res, next);
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In the Teams channel (2023-12-01 at 16:28) someone is asking if we can allow Basic Auth use of the endpoint `app/api/v1/submissions/{formSubmissionId}/template/render`. This would be so that people who are using the CHEFS API can also use it for their document generation, rather than having to also sign up for CDOGS.
- Update the endpoint with the rate limiting and apiKey middleware
- Update the API documentation Authorizations, plus add the rate limiting info to the 200 response, and the 429 response

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

> Note: Can’t really add tests since we haven’t determined how we want to test the route middleware
