### PR TITLE
fix: FORMS-951 file upload workaround for auth store reactivity problem

### DIFF
--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -112,7 +112,7 @@ export default {
     ...mapState(useAppStore, ['config']),
     ...mapState(useAuthStore, [
       'authenticated',
-      'token',
+      'keycloak',
       'tokenParsed',
       'user',
     ]),
@@ -192,7 +192,7 @@ export default {
     ...mapActions(useNotificationStore, ['addNotification']),
     isFormPublic: isFormPublic,
     getCurrentAuthHeader() {
-      return `Bearer ${this.token}`;
+      return `Bearer ${this.keycloak.token}`;
     },
     async getFormData() {
       function iterate(obj, stack, fields, propNeeded) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The JEDI folks reported that file attachments are causing 403 errors. This was reproduced in dev using a new form containing a Data Grid containing a File Upload component. The form was saved and previewed, and a couple of dozen of attachments were added, and it worked fine. Waited 15 minutes and tried again and it failed with a 403. Probably has nothing to do with the Data Grid either, just the amount of time since the form was opened, and probably something about the SSO token timeout.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

This should be viewed as a temporary fix. We need to sort out why the Pinia stores aren't reactive.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
