### PR TITLE
feat: Frontend component for GET /files API

### DIFF
--- a/app/frontend/src/components/forms/manage/ApiKey.vue
+++ b/app/frontend/src/components/forms/manage/ApiKey.vue
@@ -17,6 +17,7 @@ export default {
       showConfirmationDialog: false,
       showDeleteDialog: false,
       showSecret: false,
+      filesAPIAccess: false,
     };
   },
   computed: {
@@ -58,7 +59,7 @@ export default {
     ]),
     async createKey() {
       this.loading = true;
-      await this.generateApiKey(this.form.id);
+      await this.generateApiKey(this.form.id, this.filesAPIAccess);
       this.showSecret = false;
       this.loading = false;
       this.showConfirmationDialog = false;
@@ -74,6 +75,7 @@ export default {
     async readKey() {
       this.loading = true;
       await this.readApiKey(this.form.id);
+      this.filesAPIAccess = this.apiKey?.filesAPIAccess;
       this.loading = false;
     },
     showHideKey() {
@@ -234,4 +236,12 @@ export default {
       </template>
     </BaseDialog>
   </div>
+  <v-row>
+    <v-col>
+      <v-checkbox
+        v-model="filesAPIAccess"
+        label="Allow this API key to access files"
+      ></v-checkbox>
+    </v-col>
+  </v-row>
 </template>

--- a/app/frontend/src/services/apiKeyService.js
+++ b/app/frontend/src/services/apiKeyService.js
@@ -18,8 +18,10 @@ export default {
    * @param {string} formId The form uuid
    * @returns {Promise} An axios response
    */
-  generateApiKey(formId) {
-    return appAxios().put(`${ApiRoutes.FORMS}/${formId}${ApiRoutes.APIKEY}`);
+  generateApiKey(formId, filesAPIAccess) {
+    return appAxios().put(`${ApiRoutes.FORMS}/${formId}${ApiRoutes.APIKEY}`, {
+      filesAPIAccess,
+    });
   },
 
   /**

--- a/app/frontend/src/store/form.js
+++ b/app/frontend/src/store/form.js
@@ -710,10 +710,13 @@ export const useFormStore = defineStore('form', {
         });
       }
     },
-    async generateApiKey(formId) {
+    async generateApiKey(formId, filesAPIAccess) {
       const notificationStore = useNotificationStore();
       try {
-        const { data } = await apiKeyService.generateApiKey(formId);
+        const { data } = await apiKeyService.generateApiKey(
+          formId,
+          filesAPIAccess
+        );
         this.apiKey = data;
         notificationStore.addNotification({
           text: i18n.t('trans.store.form.generateApiKeyNotifyMsg'),

--- a/app/src/db/migrations/20210721210234_019-api-key-models.js
+++ b/app/src/db/migrations/20210721210234_019-api-key-models.js
@@ -89,6 +89,7 @@ exports.up = function (knex) {
       );
       table.uuid('formId').references('id').inTable('form').notNullable().index();
       table.uuid('secret').unique().notNullable();
+      table.boolean('filesAPIAccess').defaultTo(false);
       stamps(knex, table);
     }))
 

--- a/app/src/forms/auth/middleware/apiAccess.js
+++ b/app/src/forms/auth/middleware/apiAccess.js
@@ -31,6 +31,15 @@ module.exports = async (req, res, next) => {
         }
         const result = await submissionService.read(sid.formSubmissionId);
         formId = result?.form?.id;
+
+        let filesAPIAccess = false; // Must be initialized as a boolean
+        if (formId && uuidValidate(formId)) {
+          const result = await formService.readApiKey(formId);
+          filesAPIAccess = result && result.filesAPIAccess ? result.filesAPIAccess : false;
+          if (!filesAPIAccess) {
+            return next(new Problem(403, { detail: 'Files API access is not enabled for this form.' }));
+          }
+        }
       }
 
       let secret = ''; // Must be initialized as a string

--- a/app/src/forms/common/models/tables/formApiKey.js
+++ b/app/src/forms/common/models/tables/formApiKey.js
@@ -26,6 +26,7 @@ class FormApiKey extends Timestamps(Model) {
         id: { type: 'integer' },
         formId: { type: 'string', pattern: Regex.UUID },
         secret: { type: 'string', pattern: Regex.UUID },
+        filesAPIAccess: { type: 'boolean', default: false },
         ...stamps,
       },
       additionalProperties: false,

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -242,9 +242,9 @@ module.exports = {
       next(error);
     }
   },
-  createOrReplaceApiKey: async (req, res, next) => {
+  createOrReplaceApiKey: async (req, res, next, filesAPIAccess) => {
     try {
-      const response = await service.createOrReplaceApiKey(req.params.formId, req.currentUser);
+      const response = await service.createOrReplaceApiKey(req.params.formId, req.currentUser, filesAPIAccess);
       res.status(200).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -119,7 +119,8 @@ routes.get('/:formId/apiKey', hasFormPermissions(P.FORM_API_READ), async (req, r
 });
 
 routes.put('/:formId/apiKey', hasFormPermissions(P.FORM_API_CREATE), async (req, res, next) => {
-  await controller.createOrReplaceApiKey(req, res, next);
+  const filesAPIAccess = req.body.filesAPIAccess;
+  await controller.createOrReplaceApiKey(req, res, next, filesAPIAccess);
 });
 
 routes.delete('/:formId/apiKey', hasFormPermissions(P.FORM_API_DELETE), async (req, res, next) => {

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -692,7 +692,8 @@ const service = {
   },
 
   // Add an API key to the form, delete any existing key
-  createOrReplaceApiKey: async (formId, currentUser) => {
+  //updated to add filesAPIAccess
+  createOrReplaceApiKey: async (formId, currentUser, filesAPIAccess) => {
     let trx;
     try {
       const currentKey = await service.readApiKey(formId);
@@ -703,6 +704,7 @@ const service = {
         await FormApiKey.query(trx).modify('filterFormId', formId).update({
           formId: formId,
           secret: uuidv4(),
+          filesAPIAccess: filesAPIAccess,
           updatedBy: currentUser.usernameIdp,
         });
       } else {
@@ -710,6 +712,7 @@ const service = {
         await FormApiKey.query(trx).insert({
           formId: formId,
           secret: uuidv4(),
+          filesAPIAccess: filesAPIAccess,
           createdBy: currentUser.usernameIdp,
         });
       }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

This feature adds a checkbox to the API management section of a form allowing users to specify whether they want to allow any submitted files to be accessible via the API key. As the GET /files API now allows access to submitted files, this adds an extra level of security so that files cannot be accessed unless specified by the form owner.

![Screenshot 2024-01-10 at 2 53 54 PM](https://github.com/bcgov/common-hosted-form-service/assets/91633223/5a48ab8e-4c45-4a34-8898-411c9aaf440e)

<!-- Describe your changes in detail -->

A new table is added to the API Key schema called `filesAPIAccess` which stores a boolean value representing whether access to files is allowed via the API. To allow access to files, the checkbox must be selected before the API key is generated. Similarly, access can be revoked by deselecting the checkbox and generating a new key.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

Some consideration should be made for the JEDI folks that might already be using the /files API, since they will now have forms without the updated `filesAPIAccess` attribute. In this case we will need to manually add a `true` value to their api key or ask them to generate a new api key.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
