### PR TITLE
fix: FORMS-948 use dataErrors only one time

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -8,6 +8,7 @@ const querystring = require('querystring');
 const keycloak = require('./src/components/keycloak');
 const log = require('./src/components/log')(module.filename);
 const httpLogger = require('./src/components/log').httpLogger;
+const middleware = require('./src/forms/common/middleware');
 const v1Router = require('./src/routes/v1');
 
 const DataConnection = require('./src/db/dataConnection');
@@ -72,6 +73,7 @@ apiRouter.get('/api', (_req, res) => {
 // Host API endpoints
 apiRouter.use(config.get('server.apiPath'), v1Router);
 app.use(config.get('server.basePath'), apiRouter);
+app.use(middleware.dataErrors);
 
 // Host the static frontend assets
 const staticFilesPath = config.get('frontend.basePath');

--- a/app/src/forms/admin/index.js
+++ b/app/src/forms/admin/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('admin', app, routes, dataErrors);
+  return setupMount('admin', app, routes);
 };

--- a/app/src/forms/bcgeoaddress/index.js
+++ b/app/src/forms/bcgeoaddress/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('bcgeoaddress', app, routes, dataErrors);
+  return setupMount('bcgeoaddress', app, routes);
 };

--- a/app/src/forms/common/middleware/dataErrors.js
+++ b/app/src/forms/common/middleware/dataErrors.js
@@ -1,7 +1,7 @@
 const Problem = require('api-problem');
 const Objection = require('objection');
 
-module.exports.dataErrors = async (err, req, res, next) => {
+module.exports.dataErrors = async (err, _req, _res, next) => {
   let error = err;
   if (err instanceof Objection.NotFoundError) {
     error = new Problem(404, {

--- a/app/src/forms/common/utils.js
+++ b/app/src/forms/common/utils.js
@@ -3,10 +3,11 @@ const falsey = require('falsey');
 const moment = require('moment');
 const clone = require('lodash/clone');
 const _ = require('lodash');
-const setupMount = (type, app, routes, dataErrors) => {
+
+const setupMount = (type, app, routes) => {
   const p = `/${type}`;
   app.use(p, routes);
-  app.use(dataErrors);
+
   return p;
 };
 

--- a/app/src/forms/file/index.js
+++ b/app/src/forms/file/index.js
@@ -1,5 +1,4 @@
 const config = require('config');
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 
 const _PATH = config.get('files.uploads.path') || 'files';
@@ -16,6 +15,5 @@ fileUpload.init({
 module.exports.mount = (app) => {
   const p = `/${_PATH}`;
   app.use(p, routes);
-  app.use(dataErrors);
   return p;
 };

--- a/app/src/forms/form/index.js
+++ b/app/src/forms/form/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('forms', app, routes, dataErrors);
+  return setupMount('forms', app, routes);
 };

--- a/app/src/forms/permission/index.js
+++ b/app/src/forms/permission/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('permissions', app, routes, dataErrors);
+  return setupMount('permissions', app, routes);
 };

--- a/app/src/forms/public/index.js
+++ b/app/src/forms/public/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('public', app, routes, dataErrors);
+  return setupMount('public', app, routes);
 };

--- a/app/src/forms/rbac/index.js
+++ b/app/src/forms/rbac/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('rbac', app, routes, dataErrors);
+  return setupMount('rbac', app, routes);
 };

--- a/app/src/forms/role/index.js
+++ b/app/src/forms/role/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('roles', app, routes, dataErrors);
+  return setupMount('roles', app, routes);
 };

--- a/app/src/forms/submission/index.js
+++ b/app/src/forms/submission/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('submissions', app, routes, dataErrors);
+  return setupMount('submissions', app, routes);
 };

--- a/app/src/forms/user/index.js
+++ b/app/src/forms/user/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('users', app, routes, dataErrors);
+  return setupMount('users', app, routes);
 };

--- a/app/src/forms/utils/index.js
+++ b/app/src/forms/utils/index.js
@@ -1,7 +1,6 @@
-const dataErrors = require('../common/middleware').dataErrors;
 const routes = require('./routes');
 const setupMount = require('../common/utils').setupMount;
 
 module.exports.mount = (app) => {
-  return setupMount('utils', app, routes, dataErrors);
+  return setupMount('utils', app, routes);
 };

--- a/app/tests/unit/forms/common/middleware/dataErrors.spec.js
+++ b/app/tests/unit/forms/common/middleware/dataErrors.spec.js
@@ -1,0 +1,42 @@
+const Problem = require('api-problem');
+const Objection = require('objection');
+
+const middleware = require('../../../../../src/forms/common/middleware');
+
+describe('test data errors middleware', () => {
+  it('should handle an objection data error', () => {
+    const error = new Objection.DataError({ nativeError: { message: 'This is a DataError' } });
+    const next = jest.fn();
+
+    middleware.dataErrors(error, {}, {}, next);
+
+    expect(next).toBeCalledWith(expect.objectContaining({ status: 422 }));
+  });
+
+  it('should handle an objection not found error', () => {
+    const error = new Objection.NotFoundError({ nativeError: { message: 'This is a NotFoundError' } });
+    const next = jest.fn();
+
+    middleware.dataErrors(error, {}, {}, next);
+
+    expect(next).toBeCalledWith(expect.objectContaining({ status: 404 }));
+  });
+
+  it('should handle an objection validation error', () => {
+    const error = new Objection.ValidationError({ nativeError: { message: 'This is a ValidationError' } });
+    const next = jest.fn();
+
+    middleware.dataErrors(error, {}, {}, next);
+
+    expect(next).toBeCalledWith(expect.objectContaining({ status: 422 }));
+  });
+
+  it('should pass through any problem', () => {
+    const error = new Problem(400);
+    const next = jest.fn();
+
+    middleware.dataErrors(error, {}, {}, next);
+
+    expect(next).toBeCalledWith(expect.objectContaining({ status: 400 }));
+  });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The function `common/utils/setupMount` is doing `app.use(dataErrors)` but this is a global `use` that should only ever be done once. Because `setupMount` is called from multiple `index.js` files, when an error is thrown the error handling function is being called repeatedly. Using `dataErrors` once will simplify the code and the runtime will be faster and less complicated.

(Ran into a problem when trying to modify `dataErrors` in that the changes needed to handle being run multiple times - not ideal!)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

We need to set up some sort of integration tests (postman, etc) to regression test this sort of thing (unless someone can think of a way of unit testing it! I did add tests to cover `dataErrors`, but those don't test that its integrated - and only once - with the routes).

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
