### PR TITLE
refactor: FORMS-1265 split hasRolePermissions into two methods

### DIFF
--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -256,111 +256,135 @@ const hasFormRoles = (roles) => {
 };
 
 /**
- * Express middleware to check that the calling user has one of the given roles for
- * the form identified by params.formId or query.formId. This falls through if
- * everything is OK, otherwise it calls next() with a Problem describing the
+ * Express middleware to check that the calling user is allowed to delete roles
+ * for the form identified by params.formId or query.formId. This falls through
+ * if everything is OK, otherwise it calls next() with a Problem describing the
  * error.
  *
- * @param {string[]} roles the roles the user needs one of for the form.
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
  * @returns nothing
  */
-const hasRolePermissions = (removingUsers = false) => {
-  return async (req, _res, next) => {
-    try {
-      const currentUser = req.currentUser;
+const hasRoleDeletePermissions = async (req, _res, next) => {
+  try {
+    const currentUser = req.currentUser;
 
-      // The request must include a formId, either in params or query, but give
-      // precedence to params.
-      const form = await _getForm(currentUser, req.params.formId || req.query.formId, false);
-      const isOwner = form.roles.includes(Roles.OWNER);
+    // The request must include a formId, either in params or query, but give
+    // precedence to params.
+    const form = await _getForm(currentUser, req.params.formId || req.query.formId, false);
 
-      if (removingUsers) {
-        const userIds = req.body;
-        if (userIds.includes(currentUser.id)) {
-          throw new Problem(401, {
-            detail: "You can't remove yourself from this form.",
-          });
-        }
+    const userIds = req.body;
+    if (userIds.includes(currentUser.id)) {
+      throw new Problem(401, {
+        detail: "You can't remove yourself from this form.",
+      });
+    }
 
-        if (!isOwner) {
-          for (const userId of userIds) {
-            if (!uuid.validate(userId)) {
-              throw new Problem(400, {
-                detail: 'Bad userId',
-              });
-            }
-
-            // Convert to an array of role strings, rather than the objects.
-            const userRoles = (await rbacService.readUserRole(userId, form.formId)).map((userRole) => userRole.role);
-
-            // A non-owner can't delete an owner.
-            if (userRoles.includes(Roles.OWNER) && userId !== currentUser.id) {
-              throw new Problem(401, {
-                detail: "You can not update an owner's roles.",
-              });
-            }
-
-            // A non-owner can't delete a form designer.
-            if (userRoles.includes(Roles.FORM_DESIGNER)) {
-              throw new Problem(401, {
-                detail: "You can't remove a form designer role.",
-              });
-            }
-          }
-        }
-      } else {
-        const userId = req.params.userId || req.query.userId;
+    const isOwner = form.roles.includes(Roles.OWNER);
+    if (!isOwner) {
+      for (const userId of userIds) {
         if (!uuid.validate(userId)) {
           throw new Problem(400, {
             detail: 'Bad userId',
           });
         }
 
-        if (!isOwner) {
-          // Convert to arrays of role strings, rather than the objects.
-          const userRoles = (await rbacService.readUserRole(userId, form.formId)).map((userRole) => userRole.role);
-          const futureRoles = req.body.map((userRole) => userRole.role);
+        // Convert to an array of role strings, rather than the objects.
+        const userRoles = (await rbacService.readUserRole(userId, form.formId)).map((userRole) => userRole.role);
 
-          // If the user is trying to remove the team manager role for their own userid
-          if (userRoles.includes(Roles.TEAM_MANAGER) && !futureRoles.includes(Roles.TEAM_MANAGER) && userId == currentUser.id) {
-            throw new Problem(401, {
-              detail: "You can't remove your own team manager role.",
-            });
-          }
+        // A non-owner can't delete an owner.
+        if (userRoles.includes(Roles.OWNER) && userId !== currentUser.id) {
+          throw new Problem(401, {
+            detail: "You can not update an owner's roles.",
+          });
+        }
 
-          // Can't update another user's roles if they are an owner
-          if (userRoles.includes(Roles.OWNER) && userId !== currentUser.id) {
-            throw new Problem(401, {
-              detail: "You can't update an owner's roles.",
-            });
-          }
-
-          if (!userRoles.includes(Roles.OWNER) && futureRoles.includes(Roles.OWNER)) {
-            throw new Problem(401, {
-              detail: "You can't add an owner role.",
-            });
-          }
-
-          // If the user is trying to remove the designer role for another userid
-          if (userRoles.includes(Roles.FORM_DESIGNER) && !futureRoles.includes(Roles.FORM_DESIGNER)) {
-            throw new Problem(401, {
-              detail: "You can't remove a form designer role.",
-            });
-          }
-
-          if (!userRoles.includes(Roles.FORM_DESIGNER) && futureRoles.includes(Roles.FORM_DESIGNER)) {
-            throw new Problem(401, {
-              detail: "You can't add a form designer role.",
-            });
-          }
+        // A non-owner can't delete a form designer.
+        if (userRoles.includes(Roles.FORM_DESIGNER)) {
+          throw new Problem(401, {
+            detail: "You can't remove a form designer role.",
+          });
         }
       }
-
-      next();
-    } catch (error) {
-      next(error);
     }
-  };
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Express middleware to check that the calling user is allowed to modify roles
+ * for the form identified by params.formId or query.formId. This falls through
+ * if everything is OK, otherwise it calls next() with a Problem describing the
+ * error.
+ *
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @returns nothing
+ */
+const hasRoleModifyPermissions = async (req, _res, next) => {
+  try {
+    const currentUser = req.currentUser;
+
+    // The request must include a formId, either in params or query, but give
+    // precedence to params.
+    const form = await _getForm(currentUser, req.params.formId || req.query.formId, false);
+
+    const userId = req.params.userId || req.query.userId;
+    if (!uuid.validate(userId)) {
+      throw new Problem(400, {
+        detail: 'Bad userId',
+      });
+    }
+
+    const isOwner = form.roles.includes(Roles.OWNER);
+    if (!isOwner) {
+      // Convert to arrays of role strings, rather than the objects.
+      const userRoles = (await rbacService.readUserRole(userId, form.formId)).map((userRole) => userRole.role);
+      const futureRoles = req.body.map((userRole) => userRole.role);
+
+      // If the user is trying to remove the team manager role for their own userid
+      if (userRoles.includes(Roles.TEAM_MANAGER) && !futureRoles.includes(Roles.TEAM_MANAGER) && userId == currentUser.id) {
+        throw new Problem(401, {
+          detail: "You can't remove your own team manager role.",
+        });
+      }
+
+      // Can't update another user's roles if they are an owner
+      if (userRoles.includes(Roles.OWNER) && userId !== currentUser.id) {
+        throw new Problem(401, {
+          detail: "You can't update an owner's roles.",
+        });
+      }
+
+      if (!userRoles.includes(Roles.OWNER) && futureRoles.includes(Roles.OWNER)) {
+        throw new Problem(401, {
+          detail: "You can't add an owner role.",
+        });
+      }
+
+      // If the user is trying to remove the designer role for another userid
+      if (userRoles.includes(Roles.FORM_DESIGNER) && !futureRoles.includes(Roles.FORM_DESIGNER)) {
+        throw new Problem(401, {
+          detail: "You can't remove a form designer role.",
+        });
+      }
+
+      if (!userRoles.includes(Roles.FORM_DESIGNER) && futureRoles.includes(Roles.FORM_DESIGNER)) {
+        throw new Problem(401, {
+          detail: "You can't add a form designer role.",
+        });
+      }
+    }
+
+    next();
+  } catch (error) {
+    next(error);
+  }
 };
 
 /**
@@ -444,6 +468,7 @@ module.exports = {
   filterMultipleSubmissions,
   hasFormPermissions,
   hasFormRoles,
-  hasRolePermissions,
+  hasRoleDeletePermissions,
+  hasRoleModifyPermissions,
   hasSubmissionPermissions,
 };

--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -348,33 +348,35 @@ const hasRoleModifyPermissions = async (req, _res, next) => {
       const futureRoles = req.body.map((userRole) => userRole.role);
 
       // If the user is trying to remove the team manager role for their own userid
-      if (userRoles.includes(Roles.TEAM_MANAGER) && !futureRoles.includes(Roles.TEAM_MANAGER) && userId == currentUser.id) {
+      if (userRoles.includes(Roles.TEAM_MANAGER) && !futureRoles.includes(Roles.TEAM_MANAGER) && userId === currentUser.id) {
         throw new Problem(401, {
           detail: "You can't remove your own team manager role.",
         });
       }
 
-      // Can't update another user's roles if they are an owner
-      if (userRoles.includes(Roles.OWNER) && userId !== currentUser.id) {
-        throw new Problem(401, {
-          detail: "You can't update an owner's roles.",
-        });
-      }
-
-      if (!userRoles.includes(Roles.OWNER) && futureRoles.includes(Roles.OWNER)) {
+      if (userRoles.includes(Roles.OWNER)) {
+        // Can't remove a different user's owner role unless you are an owner.
+        if (userId !== currentUser.id) {
+          throw new Problem(401, {
+            detail: "You can't update an owner's roles.",
+          });
+        }
+      } else if (futureRoles.includes(Roles.OWNER)) {
+        // Can't add an owner role unless you are an owner.
         throw new Problem(401, {
           detail: "You can't add an owner role.",
         });
       }
 
-      // If the user is trying to remove the designer role for another userid
-      if (userRoles.includes(Roles.FORM_DESIGNER) && !futureRoles.includes(Roles.FORM_DESIGNER)) {
-        throw new Problem(401, {
-          detail: "You can't remove a form designer role.",
-        });
-      }
-
-      if (!userRoles.includes(Roles.FORM_DESIGNER) && futureRoles.includes(Roles.FORM_DESIGNER)) {
+      if (userRoles.includes(Roles.FORM_DESIGNER)) {
+        // Can't remove form designer if you are not an owner.
+        if (!futureRoles.includes(Roles.FORM_DESIGNER)) {
+          throw new Problem(401, {
+            detail: "You can't remove a form designer role.",
+          });
+        }
+      } else if (futureRoles.includes(Roles.FORM_DESIGNER)) {
+        // Can't add form designer if you are not an owner.
         throw new Problem(401, {
           detail: "You can't add a form designer role.",
         });

--- a/app/src/forms/rbac/routes.js
+++ b/app/src/forms/rbac/routes.js
@@ -4,7 +4,7 @@ const controller = require('./controller');
 const jwtService = require('../../components/jwtService');
 const P = require('../common/constants').Permissions;
 const R = require('../common/constants').Roles;
-const { currentUser, hasFormPermissions, hasSubmissionPermissions, hasFormRoles, hasRolePermissions } = require('../auth/middleware/userAccess');
+const { currentUser, hasFormPermissions, hasFormRoles, hasRoleDeletePermissions, hasRoleModifyPermissions, hasSubmissionPermissions } = require('../auth/middleware/userAccess');
 
 routes.use(currentUser);
 
@@ -40,11 +40,11 @@ routes.get('/users', jwtService.protect('admin'), async (req, res, next) => {
   await controller.getUserForms(req, res, next);
 });
 
-routes.put('/users', hasFormPermissions([P.TEAM_UPDATE]), hasFormRoles([R.OWNER, R.TEAM_MANAGER]), hasRolePermissions(false), async (req, res, next) => {
+routes.put('/users', hasFormPermissions([P.TEAM_UPDATE]), hasFormRoles([R.OWNER, R.TEAM_MANAGER]), hasRoleModifyPermissions, async (req, res, next) => {
   await controller.setUserForms(req, res, next);
 });
 
-routes.delete('/users', hasFormPermissions([P.TEAM_UPDATE]), hasFormRoles([R.OWNER, R.TEAM_MANAGER]), hasRolePermissions(true), async (req, res, next) => {
+routes.delete('/users', hasFormPermissions([P.TEAM_UPDATE]), hasFormRoles([R.OWNER, R.TEAM_MANAGER]), hasRoleDeletePermissions, async (req, res, next) => {
   await controller.removeMultiUsers(req, res, next);
 });
 

--- a/app/tests/unit/routes/v1/rbac.spec.js
+++ b/app/tests/unit/routes/v1/rbac.spec.js
@@ -31,10 +31,11 @@ userAccess.hasFormRoles = jest.fn(() => {
     next();
   });
 });
-userAccess.hasRolePermissions = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
+userAccess.hasRoleDeletePermissions = jest.fn((_req, _res, next) => {
+  next();
+});
+userAccess.hasRoleModifyPermissions = jest.fn((_req, _res, next) => {
+  next();
 });
 userAccess.hasSubmissionPermissions = jest.fn(() => {
   return jest.fn((_req, _res, next) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The `userAccess.hasRolePermissions(removingUsers=false)` function is being flagged by Code Climate as being too long and too complex. Since it is basically two separate functions, split it into two:
- `hasRoleDeletePermissions`: functionality of `hasRolePermissions(true)`
- `hasRoleModifyPermissions`: functionality of `hasRolePermissions(false)`

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Refactor (no function code changes but improve the code quality)
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
