### PR TITLE
Prevent export no subs

### DIFF
--- a/app/frontend/src/components/forms/ExportSubmissions.vue
+++ b/app/frontend/src/components/forms/ExportSubmissions.vue
@@ -82,7 +82,9 @@ export default {
     },
     FILTER_HEADERS() {
       return this.versionSelected !== ''
-        ? this.formFields.map((f) => ({ name: f, value: f }))
+        ? this.formFields.length > 0
+          ? this.formFields.map((f) => ({ name: f, value: f }))
+          : []
         : [];
     },
   },

--- a/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
+++ b/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
@@ -35,7 +35,7 @@ describe('BCGovHeader.vue', () => {
     expect(btnHeaderTitle.text()).toEqual(
       router?.currentRoute?.value?.meta?.title
         ? router.currentRoute.value.meta.title
-        : ''
+        : import.meta.env.VITE_TITLE
     );
     expect(wrapper.find('[data-test="base-auth-btn"]').exists()).toBeTruthy();
     expect(

--- a/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
+++ b/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
@@ -35,7 +35,7 @@ describe('BCGovHeader.vue', () => {
     expect(btnHeaderTitle.text()).toEqual(
       router?.currentRoute?.value?.meta?.title
         ? router.currentRoute.value.meta.title
-        : import.meta.env.VITE_TITLE
+        : ''
     );
     expect(wrapper.find('[data-test="base-auth-btn"]').exists()).toBeTruthy();
     expect(

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.42",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
+      "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -1626,9 +1626,9 @@
       "dev": true
     },
     "node_modules/@types/qs": {
-      "version": "6.9.10",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
+      "version": "6.9.11",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
       "dev": true
     },
     "node_modules/@types/range-parser": {
@@ -12356,9 +12356,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.42",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
+      "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -12440,9 +12440,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.10",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
+      "version": "6.9.11",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
       "dev": true
     },
     "@types/range-parser": {

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -9,15 +9,10 @@ module.exports = {
   export: async (req, res, next) => {
     try {
       const result = await exportService.export(req.params.formId, req.query, req.currentUser, req.headers.referer);
-      if (result.data.length === 0) {
-        res.setHeader('Content-Type', 'application/json');
-        res.status(400).send(JSON.stringify({ detail: 'There are no submissions to export.' }));
-      } else {
-        ['Content-Disposition', 'Content-Type'].forEach((h) => {
-          res.setHeader(h, result.headers[h.toLowerCase()]);
-        });
-        return res.send(result.data);
-      }
+      ['Content-Disposition', 'Content-Type'].forEach((h) => {
+        res.setHeader(h, result.headers[h.toLowerCase()]);
+      });
+      return res.send(result.data);
     } catch (error) {
       next(error);
     }
@@ -26,15 +21,10 @@ module.exports = {
   exportWithFields: async (req, res, next) => {
     try {
       const result = await exportService.export(req.params.formId, req.body, req.currentUser, req.headers.referer);
-      if (result.data.length === 0) {
-        res.setHeader('Content-Type', 'application/json');
-        res.status(400).send(JSON.stringify({ detail: 'There are no submissions to export.' }));
-      } else {
-        ['Content-Disposition', 'Content-Type'].forEach((h) => {
-          res.setHeader(h, result.headers[h.toLowerCase()]);
-        });
-        return res.send(result.data);
-      }
+      ['Content-Disposition', 'Content-Type'].forEach((h) => {
+        res.setHeader(h, result.headers[h.toLowerCase()]);
+      });
+      return res.send(result.data);
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -450,8 +450,6 @@ const service = {
     const exportTemplate = params.template ? params.template : 'multiRowEmptySpacesCSVExport';
     const form = await service._getForm(formId);
     const data = await service._getData(exportType, params.version, form, params);
-    // If there are no submissions then we don't need to format the data
-    if ((Array.isArray(data) && data.length === 0) || (typeof data === 'object' && Object.keys(data).length === 0)) return { data: [] };
     const result = await service._formatData(exportFormat, exportType, exportTemplate, form, data, params.fields, params.version, params.emailExport, currentUser, referer);
     return { data: result.data, headers: result.headers };
   },

--- a/app/tests/unit/forms/form/controller.spec.js
+++ b/app/tests/unit/forms/form/controller.spec.js
@@ -65,7 +65,7 @@ describe('form controller', () => {
     expect(exportServiceSpy).toHaveBeenCalledTimes(1);
     expect(exportService._getForm).toHaveBeenCalledTimes(1);
     expect(exportService._getSubmissions).toHaveBeenCalledTimes(1);
-    expect(formatDataSpy).toHaveBeenCalledTimes(0);
+    expect(formatDataSpy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Sometimes formFields in the frontend are given a empty value which is causing it to throw an error and break exporting because it's trying to map an array that isn't an array.

Returned the export fields to always return the correct export type and not a json error message. This also means we won't get an error message on the front end.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
