### PR TITLE
CDOGS Template Fix After Vuetify Upgrade

### DIFF
--- a/app/frontend/src/components/forms/manage/DocumentTemplate.vue
+++ b/app/frontend/src/components/forms/manage/DocumentTemplate.vue
@@ -148,10 +148,7 @@ export default {
     async handleDelete(item) {
       this.loading = true;
       try {
-        await formService.documentTemplateDelete(
-          this.form.id,
-          item.raw.templateId
-        );
+        await formService.documentTemplateDelete(this.form.id, item.templateId);
         this.fetchDocumentTemplates();
         this.addNotification({
           text: i18n.t('trans.documentTemplate.deleteSuccess'),
@@ -173,7 +170,7 @@ export default {
       try {
         const result = await formService.documentTemplateRead(
           this.form.id,
-          item.raw.templateId
+          item.templateId
         );
         const base64EncodedData = result.data.template.data
           .map((byte) => String.fromCharCode(byte))
@@ -186,7 +183,7 @@ export default {
           bytes[i] = binaryString.charCodeAt(i);
         }
         const blob = new Blob([bytes], {
-          type: this.getMimeType(item.raw.filename),
+          type: this.getMimeType(item.filename),
         });
         const url = window.URL.createObjectURL(blob);
 
@@ -198,7 +195,7 @@ export default {
           // Create an anchor element and trigger download
           const a = document.createElement('a');
           a.href = url;
-          a.download = item.raw.filename;
+          a.download = item.filename;
           document.body.appendChild(a);
           a.click();
           window.URL.revokeObjectURL(url);
@@ -270,12 +267,12 @@ export default {
     >
       <!-- Created date  -->
       <template #item.createdAt="{ item }">
-        {{ $filters.formatDateLong(item.raw.createdAt) }}
+        {{ $filters.formatDateLong(item.createdAt) }}
       </template>
 
       <!-- Preview/Download File -->
       <template #item.filename="{ item }">
-        <span v-if="!enablePreview">{{ item.raw.filename }}</span>
+        <span v-if="!enablePreview">{{ item.filename }}</span>
         <v-tooltip v-if="enablePreview" location="bottom">
           <template #activator="{ props }">
             <a
@@ -283,7 +280,7 @@ export default {
               v-bind="props"
               @click="handleFileAction(item, 'preview')"
             >
-              {{ item.raw.filename }}
+              {{ item.filename }}
             </a>
           </template>
           <span :lang="lang">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

The `v-data-table-server` component does not require using the `raw` keyword to access its data items after the Vuetify upgrade. 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
