### PR TITLE
fix: Fix forms 925 translations and other minor vue 3 frontend problems

### DIFF
--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -6,7 +6,7 @@
 @import 'vue-json-pretty/lib/styles.css';
 
 // Override bootstrap default value
-$enable-smooth-scroll: false; 
+$enable-smooth-scroll: false;
 @import 'bootstrap-scss/bootstrap.scss'; // TODO: import this only for form designer/renderer formio components
 
 // Variables
@@ -135,7 +135,7 @@ a,
 }
 
 .v-tooltip > .v-overlay__content {
-  background: rgba(97, 97, 97, .9) !important;
+  background: rgba(97, 97, 97, 0.9) !important;
 }
 
 // Customized expand/collapse section
@@ -318,7 +318,7 @@ a,
 
   // add margin to create space between the button and form.io inputs
   .formio-component-button {
-      margin-top: 1rem;
+    margin-top: 1rem;
   }
 
   // tooltips
@@ -510,9 +510,8 @@ a,
   left: auto !important;
 }
 
-
 .label span {
-  margin-right:30px;
+  margin-right: 30px;
 }
 
 .flex-xs-column-reverse {

--- a/app/frontend/src/components/admin/AdminFormsTable.vue
+++ b/app/frontend/src/components/admin/AdminFormsTable.vue
@@ -18,7 +18,7 @@ export default {
     ...mapState(useFormStore, ['isRTL', 'lang']),
     calcHeaders() {
       return this.headers.filter(
-        (x) => x.key !== 'updatedAt' || !this.showDeleted
+        (x) => x.key !== 'updatedAt' || this.showDeleted
       );
     },
     headers() {

--- a/app/frontend/src/components/base/BaseNotificationBar.vue
+++ b/app/frontend/src/components/base/BaseNotificationBar.vue
@@ -21,11 +21,14 @@ export default {
     ...mapState(useFormStore, ['form', 'isRTL', 'lang']),
   },
   created() {
-    if (this.notification.consoleError) {
+    if (
+      this.notification.consoleError &&
+      this.notification.consoleError instanceof String
+    ) {
       // eslint-disable-next-line no-console
       console.error(
         i18n.t(
-          this.notification.consoleError.text,
+          this.notification.consoleError,
           this.notification.consoleError.options
         )
       );
@@ -75,6 +78,7 @@ export default {
     :icon="notification.icon"
     prominent
     closable
+    class="mb-3"
     :title="notification.title"
     :text="$t(notification.text)"
     @update:model-value="alertClosed"

--- a/app/frontend/src/components/bcgov/BCGovAlertBanner.vue
+++ b/app/frontend/src/components/bcgov/BCGovAlertBanner.vue
@@ -24,7 +24,7 @@ export default {
       default: NotificationTypes.ERROR.type,
     },
     translate: {
-      default: false,
+      default: true,
       type: Boolean,
     },
   },

--- a/app/frontend/src/components/designer/FormsTable.vue
+++ b/app/frontend/src/components/designer/FormsTable.vue
@@ -14,7 +14,18 @@ export default {
   },
   data() {
     return {
-      headers: [
+      formId: null,
+      showDescriptionDialog: false,
+      loading: true,
+      formDescription: null,
+      search: null,
+    };
+  },
+  computed: {
+    ...mapState(useFormStore, ['formList', 'isRTL', 'lang']),
+    ...mapState(useAuthStore, ['user']),
+    headers() {
+      return [
         {
           title: i18n.t('trans.formsTable.formTitle'),
           align: 'start',
@@ -29,17 +40,8 @@ export default {
           sortable: false,
           width: '1%',
         },
-      ],
-      formId: null,
-      showDescriptionDialog: false,
-      loading: true,
-      formDescription: null,
-      search: null,
-    };
-  },
-  computed: {
-    ...mapState(useFormStore, ['formList', 'isRTL', 'lang']),
-    ...mapState(useAuthStore, ['user']),
+      ];
+    },
     canCreateForm() {
       return this.user.idp === IdentityProviders.IDIR;
     },

--- a/app/frontend/src/components/forms/manage/TeamManagement.vue
+++ b/app/frontend/src/components/forms/manage/TeamManagement.vue
@@ -60,7 +60,7 @@ export default {
     },
     DeleteMessage() {
       return this.itemsToDelete.length > 1
-        ? i18n.t('trans.teamManagement.delSelectedMembersWarning"')
+        ? i18n.t('trans.teamManagement.delSelectedMembersWarning')
         : i18n.t('trans.teamManagement.delSelectedMemberWarning');
     },
     DEFAULT_HEADERS() {

--- a/app/frontend/src/internationalization/trans/chefs/ar/ar.json
+++ b/app/frontend/src/internationalization/trans/chefs/ar/ar.json
@@ -858,7 +858,8 @@
     "submissnHistory": "تاريخ التقديم الخاص بك (يتم تحديده لاحقًا)"
   },
   "error": {
-    "logout": "تسجيل خروج"
+    "logout": "تسجيل خروج",
+    "somethingWentWrong": "خطأ: حدث خطأ ما... :("
   },
   "login": {
     "authenticateWith": "المصادقة مع:",

--- a/app/frontend/src/views/Error.vue
+++ b/app/frontend/src/views/Error.vue
@@ -12,7 +12,7 @@ export default {
       type: String,
     },
     translate: {
-      default: false,
+      default: true,
       type: Boolean,
     },
   },
@@ -26,7 +26,7 @@ export default {
         text = i18n.t(text.text, text.options);
       } catch {
         // Can't parse JSON so it's probably already a locale
-        if (this.translate) text = i18n.t(text);
+        text = this.translate ? i18n.t(text) : text;
       }
       return text;
     },

--- a/app/frontend/src/views/form/Success.vue
+++ b/app/frontend/src/views/form/Success.vue
@@ -40,7 +40,7 @@ export default {
           <div v-if="form.showSubmissionConfirmation">
             <h3>
               <span class="d-print-none" :lang="lang">
-                {{ $t('trans.sucess.keepRecord') }}
+                {{ $t('trans.sucess.keepRecord') }}{{ ' ' }}
               </span>
               <span :lang="lang">
                 {{ $t('trans.sucess.confirmationId') }}:

--- a/app/frontend/tests/unit/components/admin/AdministerFormsTable.spec.js
+++ b/app/frontend/tests/unit/components/admin/AdministerFormsTable.spec.js
@@ -79,4 +79,48 @@ describe('AdministerFormsTable.vue', () => {
     expect(store.getForms).toHaveBeenCalledTimes(3);
     expect(store.getForms).toHaveBeenLastCalledWith(true);
   });
+
+  it('headers shown active forms', async () => {
+    const wrapper = mount(AdministerFormsTable, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RouterLink: ROUTER_LINK,
+        },
+      },
+    });
+    
+    const thead = wrapper.find('thead');
+    const th = thead.findAll('.v-data-table__td');
+    expect(th.length).toBe(3);
+    expect(th[0].text()).toMatch('trans.adminFormsTable.formTitle');
+    expect(th[1].text()).toMatch('trans.adminFormsTable.created');
+    expect(th[2].text()).toMatch('trans.adminFormsTable.actions');
+
+  });
+
+  it('headers shown deleted forms', async () => {
+    const wrapper = mount(AdministerFormsTable, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RouterLink: ROUTER_LINK,
+        },
+      },
+    });
+    
+    const showDeleted = wrapper.findComponent(CHECKBOX_SHOW_DELETED);
+    showDeleted.setValue(true);
+    await nextTick();
+
+    const thead = wrapper.find('thead');
+    const th = thead.findAll('.v-data-table__td');
+
+    expect(th.length).toBe(4);
+    expect(th[0].text()).toMatch('trans.adminFormsTable.formTitle');
+    expect(th[1].text()).toMatch('trans.adminFormsTable.created');
+    expect(th[2].text()).toMatch('trans.adminFormsTable.deleted');
+    expect(th[3].text()).toMatch('trans.adminFormsTable.actions');
+
+  });
 });


### PR DESCRIPTION
The following PR aims to fix issues introduced in the Vue3 migration.

Fixed few translation issues
few alerts/error notifications not translating
form table headers not properly translating on language change
Fixed the logic in the active forms in the Admin Page - it would display the "deleted" header for active forms, but would not for the deleted forms.
More info can be found here: https://bcdevex.atlassian.net/browse/FORMS-925


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
