### PR TITLE
refactor: FORMS-965 hasSubmissionPermissions cleanup

### DIFF
--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -86,9 +86,8 @@ const _getForm = async (currentUser, formId, includeDeleted) => {
 /**
  * Express middleware that adds the user information as the res.currentUser
  * attribute so that all downstream middleware and business logic can use it.
- *
- * This will fall through if everything is OK. If the Bearer auth is not valid,
- * this will produce a 403 error.
+ * This will fall through if everything is OK, otherwise it will call next()
+ * with a Problem describing the error.
  *
  * @param {*} req the Express object representing the HTTP request.
  * @param {*} _res the Express object representing the HTTP response - unused.
@@ -119,7 +118,7 @@ const currentUser = async (req, _res, next) => {
 /**
  * Express middleware to check that a user has all the given permissions for a
  * form. This will fall through if everything is OK, otherwise it will call
- * next() with a Problem that describes the error.
+ * next() with a Problem describing the error.
  *
  * @param {string[]} permissions the form permissions that the user must have.
  * @returns nothing
@@ -160,23 +159,28 @@ const hasFormPermissions = (permissions) => {
   };
 };
 
+/**
+ * Express middleware to check that the caller has the given permissions for the
+ * submission identified by params.formSubmissionId or query.formSubmissionId.
+ * This will fall through if everything is OK, otherwise it will call next()
+ * with a Problem describing the error.
+ *
+ * @param {string[]} permissions the access the user needs for the submission
+ * @returns nothing
+ */
 const hasSubmissionPermissions = (permissions) => {
   return async (req, _res, next) => {
     try {
-      // Skip permission checks if requesting as API entity
+      // Skip permission checks if req is already authorized using an API key.
       if (req.apiUser) {
         return next();
       }
 
-      if (!Array.isArray(permissions)) {
-        permissions = [permissions];
-      }
-
       // Get the provided submission ID whether in a param or query (precedence to param)
       const submissionId = req.params.formSubmissionId || req.query.formSubmissionId;
-      if (!submissionId) {
+      if (!uuid.validate(submissionId)) {
         // No submission provided to this route that secures based on form... that's a problem!
-        return next(new Problem(401, { detail: 'Submission Id not found on request.' }));
+        throw new Problem(400, { detail: 'Bad formSubmissionId' });
       }
 
       // Get the submission results so we know what form this submission is for
@@ -200,12 +204,14 @@ const hasSubmissionPermissions = (permissions) => {
 
       // Deleted submissions are inaccessible
       if (submissionForm.submission.deleted) {
-        return next(new Problem(401, { detail: 'You do not have access to this submission.' }));
+        throw new Problem(401, {
+          detail: 'You do not have access to this submission.',
+        });
       }
 
       // TODO: consider whether DRAFT submissions are restricted as deleted above
 
-      // Public (annonymous) forms are publicly viewable
+      // Public (anonymous) forms are publicly viewable
       const publicAllowed = submissionForm.form.identityProviders.find((p) => p.code === 'public') !== undefined;
       if (permissions.length === 1 && permissions.includes(Permissions.SUBMISSION_READ) && publicAllowed) {
         return next();
@@ -213,10 +219,14 @@ const hasSubmissionPermissions = (permissions) => {
 
       // check against the submission level permissions assigned to the user...
       const submissionPermission = await service.checkSubmissionPermission(req.currentUser, submissionId, permissions);
-      if (submissionPermission) return next();
+      if (!submissionPermission) {
+        // no access to this submission...
+        throw new Problem(401, {
+          detail: 'You do not have access to this submission.',
+        });
+      }
 
-      // no access to this submission...
-      return next(new Problem(401, { detail: 'You do not have access to this submission.' }));
+      return next();
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -204,9 +204,7 @@ const hasSubmissionPermissions = (permissions) => {
 
       // Deleted submissions are inaccessible
       if (submissionForm.submission.deleted) {
-        throw new Problem(401, {
-          detail: 'You do not have access to this submission.',
-        });
+        return next(new Problem(401, { detail: 'You do not have access to this submission.' }));
       }
 
       // TODO: consider whether DRAFT submissions are restricted as deleted above
@@ -219,14 +217,10 @@ const hasSubmissionPermissions = (permissions) => {
 
       // check against the submission level permissions assigned to the user...
       const submissionPermission = await service.checkSubmissionPermission(req.currentUser, submissionId, permissions);
-      if (!submissionPermission) {
-        // no access to this submission...
-        throw new Problem(401, {
-          detail: 'You do not have access to this submission.',
-        });
-      }
+      if (submissionPermission) return next();
 
-      return next();
+      // no access to this submission...
+      return next(new Problem(401, { detail: 'You do not have access to this submission.' }));
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/file/middleware/filePermissions.js
+++ b/app/src/forms/file/middleware/filePermissions.js
@@ -49,7 +49,7 @@ const hasFileCreate = (req, res, next) => {
  * Middleware to determine if the current user can do a specific permission on a file
  * This is generally based on the SUBMISSION permissions that the file is attached to
  * but has to handle management for files that are added before submit
- * @param {string} permissions the permission to require on this route
+ * @param {string[]} permissions the permission to require on this route
  * @returns {Function} a middleware function
  */
 const hasFilePermissions = (permissions) => {

--- a/app/src/forms/file/routes.js
+++ b/app/src/forms/file/routes.js
@@ -14,11 +14,11 @@ routes.post('/', hasFileCreate, fileUpload.upload, async (req, res, next) => {
   await controller.create(req, res, next);
 });
 
-routes.get('/:id', rateLimiter, apiAccess, currentFileRecord, hasFilePermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:id', rateLimiter, apiAccess, currentFileRecord, hasFilePermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.read(req, res, next);
 });
 
-routes.delete('/:id', currentFileRecord, hasFilePermissions(P.SUBMISSION_UPDATE), async (req, res, next) => {
+routes.delete('/:id', currentFileRecord, hasFilePermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
   await controller.delete(req, res, next);
 });
 

--- a/app/src/forms/rbac/routes.js
+++ b/app/src/forms/rbac/routes.js
@@ -29,11 +29,11 @@ routes.put('/forms', hasFormPermissions([P.TEAM_UPDATE]), async (req, res, next)
   await controller.setFormUsers(req, res, next);
 });
 
-routes.get('/submissions', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/submissions', hasSubmissionPermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.getSubmissionUsers(req, res, next);
 });
 
-routes.put('/submissions', hasSubmissionPermissions(P.SUBMISSION_UPDATE), async (req, res, next) => {
+routes.put('/submissions', hasSubmissionPermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
   await controller.setSubmissionUserPermissions(req, res, next);
 });
 

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -8,23 +8,23 @@ const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
 routes.use(currentUser);
 
-routes.get('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.read(req, res, next);
 });
 
-routes.put('/:formSubmissionId', hasSubmissionPermissions(P.SUBMISSION_UPDATE), async (req, res, next) => {
+routes.put('/:formSubmissionId', hasSubmissionPermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
   await controller.update(req, res, next);
 });
 
-routes.delete('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_DELETE), async (req, res, next) => {
+routes.delete('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions([P.SUBMISSION_DELETE]), async (req, res, next) => {
   await controller.delete(req, res, next);
 });
 
-routes.put('/:formSubmissionId/:formId/submissions/restore', hasSubmissionPermissions(P.SUBMISSION_DELETE), filterMultipleSubmissions(), async (req, res, next) => {
+routes.put('/:formSubmissionId/:formId/submissions/restore', hasSubmissionPermissions([P.SUBMISSION_DELETE]), filterMultipleSubmissions(), async (req, res, next) => {
   await controller.restoreMutipleSubmissions(req, res, next);
 });
 
-routes.put('/:formSubmissionId/restore', hasSubmissionPermissions(P.SUBMISSION_DELETE), async (req, res, next) => {
+routes.put('/:formSubmissionId/restore', hasSubmissionPermissions([P.SUBMISSION_DELETE]), async (req, res, next) => {
   await controller.restore(req, res, next);
 });
 
@@ -32,41 +32,36 @@ routes.get('/:formSubmissionId/options', async (req, res, next) => {
   await controller.readOptions(req, res, next);
 });
 
-routes.get('/:formSubmissionId/notes', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId/notes', hasSubmissionPermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.getNotes(req, res, next);
 });
 
-routes.post('/:formSubmissionId/notes', hasSubmissionPermissions(P.SUBMISSION_UPDATE), async (req, res, next) => {
+routes.post('/:formSubmissionId/notes', hasSubmissionPermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
   await controller.addNote(req, res, next);
 });
 
-routes.get('/:formSubmissionId/status', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId/status', rateLimiter, apiAccess, hasSubmissionPermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.getStatus(req, res, next);
 });
 
-routes.post('/:formSubmissionId/status', hasSubmissionPermissions(P.SUBMISSION_UPDATE), async (req, res, next) => {
+routes.post('/:formSubmissionId/status', hasSubmissionPermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
   await controller.addStatus(req, res, next);
 });
 
-routes.post('/:formSubmissionId/email', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.post('/:formSubmissionId/email', hasSubmissionPermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.email(req, res, next);
 });
 
-routes.get('/:formSubmissionId/edits', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.get('/:formSubmissionId/edits', hasSubmissionPermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.listEdits(req, res, next);
 });
 
-routes.post('/:formSubmissionId/template/render', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+routes.post('/:formSubmissionId/template/render', rateLimiter, apiAccess, hasSubmissionPermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.templateUploadAndRender(req, res, next);
 });
 
-routes.delete('/:formSubmissionId/:formId/submissions', hasSubmissionPermissions(P.SUBMISSION_DELETE), filterMultipleSubmissions(), async (req, res, next) => {
+routes.delete('/:formSubmissionId/:formId/submissions', hasSubmissionPermissions([P.SUBMISSION_DELETE]), filterMultipleSubmissions(), async (req, res, next) => {
   await controller.deleteMutipleSubmissions(req, res, next);
 });
-
-// Implement this when we want to fetch a specific audit row including the whole old submission record
-// routes.get('/:formSubmissionId/edits/:auditId', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
-//   await controller.listEdits(req, res, next);
-// });
 
 module.exports = routes;

--- a/app/tests/unit/forms/auth/middleware/userAccess.spec.js
+++ b/app/tests/unit/forms/auth/middleware/userAccess.spec.js
@@ -431,355 +431,458 @@ describe('hasFormPermissions', () => {
   });
 });
 
+// External dependencies used by the implementation are:
+//  - service.checkSubmissionPermission: gets whether the user has permission
+//  - service.getSubmissionForm: gets the submission that the user can access
+//  - service.getUserForms: gets the forms that the user can access
+//
 describe('hasSubmissionPermissions', () => {
+  // Default mock value where the user has no access to submission
+  service.checkSubmissionPermission = jest.fn().mockReturnValue(false);
+
+  // Default mock value where there is no submission
+  service.getSubmissionForm = jest.fn().mockReturnValue();
+
+  // Default mock value where the user has no access to forms
+  service.getUserForms = jest.fn().mockReturnValue([]);
+
   it('returns a middleware function', () => {
-    const mw = hasSubmissionPermissions(['abc']);
-    expect(mw).toBeInstanceOf(Function);
+    const middleware = hasSubmissionPermissions(['submission_read']);
+
+    expect(middleware).toBeInstanceOf(Function);
+  });
+
+  it('400s if the request has no formSubmissionId', async () => {
+    const req = getMockReq();
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(0);
+    expect(service.getUserForms).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('400s if the formSubmissionId is not a uuid', async () => {
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: 'undefined',
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(0);
+    expect(service.getUserForms).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 400 }));
+  });
+
+  it('401s for deleted submission when no current user', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { deleted: true, id: formSubmissionId },
+    });
+    const req = getMockReq({
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('401s for deleted submission', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { deleted: true, id: formSubmissionId },
+    });
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('401s for deleted submission if user has no forms', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { deleted: true, id: formSubmissionId },
+    });
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('401s for deleted submission if user has no form access', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { deleted: true, id: formSubmissionId },
+    });
+    service.getUserForms.mockReturnValueOnce([
+      {
+        formId: formId,
+        permissions: [],
+      },
+    ]);
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('401s for deleted submission if user only has some form access', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { deleted: true, id: formSubmissionId },
+    });
+    service.getUserForms.mockReturnValueOnce([
+      {
+        formId: formId,
+        permissions: ['submission_read'],
+      },
+    ]);
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read', 'submission_update'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('401s on submission permissions if public access and not read permission', async () => {
+    service.checkSubmissionPermission.mockReturnValueOnce(undefined);
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId, identityProviders: [{ code: 'public' }] },
+      submission: { deleted: false, id: formSubmissionId },
+    });
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_delete'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('401s on submission permissions if public access and more than read permission', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId, identityProviders: [{ code: 'public' }] },
+      submission: { deleted: false, id: formSubmissionId },
+    });
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read', 'submission_delete'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('401 on submission permissions if form does not have the public idp', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: {
+        id: formId,
+        identityProviders: [{ code: 'idir' }, { code: 'bceid' }],
+      },
+      submission: { deleted: false, id: formSubmissionId },
+    });
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ status: 401 }));
+  });
+
+  it('goes to error handler when getSubmissionForm errors', async () => {
+    const error = new Error();
+    service.getSubmissionForm.mockRejectedValueOnce(error);
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it('goes to error handler when getUserForms errors', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { submissionId: formSubmissionId },
+    });
+    const error = new Error();
+    service.getUserForms.mockRejectedValueOnce(error);
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(error);
   });
 
   it('moves on if a valid API key user has already been set', async () => {
-    const mw = hasSubmissionPermissions(['abc']);
-    const nxt = jest.fn();
-    const req = {
-      apiUser: 1,
-    };
-
-    mw(req, testRes, nxt);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith();
-  });
-
-  it('401s if the request has no formId', async () => {
-    const mw = hasSubmissionPermissions(['abc']);
-    const nxt = jest.fn();
-    const req = {
+    const req = getMockReq({
+      apiUser: true,
       params: {
-        formId: 123,
-      },
-      query: {
-        otherQueryThing: 'abc',
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'Submission Id not found on request.' }));
-  });
-
-  it('401s if the submission was deleted', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({ submission: { deleted: true } });
-
-    const mw = hasSubmissionPermissions(['abc']);
-    const nxt = jest.fn();
-    const req = {
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
-    expect(service.getSubmissionForm).toHaveBeenCalledWith(123);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
-  });
-
-  it('moves on if the form is public and you are only requesting read permission', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: { identityProviders: [{ code: 'random' }, { code: 'public' }] },
-    });
-
-    const mw = hasSubmissionPermissions('submission_read');
-    const nxt = jest.fn();
-    const req = {
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith();
-  });
-
-  it('moves on if the form is public and you are only requesting read permission (only 1 idp)', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: { identityProviders: [{ code: 'public' }] },
-    });
-
-    const mw = hasSubmissionPermissions(['submission_read']);
-    const nxt = jest.fn();
-    const req = {
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith();
-  });
-
-  it('does not allow public access if more than read permission is needed', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: { identityProviders: [{ code: 'public' }] },
-    });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
-
-    const mw = hasSubmissionPermissions(['submission_read', 'submission_delete']);
-    const nxt = jest.fn();
-    const req = {
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
-    expect(service.checkSubmissionPermission).toHaveBeenCalledWith(undefined, 123, ['submission_read', 'submission_delete']);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
-  });
-
-  it('does not allow public access if the form does not have the public idp', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: { identityProviders: [{ code: 'idir' }, { code: 'bceid' }] },
-    });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
-
-    const mw = hasSubmissionPermissions('submission_read');
-    const nxt = jest.fn();
-    const req = {
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
-    expect(service.checkSubmissionPermission).toHaveBeenCalledWith(undefined, 123, ['submission_read']);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
-  });
-
-  it('moves on if the permission check query succeeds', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: { identityProviders: [{ code: 'idir' }, { code: 'bceid' }] },
-    });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(true);
-
-    const mw = hasSubmissionPermissions('submission_read');
-    const nxt = jest.fn();
-    const req = {
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith();
-  });
-
-  it('falls through to the query if the current user has no forms', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: { identityProviders: [{ code: 'idir' }, { code: 'bceid' }] },
-    });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
-
-    const mw = hasSubmissionPermissions('submission_read');
-    const nxt = jest.fn();
-    const cu = {};
-    const req = {
-      currentUser: cu,
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
-    expect(service.checkSubmissionPermission).toHaveBeenCalledWith(cu, 123, ['submission_read']);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
-  });
-
-  it('falls through to the query if the current user has no forms', async () => {
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { id: 456, deleted: false },
-      form: { identityProviders: [{ code: 'idir' }, { code: 'bceid' }] },
-    });
-    service.getUserForms = jest.fn().mockReturnValue([]);
-
-    const nxt = jest.fn();
-    const req = {
-      currentUser: {},
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    const mw = hasSubmissionPermissions('submission_read');
-    await mw(req, testRes, nxt);
-
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
-    expect(service.checkSubmissionPermission).toHaveBeenCalledWith(req.currentUser, 123, ['submission_read']);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
-  });
-
-  it('falls through to the query if the current user does not have any FORM access on the current form', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: { id: '999', identityProviders: [{ code: 'idir' }, { code: 'bceid' }] },
-    });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
-
-    const mw = hasSubmissionPermissions('submission_read');
-    const nxt = jest.fn();
-    const cu = {};
-    const req = {
-      currentUser: cu,
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
-    expect(service.checkSubmissionPermission).toHaveBeenCalledWith(cu, 123, ['submission_read']);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
-  });
-
-  it('falls through to the query if the current user does not have the expected permission for FORM access on the current form', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: {
-        id: '999',
-        identityProviders: [{ code: 'idir' }, { code: 'bceid' }],
+        formSubmissionId: formSubmissionId,
       },
     });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
