### PR TITLE
fix: FORMS-994 check version id in route params

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -526,10 +526,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -563,10 +567,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -643,10 +651,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -767,10 +779,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -812,10 +828,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -844,10 +864,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -881,10 +905,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -969,10 +997,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -1011,10 +1043,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -1054,10 +1090,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -1106,10 +1146,14 @@ paths:
               $ref: '#/components/headers/RateLimit'
             RateLimit-Policy:
               $ref: '#/components/headers/RateLimit-Policy'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         default:
@@ -3761,13 +3805,13 @@ components:
           description: What type of problem, link to explanation of problem
         title:
           type: string
-          description: Title of problem, generally the Http Status Code description
+          description: Title of problem, generally the HTTP status code description
         status:
           type: string
-          description: The Http Status code
+          description: The HTTP status code
         detail:
           type: string
-          description: short description of why this problem was raised.
+          description: Short description of why this problem was raised
     Role:
       allOf:
         - $ref: '#/components/schemas/RoleBasic'

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -1,7 +1,7 @@
 const config = require('config');
 const routes = require('express').Router();
 const apiAccess = require('../auth/middleware/apiAccess');
-const { currentUser, hasFormPermissions } = require('../auth/middleware/userAccess');
+const { checkFormVersionId, currentUser, hasFormPermissions } = require('../auth/middleware/userAccess');
 const P = require('../common/constants').Permissions;
 const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
@@ -58,33 +58,61 @@ routes.get('/:formId/submissions', rateLimiter, apiAccess, hasFormPermissions([P
   await controller.listFormSubmissions(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), checkFormVersionId, async (req, res, next) => {
   await controller.readVersion(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId/fields', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
+routes.get('/:formId/versions/:formVersionId/fields', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), checkFormVersionId, async (req, res, next) => {
   await controller.readVersionFields(req, res, next);
 });
 
-routes.post('/:formId/versions/:formVersionId/publish', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
+routes.post('/:formId/versions/:formVersionId/publish', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), checkFormVersionId, async (req, res, next) => {
   await controller.publishVersion(req, res, next);
 });
 
-routes.get('/:formId/versions/:formVersionId/submissions', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
-  await controller.listSubmissions(req, res, next);
-});
+routes.get(
+  '/:formId/versions/:formVersionId/submissions',
+  rateLimiter,
+  apiAccess,
+  hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]),
+  checkFormVersionId,
+  async (req, res, next) => {
+    await controller.listSubmissions(req, res, next);
+  }
+);
 
-routes.post('/:formId/versions/:formVersionId/submissions', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]), async (req, res, next) => {
-  await controller.createSubmission(req, res, next);
-});
+routes.post(
+  '/:formId/versions/:formVersionId/submissions',
+  rateLimiter,
+  apiAccess,
+  hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]),
+  checkFormVersionId,
+  async (req, res, next) => {
+    await controller.createSubmission(req, res, next);
+  }
+);
 
-routes.post('/:formId/versions/:formVersionId/multiSubmission', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]), async (req, res, next) => {
-  await controller.createMultiSubmission(req, res, next);
-});
+routes.post(
+  '/:formId/versions/:formVersionId/multiSubmission',
+  rateLimiter,
+  apiAccess,
+  hasFormPermissions([P.FORM_READ, P.SUBMISSION_CREATE]),
+  checkFormVersionId,
+  async (req, res, next) => {
+    await controller.createMultiSubmission(req, res, next);
+  }
+);
 
