### PR TITLE
feat: FORMS-916 add Confirmation ID and Submission ID to data available in CDOGS

### DIFF
--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -122,7 +122,16 @@ module.exports = {
   templateUploadAndRender: async (req, res, next) => {
     try {
       const submission = await service.read(req.params.formSubmissionId);
-      const templateBody = { ...req.body, data: submission.submission.submission.data };
+      const templateBody = {
+        ...req.body,
+        data: {
+          ...submission.submission.submission.data,
+          chefs: {
+            confirmationId: submission.submission.confirmationId,
+            submissionId: submission.submission.id,
+          },
+        },
+      };
       const { data, headers, status } = await cdogsService.templateUploadAndRender(templateBody);
       const contentDisposition = headers['content-disposition'];
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

A request has come in from the Teams channel (2023-11-16 11:24 a.m. - Jeremy K.) to be able to include the submission’s Confirmation ID in a CDOGS template. As this field is currently not available in the data sent to CDOGS, it cannot be used in the template.

A couple of catches!
- If we just add `confirmationId` and have it accessible in the CDOGS template as `d.confirmationId` there is the chance that someone could have a field on their form that is also called `confirmationId`. We have seen this problem in the exports. Maybe it would be less likely to have a problem if we were to use it on the form as `d.chefs.confirmationId`?
- If we make the Confirmation ID available, we should also make the Submission ID available. Follow whatever pattern is used for the Confirmation ID, such as `d.chefs.submissionId`. 

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
