### PR TITLE
feat: FORMS-1042 new template rendering route

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -45,7 +45,7 @@ tags:
       This section of the API includes endpoints used to perform various
       operations related to form drafts, for example create or publish a draft
       from a specific version of a form.
-  - name: Document Template
+  - name: Document Templates
     description: >
       Documents can be generated using the Common Document Generation Service
       ([CDOGS](https://bcgov.github.io/common-service-showcase/services/cdogs.html)).
@@ -57,22 +57,20 @@ tags:
       CHEFS app itself) until they stabilize.
 
 
-      The MVP workflow is that a form has a single active document template:
+      Currently only a single document template per form is supported by the
+      CHEFS application:
         1. The `POST /forms/{formId}/documentTemplates` route is used to create
            a document template for a form.
         2. Subsequent calls to the `POST` route should be paired with calls to
            the `DELETE` route to delete the previously active template.
-        3. When it comes time to generate the document, the
-           `GET /forms/{formId}/documentTemplates` route is used to get "all"
-           the document template metadata for a form (although there is only one
-           active document template). This route only returns metadata and not
-           the (possibly huge) template files themselves. 
-        4. The `GET /forms/{formId}/documentTemplates/{documentTemplateId}`
-           route is used to get the specific document template's template file.
-
-      This "double GET" doesn't make a lot of sense when there is only one
-      document template for a form, but this will change soon when we allow the
-      user to choose which template they want to use for document generation.
+        
+      Submission metadata is available for use in the document templates:
+        - `{d.chefs.submissionId}`: the unique identifier for the submission,
+          such as `3cb9acc7-cfd8-4491-b091-1277bc0ec303` 
+        - `{d.chefs.confirmationId}`: The uppercased first eight characters of
+          the `submissionId`, such as `3CB9ACC7`
+        - `{d.chefs.formVersion}`: The numeric version of the form that was used
+          to create the submission, such as `1`
   - name: Submission
     description: >-
       These API endpoints handle the input data provided by a user that
@@ -422,7 +420,7 @@ paths:
         - BearerAuth: []
           OpenID: []
       tags:
-        - Document Template
+        - Document Templates
       parameters:
         - $ref: '#/components/parameters/formIdParam'
       responses:
@@ -454,7 +452,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     post:
-      summary: Create a document template for a form
+      summary: Create a document template
       description: >
         Creates a document template for a form. This makes it easier for users
         to generate documents, as the template is associated with the form and
@@ -465,7 +463,7 @@ paths:
         - BearerAuth: []
           OpenID: []
       tags:
-        - Document Template
+        - Document Templates
       parameters:
         - $ref: '#/components/parameters/formIdParam'
       requestBody:
@@ -502,7 +500,7 @@ paths:
                 $ref: '#/components/schemas/Error'
   /forms/{formId}/documentTemplates/{documentTemplateId}:
     get:
-      summary: Get a document template for a form
+      summary: Get a document template
       description: >
         Gets a document template for the given form. The response will include
         the `template` field, which is the actual document template file.
@@ -512,7 +510,7 @@ paths:
         - BearerAuth: []
           OpenID: []
       tags:
-        - Document Template
+        - Document Templates
       parameters:
         - $ref: '#/components/parameters/formIdParam'
         - $ref: '#/components/parameters/documentTemplateIdParam'
@@ -554,7 +552,7 @@ paths:
         - BearerAuth: []
           OpenID: []
       tags:
-        - Document Template
+        - Document Templates
       parameters:
         - $ref: '#/components/parameters/formIdParam'
         - $ref: '#/components/parameters/documentTemplateIdParam'
@@ -580,7 +578,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
   /forms/{formId}/export:
     get:
       summary: Export submissions for a form
@@ -1724,9 +1721,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /submissions/{formSubmissionId}/template/{documentTemplateId}/render:
+    get:
+      summary: Generate document from submission ID and template ID
+      description: >-
+        Uses form submission data (given the form submission ID) and a document
+        template (given the document template ID) and generates a document
+        containing the submission data.
+
+        #### Common Document Generation Service (CDOGS)
+
+        This endpoint is a passthrough to CDOGS. Instead of using *BasicAuth* to
+        call this endpoint, it is highly recommended that you [directly call
+        CDOGS](https://bcgov.github.io/common-service-showcase/services/cdogs.html).
+        Benefits of calling CDOGS directly from your application:
+          - avoid CHEFS API rate limiting restrictions
+          - avoid CHEFS API timeout restrictions (for large documents)
+          - better performance (direct call instead of passthrough)
+          - ability to use the CDOGS template cache
+          - direct support from the CDOGS team for your specific Client ID
+      operationId: templateIdSubmissionIdRender
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
+      tags:
+        - Document Templates
+      parameters:
+        - $ref: '#/components/parameters/formSubmissionIdParam'
+        - $ref: '#/components/parameters/documentTemplateIdParam'
+      responses:
+        '200':
+          description: Returns the document template with merged variables
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+                description: Raw binary-encoded response
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+              description: >-
+                Indicates if a browser should render this resource inline or
+                treat as an attachment for download
+              example: attachment; filename=file.pdf
+            Content-Type:
+              schema:
+                type: string
+              description: The MIME-type of the binary file payload
+              example: application/pdf
+            RateLimit:
+              $ref: '#/components/headers/RateLimit'
+            RateLimit-Policy:
+              $ref: '#/components/headers/RateLimit-Policy'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /submissions/{formSubmissionId}/template/render:
     post:
-      summary: Generate a document by providing a document template
+      summary: Generate document from submission ID and template object
       description: >-
         Merges data from a form submission into a document template.
 
@@ -1741,13 +1807,13 @@ paths:
           - better performance (direct call instead of passthrough)
           - ability to use the CDOGS template cache
           - direct support from the CDOGS team for your specific Client ID
-      operationId: uploadTemplateAndRenderReport
+      operationId: templateObjectSubmissionIdRender
       security:
         - BasicAuth: []
         - BearerAuth: []
           OpenID: []
       tags:
-        - Document Template
+        - Document Templates
       parameters:
         - $ref: '#/components/parameters/formSubmissionIdParam'
       requestBody:
@@ -3464,7 +3530,7 @@ components:
           description: >
             The file that is the document template to be used in document
             generation.
-          example: Hello {firstName}
+          example: Hello {d.firstName}
     DocumentTemplateResponse:
       allOf:
         - $ref: '#/components/schemas/DocumentTemplateResponseBasic'
@@ -3475,7 +3541,7 @@ components:
               description: >
                 The file that is the document template to be used in document
                 generation.
-              example: Hello {firstName}
+              example: Hello {d.firstName}
     DocumentTemplateResponseBasic:
       allOf:
         - type: object

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -236,6 +236,7 @@ module.exports = {
       next(error);
     }
   },
+
   listEdits: async (req, res, next) => {
     try {
       const response = await service.listEdits(req.params.formSubmissionId);

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -1,6 +1,9 @@
-const { Statuses } = require('../common/constants');
 const cdogsService = require('../../components/cdogsService');
+
+const { Statuses } = require('../common/constants');
 const emailService = require('../email/emailService');
+const formService = require('../form/service');
+
 const service = require('./service');
 
 module.exports = {
@@ -119,6 +122,66 @@ module.exports = {
       next(error);
     }
   },
+
+  /**
+   * Takes a document template ID and a form submission ID and renders the
+   * template into a document.
+   *
+   * @param {Object} req the Express object representing the HTTP request.
+   * @param {Object} res the Express object representing the HTTP response.
+   * @param {Object} next the Express chaining function.
+   */
+  templateRender: async (req, res, next) => {
+    try {
+      const submission = await service.read(req.params.formSubmissionId);
+      const template = await formService.documentTemplateRead(req.params.documentTemplateId);
+      const fileName = template.filename.substring(0, template.filename.lastIndexOf('.'));
+      const fileExtension = template.filename.substring(template.filename.lastIndexOf('.') + 1);
+
+      const templateBody = {
+        data: {
+          ...submission.submission.submission.data,
+          chefs: {
+            confirmationId: submission.submission.confirmationId,
+            formVersion: submission.version.version,
+            submissionId: submission.submission.id,
+          },
+        },
+        options: {
+          convertTo: 'pdf',
+          overwrite: true,
+          reportName: fileName,
+        },
+        template: {
+          content: btoa(template.template),
+          encodingType: 'base64',
+          fileType: fileExtension,
+        },
+      };
+
+      const { data, headers, status } = await cdogsService.templateUploadAndRender(templateBody);
+      const contentDisposition = headers['content-disposition'];
+
+      res
+        .status(status)
+        .set({
+          'Content-Disposition': contentDisposition ? contentDisposition : 'attachment',
+          'Content-Type': headers['content-type'],
+        })
+        .send(data);
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  /**
+   * Takes a document template file and a form submission ID and renders the
+   * template into a document.
+   *
+   * @param {Object} req the Express object representing the HTTP request.
+   * @param {Object} res the Express object representing the HTTP response.
+   * @param {Object} next the Express chaining function.
+   */
   templateUploadAndRender: async (req, res, next) => {
     try {
       const submission = await service.read(req.params.formSubmissionId);
@@ -128,6 +191,7 @@ module.exports = {
           ...submission.submission.submission.data,
           chefs: {
             confirmationId: submission.submission.confirmationId,
+            formVersion: submission.version.version,
             submissionId: submission.submission.id,
           },
         },
@@ -146,6 +210,15 @@ module.exports = {
       next(error);
     }
   },
+
+  /**
+   * Takes a document template file and a form submission object and renders the
+   * template into a document.
+   *
+   * @param {Object} req the Express object representing the HTTP request.
+   * @param {Object} res the Express object representing the HTTP response.
+   * @param {Object} next the Express chaining function.
+   */
   draftTemplateUploadAndRender: async (req, res, next) => {
     try {
       const templateBody = { ...req.body.template, data: req.body.submission.data };

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -5,8 +5,11 @@ const controller = require('./controller');
 const P = require('../common/constants').Permissions;
 const { currentUser, hasSubmissionPermissions, filterMultipleSubmissions } = require('../auth/middleware/userAccess');
 const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
+const validateParameter = require('../common/middleware/validateParameter');
 
 routes.use(currentUser);
+
+routes.param('documentTemplateId', validateParameter.validateDocumentTemplateId);
 
 routes.get('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.read(req, res, next);
@@ -56,6 +59,10 @@ routes.get('/:formSubmissionId/edits', hasSubmissionPermissions(P.SUBMISSION_REA
   await controller.listEdits(req, res, next);
 });
 
+routes.get('/:formSubmissionId/template/:documentTemplateId/render', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
+  await controller.templateRender(req, res, next);
+});
+
 routes.post('/:formSubmissionId/template/render', rateLimiter, apiAccess, hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
   await controller.templateUploadAndRender(req, res, next);
 });
@@ -63,10 +70,5 @@ routes.post('/:formSubmissionId/template/render', rateLimiter, apiAccess, hasSub
 routes.delete('/:formSubmissionId/:formId/submissions', hasSubmissionPermissions(P.SUBMISSION_DELETE), filterMultipleSubmissions(), async (req, res, next) => {
   await controller.deleteMutipleSubmissions(req, res, next);
 });
-
-// Implement this when we want to fetch a specific audit row including the whole old submission record
-// routes.get('/:formSubmissionId/edits/:auditId', hasSubmissionPermissions(P.SUBMISSION_READ), async (req, res, next) => {
-//   await controller.listEdits(req, res, next);
-// });
 
 module.exports = routes;

--- a/app/tests/unit/forms/submission/routes.spec.js
+++ b/app/tests/unit/forms/submission/routes.spec.js
@@ -1,0 +1,72 @@
+const request = require('supertest');
+const { v4: uuidv4 } = require('uuid');
+
+const { expressHelper } = require('../../../common/helper');
+
+const apiAccess = require('../../../../src/forms/auth/middleware/apiAccess');
+const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
+const rateLimiter = require('../../../../src/forms/common/middleware/rateLimiter');
+const validateParameter = require('../../../../src/forms/common/middleware/validateParameter');
+const controller = require('../../../../src/forms/submission/controller');
+
+//
+// Mock out all the middleware - we're testing that the routes are set up
+// correctly, not the functionality of the middleware.
+//
+
+jest.mock('../../../../src/forms/auth/middleware/apiAccess');
+apiAccess.mockImplementation(
+  jest.fn((_req, _res, next) => {
+    next();
+  })
+);
+
+controller.templateRender = jest.fn((_req, _res, next) => {
+  next();
+});
+
+rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
+  next();
+});
+
+const hasSubmissionPermissionsMock = jest.fn((_req, _res, next) => {
+  next();
+});
+
+userAccess.hasSubmissionPermissions = jest.fn(() => {
+  return hasSubmissionPermissionsMock;
+});
+
+validateParameter.validateDocumentTemplateId = jest.fn((_req, _res, next) => {
+  next();
+});
+
+const documentTemplateId = uuidv4();
+const formSubmissionId = uuidv4();
+
+//
+// Create the router and a simple Express server.
+//
+
+const router = require('../../../../src/forms/submission/routes');
+const basePath = '/submissions';
+const app = expressHelper(basePath, router);
+const appRequest = request(app);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe(`${basePath}/:formSubmissionId/template/:documentTemplateId/render`, () => {
+  const path = `${basePath}/${formSubmissionId}/template/${documentTemplateId}/render`;
+
+  it('should have correct middleware for GET', async () => {
+    await appRequest.get(path);
+
+    expect(validateParameter.validateDocumentTemplateId).toHaveBeenCalledTimes(1);
+    expect(apiAccess).toHaveBeenCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toHaveBeenCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toHaveBeenCalledTimes(1);
+    expect(controller.templateRender).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/tests/unit/routes/v1/submission.spec.js
+++ b/app/tests/unit/routes/v1/submission.spec.js
@@ -588,6 +588,9 @@ describe(`${basePath}/:formSubmissionId/template/render`, () => {
         submission: {
           submission: {},
         },
+        version: {
+          version: 1,
+        },
       };
       const renderResponse = {
         headers: {},


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Now that the user can upload document templates for their forms, it would be nice if there was an endpoint that took just a submission id and a template id. This saves the frontend from getting the template and then posting it back to render it.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This won't work for draft submissions, so maybe we need another endpoint for that.