### PR TITLE
Added confirmation id and submission id to cdogs template

### DIFF
--- a/app/frontend/src/components/designer/FormViewerActions.vue
+++ b/app/frontend/src/components/designer/FormViewerActions.vue
@@ -107,8 +107,8 @@ export default {
         </v-tooltip>
       </span>
 
-      <span v-if="draftEnabled" class="ml-2">
-        <PrintOptions :submission="submission" />
+      <span class="ml-2 d-print-none">
+        <PrintOptions :submission="submission" :submission-id="submissionId" />
       </span>
 
       <!-- Save a draft -->


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
# Description
Resolves the issue where the print option would disappear if the submission was not a draft. Resolves the issue where confirmation id and submission id were not appearing in the cdogs print. This was simply because we weren't passing the submissionId to the PrintOptions. Also hid the print button when printing manually.

It does appear that the draft template render is meant to be used by CHEFS whereas the submission template render can be accessed by the API.

This resolves: https://bcdevex.atlassian.net/browse/FORMS-952

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
