### PR TITLE
test: FORMS-1265 rewrite tests for hasRolePermissions

### DIFF
--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -10,7 +10,7 @@ const rbacService = require('../../rbac/service');
 /**
  * Checks that the user's permissions contains every required permission.
  *
- * @param {string[]} userPermissions the permissions that the user has.
+ * @param {string[]|undefined} userPermissions the permissions the user has.
  * @param {string[]} requiredPermissions the permissions needed for access.
  * @returns true if all required permissions are in the user permissions.
  */
@@ -33,7 +33,7 @@ const _hasAllPermissions = (userPermissions, requiredPermissions) => {
 /**
  * Checks that the user's permissions contains any of the required permissions.
  *
- * @param {string[]} userPermissions the permissions that the user has.
+ * @param {string[]|undefined} userPermissions the permissions the user has.
  * @param {string[]} requiredPermissions the permissions needed for access.
  * @returns true if any required permissions is in the user permissions.
  */
@@ -353,8 +353,17 @@ const hasFormRoles = (roles) => {
   };
 };
 
+/**
+ * Express middleware to check that the calling user has one of the given roles for
+ * the form identified by params.formId or query.formId. This falls through if
+ * everything is OK, otherwise it calls next() with a Problem describing the
+ * error.
+ *
+ * @param {string[]} roles the roles the user needs one of for the form.
+ * @returns nothing
+ */
 const hasRolePermissions = (removingUsers = false) => {
-  return async (req, res, next) => {
+  return async (req, _res, next) => {
     try {
       // If we invoke this middleware and the caller is acting on a specific formId, whether in a param or query (precedence to param)
       const formId = req.params.formId || req.query.formId;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Rewriting the `userAccess.hasRolePermissions` tests so that we have nearly 100% coverage. Missing a test for the form ID not existing, but that probably is a bug that needs to be reworked eventually.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Test (changes only made to tests)
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

- This function should probably be split into two. It's very specific to a couple of endpoints, and maybe it doesn't need to be in the middleware? TBD.
- I'm not a fan of using the "detail" string in the tests, as it's fragile. It would be better to have API-specific error codes that could be used, but that's a much bigger issue. In the meantime using the "detail", otherwise there's a pile of 401 errors and you can't otherwise be sure the mocks are triggering the right one.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
