### PR TITLE
fix: FORMS-946 validate authorization uuids

### DIFF
--- a/app/src/forms/auth/middleware/apiAccess.js
+++ b/app/src/forms/auth/middleware/apiAccess.js
@@ -6,6 +6,74 @@ const formService = require('../../form/service');
 const submissionService = require('../../submission/service');
 const fileService = require('../../file/service');
 
+const HTTP_401_DETAIL = 'Invalid authorization credentials.';
+
+/**
+ * Gets the Form ID from the request parameters. Handles the cases where instead
+ * of an explicit Form ID, the parameters include something like a Submission ID
+ * that then has to be used to find the Form ID.
+ *
+ * @param {*} params the request parameters.
+ * @returns a UUID for form that the requested data belongs to.
+ * @throws Problem if there is a UUID validation error.
+ */
+const _getFormId = async (params) => {
+  let formId;
+  if (params.formId) {
+    formId = params.formId;
+
+    if (!uuidValidate(formId)) {
+      throw new Problem(400, { detail: `Bad formId "${formId}".` });
+    }
+  } else if (params.formSubmissionId) {
+    formId = await _getFormIdFromSubmissionId(params.formSubmissionId);
+  } else if (params.id) {
+    formId = await _getFormIdFromFileId(params.id);
+  }
+
+  return formId;
+};
+
+/**
+ * Gets the Form ID that corresponds to a given File ID.
+ *
+ * @param uuid fileId that has a corresponding Form ID.
+ * @returns a UUID for form that the File ID belongs to.
+ * @throws Problem if there is a UUID validation error.
+ */
+const _getFormIdFromFileId = async (fileId) => {
+  if (!uuidValidate(fileId)) {
+    throw new Problem(400, { detail: `Bad fileId "${fileId}".` });
+  }
+
+  // check for file id (saved as id), get submissionID from request body
+  const file = await fileService.read(fileId);
+
+  // check to see that an associated submissionId exists
+  if (file && !file.formSubmissionId) {
+    throw new Problem(500, { detail: `Submission ID missing in file storage "${fileId}".` });
+  }
+
+  return _getFormIdFromSubmissionId(file.formSubmissionId);
+};
+
+/**
+ * Gets the Form ID that corresponds to a given Submission ID.
+ *
+ * @param uuid formSubmissionId that has a corresponding Form ID.
+ * @returns a UUID for form that the Submission ID belongs to.
+ * @throws Problem if there is a UUID validation error.
+ */
+const _getFormIdFromSubmissionId = async (formSubmissionId) => {
+  if (!uuidValidate(formSubmissionId)) {
+    throw new Problem(400, { detail: `Bad formSubmissionId "${formSubmissionId}".` });
+  }
+
+  const result = await submissionService.read(formSubmissionId);
+
+  return result?.form?.id;
+};
+
 module.exports = async (req, res, next) => {
   try {
     // Check if authorization header is basic auth
@@ -13,32 +81,23 @@ module.exports = async (req, res, next) => {
       // URL params should override query string params of the same attribute
       const params = { ...req.query, ...req.params };
 
-      // Basic auth is currently only used for form and submission endpoints. Use
-      // the formId if it exists, otherwise fetch the formId from the submission's
-      // form.
-      let formId;
-      if (params.formId) {
-        formId = params.formId;
-      } else if (params.formSubmissionId && uuidValidate(params.formSubmissionId)) {
-        const result = await submissionService.read(params.formSubmissionId);
-        formId = result?.form?.id;
-      } else if (params.id && uuidValidate(params.id)) {
-        // check for file id (saved as id), get submissionID from request body
-        const sid = await fileService.read(params.id);
-        //check to see that an associated submissionId exists
-        if (!sid || !sid.formSubmissionId) {
-          throw new Error('Submission ID not found in file storage.');
-        }
-        const result = await submissionService.read(sid.formSubmissionId);
-        formId = result?.form?.id;
+      // Get the form ID using whatever parameter we have in the request (Form
+      // ID, Form Submission ID, or File Upload ID).
+      const formId = await _getFormId(params);
+      if (!formId) {
+        throw new Problem(401, { detail: HTTP_401_DETAIL });
       }
 
-      let secret = ''; // Must be initialized as a string
-
-      if (formId && uuidValidate(formId)) {
-        const result = await formService.readApiKey(formId);
-        secret = result && result.secret ? result.secret : '';
+      const apiKey = await formService.readApiKey(formId);
+      if (!apiKey || !apiKey.secret) {
+        throw new Problem(401, { detail: HTTP_401_DETAIL });
       }
+
+      // if (params.id && apiKey.filesApiAccess === false) {
+      //   throw new Problem(401, { detail: HTTP_401_DETAIL });
+      // }
+
+      const secret = apiKey.secret;
 
       const checkCredentials = basicAuth({
         // Must be a synchronous function
@@ -50,7 +109,7 @@ module.exports = async (req, res, next) => {
           return req.apiUser;
         },
         unauthorizedResponse: () => {
-          return new Problem(401, { detail: 'Invalid authorization credentials.' });
+          return new Problem(401, { detail: HTTP_401_DETAIL });
         },
       });
 

--- a/app/tests/unit/forms/auth/middleware/apiAccess.spec.js
+++ b/app/tests/unit/forms/auth/middleware/apiAccess.spec.js
@@ -1,23 +1,23 @@
-const apiAccess = require('../../../../../src/forms/auth/middleware/apiAccess');
+const { getMockReq, getMockRes } = require('@jest-mock/express');
 
+const apiAccess = require('../../../../../src/forms/auth/middleware/apiAccess');
 const formService = require('../../../../../src/forms/form/service');
 const submissionService = require('../../../../../src/forms/submission/service');
 const fileService = require('../../../../../src/forms/file/service');
+const { NotFoundError } = require('objection');
 
 describe('apiAccess', () => {
+  const fileId = 'eb6fad21-985c-46f1-865b-24807f5f970e';
   const formId = 'c6455376-382c-439d-a811-0381a012d696';
   const formSubmissionId = '3ba5659c-1a3f-4e76-a0d4-ef00f5102387';
   const secret = 'dd7d1699-61ec-4037-aa33-727f8aa79c0a';
+
   const token = Buffer.from(`${formId}:${secret}`).toString('base64');
   const authHeader = `Basic ${token}`;
 
-  const baseRes = { status: () => ({ json: () => {} }) };
-
-  const next = jest.fn();
   const mockReadApiKey = jest.spyOn(formService, 'readApiKey');
 
   beforeEach(() => {
-    next.mockReset();
     mockReadApiKey.mockReset();
   });
 
@@ -25,224 +25,396 @@ describe('apiAccess', () => {
     mockReadApiKey.mockRestore();
   });
 
-  it('should only call next if there are no headers', async () => {
-    const req = {};
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+  // Check that the apiUser parameter is not set when Basic authentication is
+  // not being used.
+  // Also ensure that we're not calling the DB unless necessary.
+  describe('no parameters', () => {
+    it('should pass through if there is no auth header', async () => {
+      const req = getMockReq({ headers: {} });
+      const { res, next } = getMockRes();
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('should pass through with bearer authorization', async () => {
+      const req = getMockReq({ headers: { authorization: 'Bearer JWT' } });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('should be unauthorized with no uuid in the params', async () => {
+      const req = getMockReq({ headers: { authorization: authHeader } });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
   });
 
-  it('should only call next if there are no auth headers', async () => {
-    const req = { headers: {} };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+  describe('form id', () => {
+    it('should be bad request with non-uuid form id', async () => {
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formId: 'invalidFormId' },
+      });
+      const { res, next } = getMockRes();
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+    });
+
+    it('should be unauthorized when db api key result is missing', async () => {
+      mockReadApiKey.mockResolvedValue();
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formId: formId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
+
+    it('should be unauthorized when db api key result is empty', async () => {
+      mockReadApiKey.mockResolvedValue({});
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formId: formId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
+
+    it('should be unauthorized when db api key does not match', async () => {
+      mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formId: formId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledTimes(0);
+    });
+
+    it('should flag apiUser as true with valid form id and credentials', async () => {
+      mockReadApiKey.mockResolvedValue({ secret: secret });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formId: formId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeTruthy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
+    });
   });
 
-  it('should only call next with bearer authorization', async () => {
-    const req = { headers: { authorization: 'Bearer JWT' } };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+  describe('form submission id', () => {
+    it('should be bad request with non-uuid form submission id', async () => {
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formSubmissionId: 'invalidFormSubmissionId' },
+      });
+      const { res, next } = getMockRes();
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+    });
+
+    it('should pass exceptions through when form submission does not exist', async () => {
+      submissionService.read = jest.fn().mockRejectedValue(new NotFoundError());
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formSubmissionId: formSubmissionId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('should be unauthorized when form submission is empty', async () => {
+      submissionService.read = jest.fn().mockReturnValue({});
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formSubmissionId: formSubmissionId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
+
+    it('should be unauthorized when form submission has no form id', async () => {
+      submissionService.read = jest.fn().mockReturnValue({ form: {} });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formSubmissionId: formSubmissionId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
+
+    it('should be unauthorized when db api key does not match', async () => {
+      mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
+      submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formSubmissionId: formSubmissionId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledTimes(0);
+    });
+
+    it('should flag apiUser as true with valid form submission id and credentials', async () => {
+      mockReadApiKey.mockResolvedValue({ secret: secret });
+      submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { formSubmissionId: formSubmissionId },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess(req, res, next);
+
+      expect(req.apiUser).toBeTruthy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
+    });
   });
 
-  it('should not call readApiKey with no formId or formSubmissionId param', async () => {
-    const req = { headers: { authorization: authHeader } };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+  describe('file id', () => {
+    it('should be bad request with non-uuid file id', async () => {
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: 'invalidFileId' },
+      });
+      const { res, next } = getMockRes();
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
-  });
+      await apiAccess(req, res, next);
 
-  it('should not call readApiKey with invalid formId param', async () => {
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formId: 'invalidForm' },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+    });
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
-  });
+    it('should pass exceptions through when file does not exist', async () => {
+      fileService.read = jest.fn().mockRejectedValue(new NotFoundError());
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-  it('should not call readApiKey with invalid formSubmissionId param', async () => {
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formSubmissionId: 'invalidForm' },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      await apiAccess(req, res, next);
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
-  });
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
 
-  it('should flag apiUser as false with no API key result', async () => {
-    mockReadApiKey.mockResolvedValue();
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formId: formId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+    it('should be unauthorized when file is empty', async () => {
+      fileService.read = jest.fn().mockReturnValue({});
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
-  });
+      await apiAccess(req, res, next);
 
-  it('should flag apiUser as false with no API key secret', async () => {
-    mockReadApiKey.mockResolvedValue({});
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formId: formId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 500 }));
+    });
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
-  });
+    it('should be unauthorized when file has no form submission id', async () => {
+      fileService.read = jest.fn().mockReturnValue({ formSubmissionId: undefined });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-  it('should flag apiUser as false with invalid formId credentials', async () => {
-    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formId: formId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      await apiAccess(req, res, next);
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
-  });
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 500 }));
+    });
 
-  it('should flag apiUser as false with invalid formSubmissionId credentials', async () => {
-    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
-    submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
+    it('should be unauthorized when form submission does not exist', async () => {
+      fileService.read = jest.fn().mockReturnValue({ formSubmissionId: formSubmissionId });
+      submissionService.read = jest.fn().mockReturnValue();
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formSubmissionId: formSubmissionId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      await apiAccess(req, res, next);
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
-  });
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
 
-  it('should flag apiUser as false with no submission result', async () => {
-    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
-    submissionService.read = jest.fn().mockReturnValue();
+    it('should be unauthorized when form submission is empty', async () => {
+      fileService.read = jest.fn().mockReturnValue({ formSubmissionId: formSubmissionId });
+      submissionService.read = jest.fn().mockReturnValue({});
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formSubmissionId: formSubmissionId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      await apiAccess(req, res, next);
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
-  });
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
 
-  it('should flag apiUser as false with submission result without form', async () => {
-    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
-    submissionService.read = jest.fn().mockReturnValue({});
+    it('should be unauthorized when form submission has no form id', async () => {
+      fileService.read = jest.fn().mockReturnValue({ formSubmissionId: formSubmissionId });
+      submissionService.read = jest.fn().mockReturnValue({ form: {} });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formSubmissionId: formSubmissionId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      await apiAccess(req, res, next);
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
-  });
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(0);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+    });
 
-  it('should flag apiUser as false with submission result without form id', async () => {
-    mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
-    submissionService.read = jest.fn().mockReturnValue({ form: {} });
+    it('should be unauthorized when db api key does not match', async () => {
+      mockReadApiKey.mockResolvedValue({ secret: 'invalidSecret' });
+      fileService.read = jest.fn().mockReturnValue({ formSubmissionId: formSubmissionId });
+      submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formSubmissionId: formSubmissionId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+      await apiAccess(req, res, next);
 
-    expect(req.apiUser).toBeFalsy();
-    expect(next).toHaveBeenCalledTimes(0);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(0);
-  });
+      expect(req.apiUser).toBeFalsy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).toHaveBeenCalledTimes(0);
+    });
 
-  it('should flag apiUser as true with valid credentials', async () => {
-    mockReadApiKey.mockResolvedValue({ secret: secret });
-    const req = {
-      headers: { authorization: authHeader },
-      params: { formId: formId },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
+    it('should flag apiUser as true with valid file id and credentials', async () => {
+      mockReadApiKey.mockResolvedValue({ secret: secret });
+      fileService.read = jest.fn().mockReturnValue({ formSubmissionId: formSubmissionId });
+      submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
+      const req = getMockReq({
+        headers: { authorization: authHeader },
+        params: { id: fileId },
+      });
+      const { res, next } = getMockRes();
 
-    expect(req.apiUser).toBeTruthy();
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(mockReadApiKey).toHaveBeenCalledTimes(1);
-  });
+      await apiAccess(req, res, next);
 
-  it('should process correctly with a valid file id and associated submissionId', async () => {
-    fileService.read = jest.fn().mockResolvedValue({ formSubmissionId: formSubmissionId });
-    submissionService.read = jest.fn().mockResolvedValue({ form: { id: formId } });
-    mockReadApiKey.mockResolvedValue({ secret: secret });
-    const req = {
-      headers: { authorization: authHeader },
-      params: { id: 'c6455376-382c-439d-a811-0381a012d696' },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
-
-    expect(fileService.read).toHaveBeenCalledWith('c6455376-382c-439d-a811-0381a012d696');
-    expect(submissionService.read).toHaveBeenCalledWith(formSubmissionId);
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(req.apiUser).toBeTruthy();
-  });
-
-  it('should throw an error if the file id does not have an associated submission id', async () => {
-    fileService.read = jest.fn().mockResolvedValue({ formSubmissionId: null });
-    mockReadApiKey.mockResolvedValue({ secret: secret });
-
-    const req = {
-      headers: { authorization: authHeader },
-      params: { id: 'c6455376-382c-439d-a811-0381a012d696' },
-    };
-    const res = { ...baseRes };
-    await apiAccess(req, res, next);
-
-    expect(fileService.read).toHaveBeenCalledWith('c6455376-382c-439d-a811-0381a012d696');
-    expect(submissionService.read).toHaveBeenCalledTimes(0);
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(next).toHaveBeenCalledWith(new Error('Submission ID not found in file storage.'));
-    expect(req.apiUser).toBeUndefined();
+      expect(req.apiUser).toBeTruthy();
+      expect(mockReadApiKey).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
+    });
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We get a lot of API Key calls with invalid UUIDs in the path. If these are not valid UUIDs, return 400 and not 401.

The apiAccess code has also increased in code complexity and has duplication in getting the form ID from the submission ID. Refactor to clean this up.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Notes:
- Refactored the part where we figure out the Form ID given the various parameters (form id, submission id, or file id)
- Failed early when there are errors in the parameters, rather than do it in checkCredentials
- The tests are a substantial rewrite. Made them much stricter in checking the HTTP response code
- The tests have to check either the status of the response or the next value - this isn't ideal, but the basic auth library does it one way, and we do it a "better" way