### PR TITLE
refactor: FORMS-1227 remove hardcoded test jwts

### DIFF
--- a/app/tests/unit/forms/auth/middleware/userAccess.spec.js
+++ b/app/tests/unit/forms/auth/middleware/userAccess.spec.js
@@ -13,6 +13,8 @@ const formSubmissionId = uuid.v4();
 const userId = 'c6455376-382c-439d-a811-0381a012d695';
 const userId2 = 'c6455376-382c-439d-a811-0381a012d696';
 
+const bearerToken = Math.random().toString(36).substring(2);
+
 const Roles = {
   OWNER: 'owner',
   TEAM_MANAGER: 'team_manager',
@@ -22,7 +24,7 @@ const Roles = {
 };
 
 jwtService.validateAccessToken = jest.fn().mockReturnValue(true);
-jwtService.getBearerToken = jest.fn().mockReturnValue('bearer-token-value');
+jwtService.getBearerToken = jest.fn().mockReturnValue(bearerToken);
 jwtService.getTokenPayload = jest.fn().mockReturnValue({ token: 'payload' });
 
 // Mock the service login
@@ -49,7 +51,7 @@ describe('currentUser', () => {
         formId: 2,
       },
       headers: {
-        authorization: 'Bearer hjvds0uds',
+        authorization: 'Bearer ' + bearerToken,
       },
     };
 
@@ -58,7 +60,7 @@ describe('currentUser', () => {
     await currentUser(testReq, testRes, nxt);
     expect(jwtService.validateAccessToken).toHaveBeenCalledTimes(1);
     expect(jwtService.getBearerToken).toHaveBeenCalledTimes(1);
-    expect(jwtService.validateAccessToken).toHaveBeenCalledWith('bearer-token-value');
+    expect(jwtService.validateAccessToken).toHaveBeenCalledWith(bearerToken);
     expect(service.login).toHaveBeenCalledTimes(1);
     expect(service.login).toHaveBeenCalledWith({ token: 'payload' });
     expect(testReq.currentUser).toEqual(mockUser);
@@ -75,7 +77,7 @@ describe('currentUser', () => {
         formId: 99,
       },
       headers: {
-        authorization: 'Bearer hjvds0uds',
+        authorization: 'Bearer ' + bearerToken,
       },
     };
 
@@ -91,7 +93,7 @@ describe('currentUser', () => {
         formId: 99,
       },
       headers: {
-        authorization: 'Bearer hjvds0uds',
+        authorization: 'Bearer ' + bearerToken,
       },
     };
 
@@ -104,7 +106,7 @@ describe('currentUser', () => {
   it('401s if the token is invalid', async () => {
     const testReq = {
       headers: {
-        authorization: 'Bearer hjvds0uds',
+        authorization: 'Bearer ' + bearerToken,
       },
     };
 
@@ -114,7 +116,7 @@ describe('currentUser', () => {
     await currentUser(testReq, testRes, nxt);
     expect(jwtService.getBearerToken).toHaveBeenCalledTimes(1);
     expect(jwtService.validateAccessToken).toHaveBeenCalledTimes(1);
-    expect(jwtService.validateAccessToken).toHaveBeenCalledWith('bearer-token-value');
+    expect(jwtService.validateAccessToken).toHaveBeenCalledWith(bearerToken);
     expect(service.login).toHaveBeenCalledTimes(0);
     expect(testReq.currentUser).toEqual(undefined);
     expect(nxt).toHaveBeenCalledWith(new Problem(401, { detail: 'Authorization token is invalid.' }));

--- a/app/tests/unit/forms/file/middleware/filePermissions.spec.js
+++ b/app/tests/unit/forms/file/middleware/filePermissions.spec.js
@@ -11,6 +11,8 @@ const testRes = {
 const zeroUuid = '00000000-0000-0000-0000-000000000000';
 const oneUuid = '11111111-1111-1111-1111-111111111111';
 
+const bearerToken = Math.random().toString(36).substring(2);
+
 describe('currentFileRecord', () => {
   const readFileSpy = jest.spyOn(service, 'read');
 
@@ -147,7 +149,7 @@ describe('hasFileCreate', () => {
   it('403s if there is no current user on the request scope', async () => {
     const testReq = {
       headers: {
-        authorization: 'Bearer hjvds0uds',
+        authorization: 'Bearer ' + bearerToken,
       },
     };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

GitHub is complaining about hard-coded dummy token values in the unit tests. Replace the hard-coded strings with random values.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Refactor (non-breaking change to improve code quality)
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
