### PR TITLE
fix: FORMS-942-copy-submission-also-copies-old-form-version

### DIFF
--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -272,7 +272,9 @@ export default {
             ? false
             : true;
         this.form = response.data.form;
-        this.versionIdToSubmitTo = response.data?.version?.id;
+        this.versionIdToSubmitTo = this.versionIdToSubmitTo
+          ? this.versionIdToSubmitTo
+          : response.data?.version?.id;
         if (!this.isDuplicate) {
           //As we know this is a Submission from existing one so we will wait for the latest version to be set on the getFormSchema
           this.formSchema = response.data.version.schema;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

When copying a submission from a previous form version, it copies the old form version as well. After initially copying the submission, the page shows the latest form version; however, after submitting the copied form, it reverts back to the old form version. 

Reported on the Bug/Defect Page: https://bcdevex.atlassian.net/wiki/spaces/CCP/pages/1292435473/Copy+submission+also+copies+old+form+version

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