+    const { res, next } = getMockRes();
 
-    const mw = hasSubmissionPermissions(['submission_delete', 'submission_create']);
-    const nxt = jest.fn();
-    const cu = {};
-    const req = {
-      currentUser: cu,
-      params: {
-        formSubmissionId: 123,
-      },
-    };
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
 
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
-    expect(service.checkSubmissionPermission).toHaveBeenCalledWith(cu, 123, ['submission_delete', 'submission_create']);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(0);
+    expect(service.getUserForms).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
   });
 
-  it('falls through to the query if the current user does not have the expected permission for FORM access on the current form (single check)', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: {
-        id: '999',
-        identityProviders: [{ code: 'idir' }, { code: 'bceid' }],
-      },
+  it('moves on if the user has the exact form permissions', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { deleted: false, id: formSubmissionId },
     });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
-
-    const mw = hasSubmissionPermissions('submission_delete');
-    const nxt = jest.fn();
-    const cu = {};
-    const req = {
-      currentUser: cu,
-      params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
-    expect(service.checkSubmissionPermission).toHaveBeenCalledWith(cu, 123, ['submission_delete']);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'You do not have access to this submission.' }));
-  });
-
-  it('moves on if the user has the appropriate requested permissions', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: {
-        id: '999',
-        identityProviders: [{ code: 'idir' }, { code: 'bceid' }],
-      },
-    });
-    service.getUserForms = jest.fn().mockReturnValue([
+    service.getUserForms.mockReturnValueOnce([
       {
-        formId: '456',
+        // Ignore this form but match formId on the next one.
+        formId: uuid.v4(),
       },
       {
-        formId: '999',
+        formId: formId,
         permissions: ['submission_read', 'submission_update'],
       },
     ]);
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
-
-    const mw = hasSubmissionPermissions(['submission_read', 'submission_update']);
-    const nxt = jest.fn();
-    const req = {
+    const req = getMockReq({
       currentUser: {},
       params: {
-        formSubmissionId: 123,
-      },
-    };
-
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
-    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith();
-  });
-
-  it('moves on if the user has the appropriate requested permissions (single included in array)', async () => {
-    service.getSubmissionForm = jest.fn().mockReturnValue({
-      submission: { deleted: false },
-      form: {
-        id: '999',
-        identityProviders: [{ code: 'idir' }, { code: 'bceid' }],
+        formSubmissionId: formSubmissionId,
       },
     });
-    service.checkSubmissionPermission = jest.fn().mockReturnValue(undefined);
+    const { res, next } = getMockRes();
 
-    const mw = hasSubmissionPermissions('submission_read');
-    const nxt = jest.fn();
-    const cu = {};
-    const req = {
-      currentUser: cu,
-      params: {
-        formSubmissionId: 123,
-      },
-    };
+    await hasSubmissionPermissions(['submission_read', 'submission_update'])(req, res, next);
 
-    await mw(req, testRes, nxt);
-    // just run to the end and fall into the base case
     expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
-    expect(nxt).toHaveBeenCalledTimes(1);
-    expect(nxt).toHaveBeenCalledWith();
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('moves on if the user has extra form permissions', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId },
+      submission: { deleted: false, id: formSubmissionId },
+    });
+    service.getUserForms.mockReturnValueOnce([
+      {
+        // Ignore this form but match formId on the next one.
+        formId: uuid.v4(),
+      },
+      {
+        formId: formId,
+        permissions: ['submission_read', 'submission_update'],
+      },
+    ]);
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_update'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('moves on for public form and read permission', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: { id: formId, identityProviders: [{ code: 'public' }] },
+      submission: { deleted: false, id: formSubmissionId },
+    });
+    service.getUserForms.mockReturnValueOnce([
+      {
+        formId: formId,
+        permissions: [],
+      },
+    ]);
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('moves on for public form and read permission with extra idp', async () => {
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: {
+        id: formId,
+        identityProviders: [{ code: 'random' }, { code: 'public' }],
+      },
+      submission: { deleted: false, id: formSubmissionId },
+    });
+    service.getUserForms.mockReturnValueOnce([
+      {
+        formId: formId,
+        permissions: [],
+      },
+    ]);
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(0);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('moves on if the permission check succeeds', async () => {
+    service.checkSubmissionPermission.mockReturnValueOnce(true);
+    service.getSubmissionForm.mockReturnValueOnce({
+      form: {
+        id: formId,
+        identityProviders: [{ code: 'idir' }, { code: 'bceid' }],
+      },
+      submission: { deleted: false, id: formSubmissionId },
+    });
+    const req = getMockReq({
+      currentUser: {},
+      params: {
+        formSubmissionId: formSubmissionId,
+      },
+    });
+    const { res, next } = getMockRes();
+
+    await hasSubmissionPermissions(['submission_read'])(req, res, next);
+
+    expect(service.checkSubmissionPermission).toHaveBeenCalledTimes(1);
+    expect(service.getSubmissionForm).toHaveBeenCalledTimes(1);
+    expect(service.getUserForms).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
   });
 });
 

--- a/app/tests/unit/forms/file/middleware/filePermissions.spec.js
+++ b/app/tests/unit/forms/file/middleware/filePermissions.spec.js
@@ -196,7 +196,7 @@ describe('hasFileCreate', () => {
 });
 
 describe('hasFilePermissions', () => {
-  const perm = 'submission_read';
+  const perm = ['submission_read'];
 
   const subPermSpy = jest.spyOn(userAccess, 'hasSubmissionPermissions');
   beforeEach(() => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Ideally we'd write tests and then refactor the `userAccess.hasSubmissionPermissions` middleware. However, it needs some changes that would break the tests, particularly with how error responses are created. Do a small refactor so that tests can be written:
- validate the `formSubmissionId` and 400 if it is missing or not a uuid
- `throw Problem` instead of `return next(Problem)` (code climate complaint about early returns)
- simplify interface by always taking an array of permissions (previously allowed a string as a shortcut to an array of one string)

Expand the tests:
- cover the new behaviour above
- increase test coverage
- organize the tests by response code / functionality
- update tests for `hasFormPermissions` to match new layout
- add new tests for `hasFormPermissions` to cover edge cases and service errors

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Refactor (improve code readability and consistency)
Tests (improve automated testing)

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
