### PR TITLE
fix: FORMS-1017 move file uploads when updating submission

### DIFF
--- a/app/src/forms/file/service.js
+++ b/app/src/forms/file/service.js
@@ -60,6 +60,30 @@ const service = {
     }
   },
 
+  /**
+   * Move a submission file from the "upload" storage location to the
+   * "submission" location. This is used when a submission is either saved as
+   * draft or submitted, and makes the uploaded files permanent.
+   *
+   * @param {uuidv4} submissionId the id of the submission that holds the file.
+   * @param {FileStorage} fileStorage the file storage object for the file.
+   * @param {string} updatedBy the user who is saving the submission.
+   */
+  moveSubmissionFile: async (submissionId, fileStorage, updatedBy) => {
+    // Move the file from its current directory to the "submissions" subdirectory.
+    const path = await storageService.move(fileStorage, 'submissions', submissionId);
+    if (!path) {
+      throw new Error('Error moving files for submission');
+    }
+
+    await FileStorage.query().patchAndFetchById(fileStorage.id, {
+      formSubmissionId: submissionId,
+      path: path,
+      storage: PERMANENT_STORAGE,
+      updatedBy: updatedBy,
+    });
+  },
+
   moveSubmissionFiles: async (submissionId, currentUser) => {
     let trx;
     try {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There is a bug where the experimental feature for “Draft” submissions does not set the `submissionId` or move the files to the `chefs/prod/submissions/` path. This works for the `POST` call, so the `PUT` call should be updated to match its behaviour.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
