### PR TITLE
fix: FORMS-993 handle trailing comma in get submissions

### DIFF
--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -358,9 +358,11 @@ const service = {
       .modify('filterVersion', params.version)
       .modify('filterformSubmissionStatusCode', params.filterformSubmissionStatusCode)
       .modify('orderDefault', params.sortBy && params.page ? true : false, params);
-    if (params.createdAt && Array.isArray(params.createdAt) && params.createdAt.length == 2) {
+
+    if (params.createdAt && Array.isArray(params.createdAt) && params.createdAt.length === 2) {
       query.modify('filterCreatedAt', params.createdAt[0], params.createdAt[1]);
     }
+
     const selection = ['confirmationId', 'createdAt', 'formId', 'formSubmissionStatusCode', 'submissionId', 'deleted', 'createdBy', 'formVersionId'];
 
     if (params.fields && params.fields.length) {
@@ -376,8 +378,11 @@ const service = {
       } else {
         fields = params.fields.split(',').map((s) => s.trim());
       }
-      // remove updatedAt and updatedBy from custom selected field so they won't be pulled from submission columns
-      fields = fields.filter((f) => f !== 'updatedAt' && f !== 'updatedBy');
+
+      // Remove updatedAt and updatedBy so they won't be pulled from submission
+      // columns. Also remove empty values to handle the case of trailing commas
+      // and other malformed data too.
+      fields = fields.filter((f) => f !== 'updatedAt' && f !== 'updatedBy' && f.trim() !== '');
 
       fields.push('lateEntry');
       query.select(
@@ -390,9 +395,11 @@ const service = {
         ['lateEntry'].map((f) => ref(`submission:data.${f}`).as(f.split('.').slice(-1)))
       );
     }
+
     if (params.paginationEnabled) {
       return await service.processPaginationData(query, parseInt(params.page), parseInt(params.itemsPerPage), params.totalSubmissions, params.search, params.searchEnabled);
     }
+
     return query;
   },
 

--- a/app/tests/unit/forms/form/service.spec.js
+++ b/app/tests/unit/forms/form/service.spec.js
@@ -446,6 +446,14 @@ describe('_findFileIds', () => {
   });
 });
 
+describe('listFormSubmissions', () => {
+  it('should not error if fields has a trailing commma', async () => {
+    await service.listFormSubmissions(formId, { fields: 'x,' });
+
+    expect(MockModel.select).toBeCalledTimes(1);
+  });
+});
+
 describe('readVersionFields', () => {
   it('should not return hidden fields', async () => {
     const schema = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix a problem where a trailing comma in the fields parameters was causing the get submissions endpoint to produce a 500 error. Added an exclusion for any fields that are empty or all spaces.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
