### PR TITLE
feat: FORMS-926 added utils.getBaseUrl for notification urls

### DIFF
--- a/app/src/forms/common/utils.js
+++ b/app/src/forms/common/utils.js
@@ -1,3 +1,4 @@
+const config = require('config');
 const falsey = require('falsey');
 const moment = require('moment');
 const clone = require('lodash/clone');
@@ -7,6 +8,35 @@ const setupMount = (type, app, routes, dataErrors) => {
   app.use(p, routes);
   app.use(dataErrors);
   return p;
+};
+
+/**
+ * Gets the base url used when providing links to the application, such as in
+ * emails that are sent out by the application. Handles both localhost and
+ * deployed versions of the application, in the form:
+ *  - http://localhost:5173/app (localhost development including port)
+ *  - https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-1234 (pr deployment)
+ *  - https://chefs-dev.apps.silver.devops.gov.bc.ca/app (non-prod deployment)
+ *  - https://submit.digital.gov.bc.ca/app (vanity url deployment)
+ * @returns a string containing the base url
+ */
+const getBaseUrl = () => {
+  let protocol = 'https';
+  let host = process.env.SERVER_HOST;
+
+  if (!host) {
+    protocol = 'http';
+    host = 'localhost';
+
+    // This only needs to be defined to use the email links in local dev.
+    if (config.has('frontend.localhostPort')) {
+      host += ':' + config.get('frontend.localhostPort');
+    }
+  }
+
+  const basePath = config.get('frontend.basePath');
+
+  return `${protocol}://${host}${basePath}`;
 };
 
 const typeUtils = {
@@ -729,6 +759,7 @@ const isClosingMessageValid = (schedule) => {
 
 module.exports = {
   falsey,
+  getBaseUrl,
   setupMount,
   queryUtils,
   typeUtils,

--- a/app/src/forms/email/emailService.js
+++ b/app/src/forms/email/emailService.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const Handlebars = require('handlebars');
 const path = require('path');
 
+const { getBaseUrl } = require('../common/utils');
 const chesService = require('../../components/chesService');
 const log = require('../../components/log')(module.filename);
 const { EmailProperties, EmailTypes } = require('../common/constants');
@@ -120,16 +121,18 @@ const buildEmailTemplate = async (formId, formSubmissionId, emailType, referer, 
     };
   }
 
+  const baseUrl = getBaseUrl();
+
   return {
     configData,
     contexts: [
       {
         context: {
-          allFormSubmissionUrl: `${service._appUrl(referer)}/user/submissions?f=${configData.form.id}`,
+          allFormSubmissionUrl: `${baseUrl}/user/submissions?f=${configData.form.id}`,
           confirmationNumber: submission.confirmationId,
           form: configData.form,
           messageLinkText: configData.messageLinkText,
-          messageLinkUrl: `${service._appUrl(referer)}/${userTypePath}?s=${submission.id}`,
+          messageLinkUrl: `${baseUrl}/${userTypePath}?s=${submission.id}`,
           emailContent: additionalProperties.emailContent,
           title: configData.title,
         },
@@ -202,27 +205,6 @@ const buildEmailTemplateFormForReminder = async (form, emailType, users, report,
 };
 
 const service = {
-  /**
-   * @function _appUrl
-   * Attempts to parse out the base application url
-   * @param {string} referer
-   * @returns base url for the application
-   */
-  _appUrl: (referer) => {
-    try {
-      const url = new URL(referer);
-      const p = url.pathname.split('/')[1];
-      const u = url.href.substring(0, url.href.indexOf(`/${p}`));
-      return `${u}/${p}`;
-    } catch (err) {
-      log.error(err.message, {
-        function: '_appUrl',
-        referer: referer,
-      });
-      throw err;
-    }
-  },
-
   /**
    * @function _mergeEmailTemplate
    * Merges the template and body HTML files to allow dynamic content in the emails
@@ -492,7 +474,7 @@ const service = {
           context: {
             form: configData.form,
             messageLinkText: configData.messageLinkText,
-            messageLinkUrl: `${service._appUrl(referer)}/${userTypePath}?id=${fileId}`,
+            messageLinkUrl: getBaseUrl() + `/${userTypePath}?id=${fileId}`,
             title: configData.title,
           },
           to: contextToVal,

--- a/app/src/forms/email/reminderService.js
+++ b/app/src/forms/email/reminderService.js
@@ -1,9 +1,7 @@
-const { getAvailableDates } = require('../common/utils');
+const { getAvailableDates, getBaseUrl } = require('../common/utils');
 const emailService = require('./emailService');
 const moment = require('moment');
 const { EmailTypes, ScheduleType } = require('../common/constants');
-const config = require('config');
-const log = require('../../components/log')(module.filename);
 const { SubmissionData, UserFormAccess, Form } = require('../common/models');
 const { Roles } = require('../common/constants');
 
@@ -13,7 +11,7 @@ const service = {
 
     const q = await service._getReminders(forms);
 
-    const referer = service._getReferer();
+    const referer = getBaseUrl();
     const resolve = [];
     const errors = [];
     let mail = 0;
@@ -263,21 +261,6 @@ const service = {
       statement.submitters = obj.submitters;
     }
     return statement;
-  },
-  _getReferer: () => {
-    // We create this function because in the header we cant get the real referer but
-    // this function allow us to generate the referer dynamicly
-    try {
-      const protocol = 'https://';
-      const basePath = config.get('frontend.basePath');
-      const host = process.env.SERVER_HOST;
-      return `${protocol}${host}${basePath}`;
-    } catch (error) {
-      log.error(error.message, {
-        function: '_getReferer',
-      });
-      throw error;
-    }
   },
   _initMailSender: async (statement, referer) => {
     const chesResponse = [];

--- a/app/tests/unit/forms/common/utils.spec.js
+++ b/app/tests/unit/forms/common/utils.spec.js
@@ -1,4 +1,60 @@
-const { queryUtils, typeUtils, validateScheduleObject } = require('../../../../src/forms/common/utils');
+const config = require('config');
+
+const { getBaseUrl, queryUtils, typeUtils, validateScheduleObject } = require('../../../../src/forms/common/utils');
+
+jest.mock('config');
+
+describe('getBaseUrl', () => {
+  const basePath = '/app';
+  const basePathPr = '/pr-1234';
+  const localhostPort = '5173';
+  const serverDev = 'chefs-dev.apps.silver.devops.gov.bc.ca';
+  const serverProd = 'submit.digital.gov.bc.ca';
+
+  it('should return a default for local development', () => {
+    config.get.mockReturnValue(basePath);
+
+    const baseUrl = getBaseUrl();
+
+    expect(baseUrl).toEqual(`http://localhost${basePath}`);
+  });
+
+  it('should return a default with port for local development', () => {
+    config.get = jest.fn((k) => (k === 'frontend.basePath' ? basePath : localhostPort));
+    config.has.mockReturnValue(true);
+
+    const baseUrl = getBaseUrl();
+
+    expect(baseUrl).toEqual(`http://localhost:${localhostPort}${basePath}`);
+  });
+
+  it('should handle non-prod SERVER_URL variable', () => {
+    process.env.SERVER_HOST = serverDev;
+    config.get.mockReturnValue(basePath);
+
+    const baseUrl = getBaseUrl();
+
+    expect(baseUrl).toEqual(`https://${serverDev}${basePath}`);
+  });
+
+  it('should handle non-prod SERVER_URL variable for PRs', () => {
+    process.env.SERVER_HOST = serverDev;
+    config.get.mockReturnValue(basePathPr);
+
+    const baseUrl = getBaseUrl();
+
+    expect(baseUrl).toEqual(`https://${serverDev}${basePathPr}`);
+  });
+
+  it('should handle prod SERVER_URL variable', () => {
+    process.env.SERVER_HOST = serverProd;
+    config.get.mockReturnValue(basePath);
+
+    const baseUrl = getBaseUrl();
+
+    expect(baseUrl).toEqual(`https://${serverProd}${basePath}`);
+  });
+});
 
 describe('Test Query Utils functions', () => {
   it('defaultActiveOnly should return params object', () => {

--- a/app/tests/unit/forms/email/emailService.spec.js
+++ b/app/tests/unit/forms/email/emailService.spec.js
@@ -6,19 +6,6 @@ const mockedReadFileSync = jest.spyOn(fs, 'readFileSync');
 
 const referer = 'https://submit.digital.gov.bc.ca';
 
-describe('_appUrl', () => {
-  it('should format the url', () => {
-    expect(emailService._appUrl('https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-139/form/success?s=13978f3b-056b-4022-9a30-60d3b63ec459')).toEqual(
-      'https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-139'
-    );
-    expect(emailService._appUrl('https://chefs.nrs.gov.bc.ca/app/form/success?s=13978f3b-056b-4022-9a30-60d3b63ec459')).toEqual('https://chefs.nrs.gov.bc.ca/app');
-  });
-
-  it('should rethrow exceptions', () => {
-    expect(() => emailService._appUrl('notaurl')).toThrow('Invalid URL');
-  });
-});
-
 describe('_mergeEmailTemplate', () => {
   it('should merge two html files', () => {
     mockedReadFileSync.mockReturnValueOnce('<!-- BODY END -->').mockReturnValueOnce('<h1>New Body</h1>');
@@ -125,6 +112,8 @@ describe('public methods', () => {
   const body_low = { priority: 'low', to: 'a@b.com' };
   const body_normal = { priority: 'normal', to: 'a@b.com' };
   const emailContent = 'Email Content';
+  const baseUrl = 'http://localhost/app';
+  const allFormSubmissionUrl = `${baseUrl}/user/submissions?f=xxx-yyy`;
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -147,11 +136,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: 'You have been assigned to a 123 submission. Please login to review it.',
-          messageLinkUrl: 'https://form/view?s=123',
+          messageLinkUrl: `${baseUrl}/form/view?s=123`,
           emailContent: 'Email Content',
           title: '123 Submission Assignment',
         },
@@ -181,11 +170,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `You have been asked to revise a ${form.name} submission. Please login to review it.`,
-          messageLinkUrl: `https://user/view?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/user/view?s=${form.name}`,
           emailContent: 'Email Content',
           title: `${form.name} Submission Revision Requested`,
         },
@@ -215,11 +204,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `Your submission from ${form.name} has been Completed.`,
-          messageLinkUrl: `https://user/view?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/user/view?s=${form.name}`,
           emailContent: 'Email Content',
           title: `${form.name} Has Been Completed`,
         },
@@ -256,11 +245,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form_idir,
           messageLinkText: `Thank you for your ${form_idir.name} submission. You can view your submission details by visiting the following links:`,
-          messageLinkUrl: `https://form/success?s=${form_idir.name}`,
+          messageLinkUrl: `${baseUrl}/form/success?s=${form_idir.name}`,
           revisionNotificationEmailContent: undefined,
           title: `${form_idir.name} Accepted`,
         },
@@ -301,11 +290,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `Thank you for your ${form.name} submission. You can view your submission details by visiting the following links:`,
-          messageLinkUrl: `https://form/success?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/form/success?s=${form.name}`,
           revisionNotificationEmailContent: undefined,
           title: `${form.name} Accepted`,
         },
@@ -346,11 +335,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `Thank you for your ${form.name} submission. You can view your submission details by visiting the following links:`,
-          messageLinkUrl: `https://form/success?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/form/success?s=${form.name}`,
           revisionNotificationEmailContent: undefined,
           title: `${form.name} Accepted`,
         },
@@ -391,11 +380,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `Thank you for your ${form.name} submission. You can view your submission details by visiting the following links:`,
-          messageLinkUrl: `https://form/success?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/form/success?s=${form.name}`,
           revisionNotificationEmailContent: undefined,
           title: `${form.name} Accepted`,
         },
@@ -436,11 +425,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `Thank you for your ${form.name} submission regarding . You can view your submission details by visiting the following links:`,
-          messageLinkUrl: `https://form/success?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/form/success?s=${form.name}`,
           revisionNotificationEmailContent: undefined,
           title: `${form.name} Accepted`,
         },
@@ -486,11 +475,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `There is a new ${form.name} submission. Please login to review it.`,
-          messageLinkUrl: `https://form/view?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/form/view?s=${form.name}`,
           revisionNotificationEmailContent: undefined,
           title: `${form.name} Submission`,
         },
@@ -527,11 +516,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `You have been uninvited from ${form.name} submission draft.`,
-          messageLinkUrl: `https://user/view?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/user/view?s=${form.name}`,
           revisionNotificationEmailContent: undefined,
           title: `Uninvited From ${form.name} Draft`,
         },
@@ -565,11 +554,11 @@ describe('public methods', () => {
     const contexts = [
       {
         context: {
-          allFormSubmissionUrl: 'https://user/submissions?f=xxx-yyy',
+          allFormSubmissionUrl: allFormSubmissionUrl,
           confirmationNumber: 'abc',
           form: form,
           messageLinkText: `You have been invited to a ${form.name} submission draft. You can review your submission draft details by visiting the following links:`,
-          messageLinkUrl: `https://user/view?s=${form.name}`,
+          messageLinkUrl: `${baseUrl}/user/view?s=${form.name}`,
           revisionNotificationEmailContent: undefined,
           title: `Invited to ${form.name} Draft`,
         },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If a form has “After Submission” team notification emails configured, they will fail if a submission is sent in via an API call. The `emailService._appUrl` method takes a `referer` parameter that is used to construct the protocol, domain name, and port portions of the URL to the resulting submission. When the request is an API call without the `referer`, it’s failing with an `Invalid URL` error. 

Since the API call will not be including a `referer`, another way must be found to construct the URLs. The fix should work for the various types of URLs that we have:
- http://localhost:5173/app/…
- https://chefs-dev.apps.silver.devops.gov.bc.ca/app/…
- https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-1111/…
- https://submit.digital.gov.bc.c.a/app/…

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Noticed that `reminderService._getReferer` has the fix needed for `emailService._appUrl`. Replaced both with a new utility function `getBaseUrl`.