### PR TITLE
fix: FORMS-1274 invalid export template

### DIFF
--- a/app/src/forms/email/emailService.js
+++ b/app/src/forms/email/emailService.js
@@ -449,13 +449,11 @@ const service = {
    * @function submissionExportLink
    * Email with the link to the Form submissions export file
    * @param {string} formId
-   * @param {string} submissionId
    * @param {object} body
-   * @param {string} referer
    * @param {string} fileId
    * @returns The result of the email merge operation
    */
-  submissionExportLink: async (formId, submissionId, body, referer, fileId) => {
+  submissionExportLink: async (formId, body, fileId) => {
     try {
       const form = await formService.readForm(formId);
       const contextToVal = [body.to];
@@ -487,7 +485,6 @@ const service = {
         function: EmailTypes.SUBMISSION_EXPORT,
         formId: formId,
         body: body,
-        referer: referer,
       });
       throw e;
     }

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -73,7 +73,7 @@ module.exports = {
 
   export: async (req, res, next) => {
     try {
-      const result = await exportService.export(req.params.formId, req.query, req.currentUser, req.headers.referer);
+      const result = await exportService.export(req.params.formId, req.query, req.currentUser);
       ['Content-Disposition', 'Content-Type'].forEach((h) => {
         res.setHeader(h, result.headers[h.toLowerCase()]);
       });
@@ -85,7 +85,7 @@ module.exports = {
 
   exportWithFields: async (req, res, next) => {
     try {
-      const result = await exportService.export(req.params.formId, req.body, req.currentUser, req.headers.referer);
+      const result = await exportService.export(req.params.formId, req.body, req.currentUser);
       ['Content-Disposition', 'Content-Type'].forEach((h) => {
         res.setHeader(h, result.headers[h.toLowerCase()]);
       });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Had some 500 errors when a custom API call was made with the parameters:
> /app/api/v1/forms/REMOVED/export?format=csv&template=multiRowEmptySpaceCSVExport&version=2&type=submissions

The problem is that `multiRowEmptySpaceCSVExport` isn't the export template, it's `multiRowEmptySpacesCSVExport`.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

Did a bit of simplification of the code as well:
- removed the `referer` parameter from the export code. It was being passed around all over the place and was only ever used in the error log if there was an error sending the email, and even then was of debatable value
- in `emailService.submissionExportLink` removed the unused parameter `referer` to support the above 
- in `emailService.submissionExportLink` removed the unused parameter `submissionId` 
- in `exportService.export` removed the default values for `params` and `currentUser` - keep it simple by requiring these
- did a bit of simplification in the unit tests, but there's a long way to go and a lot of refactoring to be done