### PR TITLE
Add encoded JWT token to CHEFS context

### DIFF
--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -148,6 +148,7 @@ export default {
         evalContext: {
           token: this.tokenParsed,
           user: this.user,
+          encoded_token: this.keycloak.token,
         },
       };
     },

--- a/components/src/overrides/editform/utils.ts
+++ b/components/src/overrides/editform/utils.ts
@@ -15,6 +15,7 @@ function logicVariablesTable(additional = '') {
 
   const customEval =
     '<tr><th>token</th><td>The decoded JWT token for the authenticated user.</td></tr>' +
+    '<tr><th>encoded_token</th><td>The encoded JWT token for the authenticated user.</td></tr>' +
     '<tr><th>user</th><td>The currently logged in user</td></tr>';
   return originalLogicVariablesTable(additional + customEval);
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

This PR is to add the encoded JWT token to CHEFS context to use it in `Calculated values` same way as `token` (decoded JWT token) and `user`. That would mean we can use it to call CHEFS API securely by using full `encoded JWT token` in a header instead unrestricted `API key`. Also, this would help identify the user who calling the API, which is required by RLS (Row level Security)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
