### PR TITLE
fix: FORMS-954 express update to handle proxied ip addresses

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -75,6 +75,14 @@ apiRouter.use(config.get('server.apiPath'), v1Router);
 app.use(config.get('server.basePath'), apiRouter);
 app.use(middleware.dataErrors);
 
+// Temporary.
+app.set('trust proxy', 1);
+app.get(config.get('server.basePath') + config.get('server.apiPath') + '/ip', (req, res) => {
+  console.error('------------->', req);
+  return res.send(req.ip);
+});
+app.get(config.get('server.basePath') + config.get('server.apiPath') + '/x-forwarded-for', (request, response) => response.send(request.headers['x-forwarded-for']));
+
 // Host the static frontend assets
 const staticFilesPath = config.get('frontend.basePath');
 app.use('/favicon.ico', (_req, res) => {

--- a/app/app.js
+++ b/app/app.js
@@ -27,6 +27,11 @@ app.use(compression());
 app.use(express.json({ limit: config.get('server.bodyLimit') }));
 app.use(express.urlencoded({ extended: true }));
 
+// Express needs to know about the OpenShift proxy. With this setting Express
+// pulls the IP address from the headers, rather than use the proxy IP address.
+// See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR
+app.set('trust proxy', 1);
+
 // Skip if running tests
 if (process.env.NODE_ENV !== 'test') {
   // Initialize connections and exit if unsuccessful


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The new custom Rate Limiter middleware for Express is causing the following error message on the first basic auth call to the API:

> ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users. See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/ for more information.

This could indicate that we are rate limiting based on a proxy IP address rather than the original IP address of the requester. Need to double-check that this is not the case.

Also look at the IP address being logged - these do not seem to be IP addresses of the requesters, but rather something in between. The problem is probably that we’re logging the proxy IP addresses rather than the requester’s IP address.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
