### PR TITLE
Status Panel dropdown assignment subtitle fix.

### DIFF
--- a/app/frontend/src/components/forms/submission/StatusPanel.vue
+++ b/app/frontend/src/components/forms/submission/StatusPanel.vue
@@ -410,7 +410,7 @@ export default {
                   <v-list-item
                     v-bind="props"
                     :title="`${item?.raw?.fullName} (${item?.raw?.email})`"
-                    :subtitle="`${item?.raw?.username} (${item?.raw?.idpCode})`"
+                    :subtitle="`${item?.raw?.username} (${item?.raw?.user_idpCode})`"
                   >
                   </v-list-item>
                 </template>


### PR DESCRIPTION
![image](https://github.com/bcgov/common-hosted-form-service/assets/39388115/215c343f-c1f1-4a2b-b28b-92803b4ddaf2)
<!-- Provide a general summary of your changes in the Title above -->
# Description
Status Panel - the assignment dropdown list was not populating the user's idp.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Update code to read the correct value coming from the view query (these are not transformed into user objects so need the name of the view column).

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
