### PR TITLE
fix: FORMS-959 optimize the /forms routes

### DIFF
--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -60,16 +60,14 @@ const currentUserTemp = async (req, res, next) => {
     if (!ok) {
       return new Problem(403, { detail: 'Authorization token is invalid.' }).send(res);
     }
-
-    // Temporarily set a flag to prevent expensive database calls. We will
-    // eventually move all routes to working in this way, and then the extra
-    // downstream logic can be removed.
-    req.chefsLoadForms = false;
-
-    return setUser(req, res, next);
   }
 
-  next();
+  // Temporarily set a flag to prevent expensive database calls. We will
+  // eventually move all routes to working in this way, and then the extra
+  // downstream logic can be removed.
+  req.chefsLoadForms = false;
+
+  return setUser(req, res, next);
 };
 
 // To deal with performance problems, we are going to move away from setting the

--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -22,7 +22,7 @@ const setUser = async (req, _res, next) => {
     // ex. /forms/:formId=ABC/version?formId=123
     // the ABC in the url will be used... so don't do that.
     const params = { ...req.query, ...req.params };
-    req.currentUser = await service.login(token, params);
+    req.currentUser = await service.login(token, params, req.chefsLoadForms);
     next();
   } catch (error) {
     next(error);
@@ -61,14 +61,46 @@ const currentUserTemp = async (req, res, next) => {
       return new Problem(403, { detail: 'Authorization token is invalid.' }).send(res);
     }
 
+    // Temporarily set a flag to prevent expensive database calls. We will
+    // eventually move all routes to working in this way, and then the extra
+    // downstream logic can be removed.
+    req.chefsLoadForms = false;
+
     return setUser(req, res, next);
   }
 
   next();
 };
 
+// To deal with performance problems, we are going to move away from setting the
+// req.currentUser.forms and req.currentUser.deletedForms data. The code using
+// those will eventually be removed from this function.
+const _getForm = async (currentUser, formId) => {
+  let forms;
+  if (currentUser.forms) {
+    forms = currentUser.forms;
+  } else {
+    forms = await service.getUserForms(currentUser, { active: true, formId: formId });
+  }
+
+  let form = forms.find((f) => f.formId === formId);
+
+  if (!form) {
+    let deletedForms;
+    if (currentUser.deletedForms) {
+      deletedForms = currentUser.deletedForms;
+    } else {
+      deletedForms = await service.getUserForms(currentUser, { active: false, formId: formId });
+    }
+
+    form = deletedForms.find((f) => f.formId === formId);
+  }
+
+  return form;
+};
+
 const hasFormPermissions = (permissions) => {
-  return (req, res, next) => {
+  return async (req, res, next) => {
     // Skip permission checks if requesting as API entity
     if (req.apiUser) {
       return next();
@@ -84,16 +116,10 @@ const hasFormPermissions = (permissions) => {
       // No form provided to this route that secures based on form... that's a problem!
       return new Problem(401, { detail: 'Form Id not found on request.' }).send(res);
     }
-    let form = req.currentUser.forms.find((f) => f.formId === formId);
+    let form = await _getForm(req.currentUser, formId);
     if (!form) {
-      // check deleted... (this allows 404 on other queries later)
-      if (req.currentUser.deletedForms) {
-        form = req.currentUser.deletedForms.find((f) => f.formId === formId);
-      }
-      if (!form) {
-        // cannot find the form... guess we don't have access... FAIL!
-        return new Problem(401, { detail: 'Current user has no access to form.' }).send(res);
-      }
+      // cannot find the form... guess we don't have access... FAIL!
+      return new Problem(401, { detail: 'Current user has no access to form.' }).send(res);
     }
 
     if (!Array.isArray(permissions)) {

--- a/app/src/forms/auth/service.js
+++ b/app/src/forms/auth/service.js
@@ -201,12 +201,18 @@ const service = {
     };
   },
 
-  login: async (token, params = {}) => {
+  login: async (token, params = {}, loadForms = true) => {
     const userInfo = service.parseToken(token);
     const user = await service.getUserId(userInfo);
+
+    if (!loadForms) {
+      return { ...user };
+    }
+
     const forms = await service.getUserForms(user, params); // get forms for user (filtered by params)...
     params.active = false;
     const deletedForms = await service.getUserForms(user, params); // get forms for user (filtered by params)...
+
     return { ...user, forms: forms, deletedForms: deletedForms };
   },
 

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -1,14 +1,14 @@
 const config = require('config');
 const routes = require('express').Router();
 const apiAccess = require('../auth/middleware/apiAccess');
-const { currentUser, hasFormPermissions } = require('../auth/middleware/userAccess');
+const { currentUserTemp, hasFormPermissions } = require('../auth/middleware/userAccess');
 const P = require('../common/constants').Permissions;
 const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
 const keycloak = require('../../components/keycloak');
 const controller = require('./controller');
 
-routes.use(currentUser);
+routes.use(currentUserTemp);
 
 routes.get('/', keycloak.protect(`${config.get('server.keycloak.clientId')}:admin`), async (req, res, next) => {
   await controller.listForms(req, res, next);

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -3,17 +3,14 @@ const routes = require('express').Router();
 
 const controller = require('./controller');
 const P = require('../common/constants').Permissions;
-const { currentUser, currentUserTemp, hasSubmissionPermissions, filterMultipleSubmissions } = require('../auth/middleware/userAccess');
+const { currentUser, hasSubmissionPermissions, filterMultipleSubmissions } = require('../auth/middleware/userAccess');
 const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
-// This endpoint is the one most used by API Key users. Try it with a temporary
-// version of currentUser that only creates req.currentUser for Bearer tokens.
-// This saves a couple of big database calls that are not needed for API Keys.
-routes.get('/:formSubmissionId', currentUserTemp, rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.use(currentUser);
+
+routes.get('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.read(req, res, next);
 });
-
-routes.use(currentUser);
 
 routes.put('/:formSubmissionId', hasSubmissionPermissions(P.SUBMISSION_UPDATE), async (req, res, next) => {
   await controller.update(req, res, next);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The API is set up to load the active forms and deleted forms for all API calls. For example, to get a form the API will get the permissions for all active forms and all deleted forms, and then it will pull the one form out of active or deleted to check permissions. We cannot afford these expensive database queries on every API call.

Change the API so that it only fetches the one form that is required to check permissions. Only do the active if the deleted fail.

Since this is a big scary change, only do one set of endpoints at a time. There will need to be a lot of manual testing to check this out.

Going to start with the /forms endpoints and then move onto the others once it checks out.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
