### PR TITLE
fix: FORMS-957 move form sorting to the frontend

### DIFF
--- a/app/frontend/src/components/designer/FormsTable.vue
+++ b/app/frontend/src/components/designer/FormsTable.vue
@@ -19,6 +19,7 @@ export default {
       loading: true,
       formDescription: null,
       search: null,
+      sortBy: [{ key: 'name', order: 'asc' }],
     };
   },
   computed: {
@@ -136,6 +137,7 @@ export default {
     :loading-text="$t('trans.formsTable.loadingText')"
     :search="search"
     :lang="lang"
+    :sort-by="sortBy"
   >
     <template #item.name="{ item }">
       <router-link

--- a/app/src/forms/auth/service.js
+++ b/app/src/forms/auth/service.js
@@ -132,12 +132,12 @@ const service = {
     let items = [];
     if (userInfo && userInfo.public) {
       // if the user is 'public', then we can only fetch public accessible forms...
-      items = await PublicFormAccess.query().modify('filterFormId', params.formId).modify('filterActive', params.active).modify('orderDefault');
+      items = await PublicFormAccess.query().modify('filterFormId', params.formId).modify('filterActive', params.active);
       // ignore any passed in accessLevel params, only return public
       return service.filterForms(userInfo, items, ['public']);
     } else {
       // if user has an id, then we fetch whatever forms match the query params
-      items = await UserFormAccess.query().modify('filterUserId', userInfo.id).modify('filterFormId', params.formId).modify('filterActive', params.active).modify('orderDefault');
+      items = await UserFormAccess.query().modify('filterUserId', userInfo.id).modify('filterFormId', params.formId).modify('filterActive', params.active);
       return service.filterForms(userInfo, items, params.accessLevels);
     }
   },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When the forms service sets the forms in the currentUser, it is sorting them by user names and form name. We only really need this for the “My Forms” table.

Since most of the use of the currentUser does not need the sorting, move the sort to the frontend.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
