### PR TITLE
feat: FORMS-950 only use express error handling for 500s

### DIFF
--- a/app/tests/unit/forms/common/middleware/dataErrors.spec.js
+++ b/app/tests/unit/forms/common/middleware/dataErrors.spec.js
@@ -1,3 +1,4 @@
+const { getMockRes } = require('@jest-mock/express');
 const Problem = require('api-problem');
 const Objection = require('objection');
 
@@ -6,37 +7,63 @@ const middleware = require('../../../../../src/forms/common/middleware');
 describe('test data errors middleware', () => {
   it('should handle an objection data error', () => {
     const error = new Objection.DataError({ nativeError: { message: 'This is a DataError' } });
+    const { res } = getMockRes();
     const next = jest.fn();
 
-    middleware.dataErrors(error, {}, {}, next);
+    middleware.dataErrors(error, {}, res, next);
 
-    expect(next).toBeCalledWith(expect.objectContaining({ status: 422 }));
+    expect(next).not.toBeCalled();
+    expect(res.end).toBeCalledWith(expect.stringContaining('422'));
   });
 
   it('should handle an objection not found error', () => {
     const error = new Objection.NotFoundError({ nativeError: { message: 'This is a NotFoundError' } });
+    const { res } = getMockRes();
     const next = jest.fn();
 
-    middleware.dataErrors(error, {}, {}, next);
+    middleware.dataErrors(error, {}, res, next);
 
-    expect(next).toBeCalledWith(expect.objectContaining({ status: 404 }));
+    expect(next).not.toBeCalled();
+    expect(res.end).toBeCalledWith(expect.stringContaining('404'));
   });
 
   it('should handle an objection validation error', () => {
     const error = new Objection.ValidationError({ nativeError: { message: 'This is a ValidationError' } });
+    const { res } = getMockRes();
     const next = jest.fn();
 
-    middleware.dataErrors(error, {}, {}, next);
+    middleware.dataErrors(error, {}, res, next);
 
-    expect(next).toBeCalledWith(expect.objectContaining({ status: 422 }));
+    expect(next).not.toBeCalled();
+    expect(res.end).toBeCalledWith(expect.stringContaining('422'));
   });
 
-  it('should pass through any problem', () => {
-    const error = new Problem(400);
+  it('should handle any non-500 Problems', () => {
+    const error = new Problem(429);
+    const { res } = getMockRes();
+    const next = jest.fn();
+
+    middleware.dataErrors(error, {}, res, next);
+
+    expect(next).not.toBeCalled();
+    expect(res.end).toBeCalledWith(expect.stringContaining('429'));
+  });
+
+  it('should pass through any 500s', () => {
+    const error = new Problem(500);
     const next = jest.fn();
 
     middleware.dataErrors(error, {}, {}, next);
 
-    expect(next).toBeCalledWith(expect.objectContaining({ status: 400 }));
+    expect(next).toBeCalledWith(error);
+  });
+
+  it('should pass through any Errors', () => {
+    const error = new Error();
+    const next = jest.fn();
+
+    middleware.dataErrors(error, {}, {}, next);
+
+    expect(next).toBeCalledWith(error);
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If a Problem is being created but not handled, it is eventually handled by the default express middleware error handler. This error handler will correctly return the response to the caller, but will also log the Problem as an ERROR. This is useful when there are unexpected errors in the API, but this logging is not wanted when the problems are due to things like malformed API Key calls. Logging as ERROR should only ever be done when something unexpected happens in the API and it needs to be investigated and fixed.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
