### PR TITLE
fix: FORMS-1037 handle missing submission schedule

### DIFF
--- a/app/src/forms/email/reminderService.js
+++ b/app/src/forms/email/reminderService.js
@@ -124,6 +124,8 @@ const service = {
         }),
       ];
     }
+
+    return [];
   },
   _getGraceDate: (schedule) => {
     let substartDate = moment(schedule.openSubmissionDateTime);

--- a/app/tests/unit/forms/email/reminderService.spec.js
+++ b/app/tests/unit/forms/email/reminderService.spec.js
@@ -27,6 +27,16 @@ const schedule = {
   closeSubmissionDateTime: null,
 };
 
+describe('_init', () => {
+  it('should handle reminder enabled with empty schedule', async () => {
+    reminderService._getForms = jest.fn().mockReturnValue([{ schedule: {} }]);
+
+    const result = await reminderService._init();
+
+    expect(result.errors).not.toBe([]);
+  });
+});
+
 describe('getDifference', () => {
   it('should return the difference between 2 arrays of object', () => {
     let obj1 = [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The backend is failing to send out submission reminders due to not handling inconsistent state in the database (FORMS-1036). As a first step fix the backend to be more resilient.
```
TypeError: Cannot read properties of undefined (reading 'length')
    at Object._getReminders (/opt/app-root/src/app/src/forms/email/reminderService.js:153:29)
    at Object._init (/opt/app-root/src/app/src/forms/email/reminderService.js:12:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.sendReminderToSubmitter (/opt/app-root/src/app/src/forms/public/service.js:4:12)
    at async Object.sendReminderToSubmitter (/opt/app-root/src/app/src/forms/public/controller.js:5:24)
    at async /opt/app-root/src/app/src/forms/public/routes.js:25:3
```
## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