-routes.get('/:formId/versions/:formVersionId/submissions/discover', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), (req, res, next) => {
-  controller.listSubmissionFields(req, res, next);
-});
+routes.get(
+  '/:formId/versions/:formVersionId/submissions/discover',
+  rateLimiter,
+  apiAccess,
+  hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]),
+  checkFormVersionId,
+  (req, res, next) => {
+    controller.listSubmissionFields(req, res, next);
+  }
+);
 
 routes.get('/:formId/drafts', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_READ]), async (req, res, next) => {
   await controller.listDrafts(req, res, next);

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -1,7 +1,7 @@
 const config = require('config');
 const routes = require('express').Router();
 const apiAccess = require('../auth/middleware/apiAccess');
-const { checkFormVersionId, currentUser, hasFormPermissions } = require('../auth/middleware/userAccess');
+const { checkFormVersionDraftId, checkFormVersionId, currentUser, hasFormPermissions } = require('../auth/middleware/userAccess');
 const P = require('../common/constants').Permissions;
 const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
@@ -122,21 +122,35 @@ routes.post('/:formId/drafts', rateLimiter, apiAccess, hasFormPermissions([P.FOR
   await controller.createDraft(req, res, next);
 });
 
-routes.get('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_READ]), async (req, res, next) => {
+routes.get('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_READ]), checkFormVersionDraftId, async (req, res, next) => {
   await controller.readDraft(req, res, next);
 });
 
-routes.put('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_UPDATE]), async (req, res, next) => {
+routes.put('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_UPDATE]), checkFormVersionDraftId, async (req, res, next) => {
   await controller.updateDraft(req, res, next);
 });
 
-routes.delete('/:formId/drafts/:formVersionDraftId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_DELETE]), async (req, res, next) => {
-  await controller.deleteDraft(req, res, next);
-});
+routes.delete(
+  '/:formId/drafts/:formVersionDraftId',
+  rateLimiter,
+  apiAccess,
+  hasFormPermissions([P.FORM_READ, P.DESIGN_DELETE]),
+  checkFormVersionDraftId,
+  async (req, res, next) => {
+    await controller.deleteDraft(req, res, next);
+  }
+);
 
-routes.post('/:formId/drafts/:formVersionDraftId/publish', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]), async (req, res, next) => {
-  await controller.publishDraft(req, res, next);
-});
+routes.post(
+  '/:formId/drafts/:formVersionDraftId/publish',
+  rateLimiter,
+  apiAccess,
+  hasFormPermissions([P.FORM_READ, P.DESIGN_CREATE]),
+  checkFormVersionDraftId,
+  async (req, res, next) => {
+    await controller.publishDraft(req, res, next);
+  }
+);
 
 routes.get('/:formId/statusCodes', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.getStatusCodes(req, res, next);

--- a/app/tests/unit/routes/v1/form.spec.js
+++ b/app/tests/unit/routes/v1/form.spec.js
@@ -19,6 +19,9 @@ keycloak.protect = jest.fn(() => {
 });
 
 const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
+userAccess.checkFormVersionId = jest.fn((_req, _res, next) => {
+  next();
+});
 userAccess.currentUser = jest.fn((_req, _res, next) => {
   next();
 });

--- a/app/tests/unit/routes/v1/form.spec.js
+++ b/app/tests/unit/routes/v1/form.spec.js
@@ -19,6 +19,9 @@ keycloak.protect = jest.fn(() => {
 });
 
 const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
+userAccess.checkFormVersionDraftId = jest.fn((_req, _res, next) => {
+  next();
+});
 userAccess.checkFormVersionId = jest.fn((_req, _res, next) => {
   next();
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

James P from JEDI reported a problem when calling API routes that have both `formId` and `formVersionId` parameters. The data for the `formVersionId` will be returned even if the form version does not belong to the given `formId`. Whenever these two parameters exist on a route we need to check that form contains the form version, and return a 404 response if not. We also need to check the routes that have both `formId` and `formVersionDraftId`.

While this is a potential security problem, the exploit would involve having the `formVersionId` for someone else’s form. The large key space of UUIDs protects us here, but the problem still needs to be fixed.

Changes:
- Prevent `formId` and `formVersionDraftId` pairs where the `formVersionDraftId` doesn't belong to the form. Return HTTP 404 on mismatch
- Prevent `formId` and `formVersionId` pairs where the `formVersionId` doesn't belong to the form. Return HTTP 404 on mismatch
- Validate `formId`, `formVersionDraftId`, and `formVersionId` parameters and return HTTP 400 if they are not valid UUIDs (was previously returning HTTP 401)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This is a breaking change if:
- Developers are relying on the incorrect behaviour that allows `formId` mismatches
- Developers are using the HTTP 401 status code to detect invalid parameters and are not handling the 400 status code