### PR TITLE
fix: FORMS-1113 handle bad json in export

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -615,28 +615,28 @@ paths:
           name: preference
           schema:
             type: object
-          example: '{ minDate=2020-12-17T08:00:00Z, maxDate=2020-12-17T08:00:00Z, updatedMinDate=2020-12-17T08:00:00Z, updatedMaxDate=2020-12-17T08:00:00Z }'
+          example: '{minDate=2020-12-17T08:00:00Z,maxDate=2020-12-18T08:00:00Z,updatedMinDate=2020-12-17T08:00:00Z,updatedMaxDate=2020-12-18T08:00:00Z}'
           description: form submissions export preferences
         - in: query
           name: deleted
           schema:
             type: boolean
-          description: (optional) This optional parameter should be set to true if deleted records (submissions) need to be fetched
+          description: Set to true to return deleted submissions
           example: false
         - in: query
           name: drafts
           schema:
             type: boolean
-          description: (optional) This optional parameter should be set to true if draft records (submissions) need to be fetched
+          description: Set to true to return draft submissions
           example: false
         - in: query
           name: columns
           schema:
             type: array
-          description: (optional) List of form level columns (Only Allowed draft, deleted, updatedAt columns) to be include. Other then allowed columns will be ignored
+          description: List of form level columns (Only Allowed `deleted`, `draft`, `updatedAt`) to be included, others will be ignored
           example:
-            - draft,
             - deleted,
+            - draft,
             - updatedAt
         - in: query
           name: status

--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -192,14 +192,35 @@ const service = {
     });
   },
 
-  _getSubmissions: async (form, params, version) => {
-    //let preference = params.preference ? JSON.parse(params.preference) : undefined;
-    let preference;
-    if (params.preference && _.isString(params.preference)) {
-      preference = JSON.parse(params.preference);
+  /**
+   * Parse the preferences that come in on the request.
+   *
+   * @param {any} preferences the preferences - probably a string or undefined
+   * but unsure exactly what this could be.
+   * @returns {any} the preferences. If a string was given as an argument then
+   * it's treated as JSON and an object is returned.
+   */
+  _parsePreferences: (preferences) => {
+    let parsedPreferences;
+    if (preferences && _.isString(preferences)) {
+      try {
+        parsedPreferences = JSON.parse(preferences);
+      } catch (error) {
+        throw new Problem(400, {
+          detail: 'Bad preferences: ' + error.message,
+        });
+      }
     } else {
-      preference = params.preference;
+      // What is this? How is it not a string? Is this just handling undefined?
+      parsedPreferences = preferences;
     }
+
+    return parsedPreferences;
+  },
+
+  _getSubmissions: async (form, params, version) => {
+    const preference = service._parsePreferences(params.preference);
+
     // let submissionData;
     // params for this export include minDate and maxDate (full timestamp dates).
     return SubmissionData.query()

--- a/app/tests/unit/forms/form/exportService.spec.js
+++ b/app/tests/unit/forms/form/exportService.spec.js
@@ -36,6 +36,15 @@ describe('export', () => {
     };
     exportService._getForm = jest.fn().mockReturnValue(form);
 
+    describe('400 response when', () => {
+      test('invalid preferences json', async () => {
+        const params = { preference: '{' };
+        exportService._readLatestFormSchema = jest.fn().mockReturnValueOnce();
+
+        await expect(exportService.export(formId, params, currentUser)).rejects.toThrow('400');
+      });
+    });
+
     describe('type 1', () => {
       const params = {
         emailExport: false,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The export was producing 500 errors when the `preference` parameter was unparseable JSON. Added a new internal function to deal with the `preference` and put the JSON parsing in a try/catch block.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
