### PR TITLE
fix: FORMS-959 optimize the /submissions routes

### DIFF
--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -160,7 +160,14 @@ const hasSubmissionPermissions = (permissions) => {
 
       // Does the user have permissions for this submission due to their FORM permissions
       if (req.currentUser) {
-        let formFromCurrentUser = req.currentUser.forms.find((f) => f.formId === submissionForm.form.id);
+        let forms;
+        if (req.currentUser.forms) {
+          forms = req.currentUser.forms;
+        } else {
+          forms = await service.getUserForms(req.currentUser, { active: true, formId: submissionForm.form.id });
+        }
+
+        let formFromCurrentUser = forms.find((f) => f.formId === submissionForm.form.id);
         if (formFromCurrentUser) {
           // Do they have the submission permissions being requested on this FORM
           const intersection = permissions.filter((p) => {

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -3,10 +3,10 @@ const routes = require('express').Router();
 
 const controller = require('./controller');
 const P = require('../common/constants').Permissions;
-const { currentUser, hasSubmissionPermissions, filterMultipleSubmissions } = require('../auth/middleware/userAccess');
+const { currentUserTemp, hasSubmissionPermissions, filterMultipleSubmissions } = require('../auth/middleware/userAccess');
 const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
-routes.use(currentUser);
+routes.use(currentUserTemp);
 
 routes.get('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.read(req, res, next);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The API is set up to load the active forms and deleted forms for all API calls. For example, to get a form the API will get the permissions for all active forms and all deleted forms, and then it will pull the one form out of active or deleted to check permissions. We cannot afford these expensive database queries on every API call.

Change the API so that it only fetches the one form that is required to check permissions. Only do the active if the deleted fail.

Since this is a big scary change, only do one set of endpoints at a time. There will need to be a lot of manual testing to check this out.

Next up is the /submissions endpoints.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
