### PR TITLE
feat: FORMS-1279 cdogs file output type

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -1750,6 +1750,12 @@ paths:
       parameters:
         - $ref: '#/components/parameters/formSubmissionIdParam'
         - $ref: '#/components/parameters/documentTemplateIdParam'
+        - in: query
+          name: convertTo
+          schema:
+            type: string
+          description: file type to convert to
+          example: pdf
       responses:
         '200':
           description: Returns the document template with merged variables

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -137,6 +137,7 @@ module.exports = {
       const template = await formService.documentTemplateRead(req.params.documentTemplateId);
       const fileName = template.filename.substring(0, template.filename.lastIndexOf('.'));
       const fileExtension = template.filename.substring(template.filename.lastIndexOf('.') + 1);
+      const convertTo = req.query.convertTo || 'pdf';
 
       const templateBody = {
         data: {
@@ -148,12 +149,12 @@ module.exports = {
           },
         },
         options: {
-          convertTo: 'pdf',
+          convertTo: convertTo,
           overwrite: true,
           reportName: fileName,
         },
         template: {
-          content: btoa(template.template),
+          content: template.template.toString(),
           encodingType: 'base64',
           fileType: fileExtension,
         },

--- a/app/tests/unit/forms/submission/controller.spec.js
+++ b/app/tests/unit/forms/submission/controller.spec.js
@@ -125,7 +125,7 @@ describe('template rendering', () => {
 
   const validDocumentTemplate = {
     filename: 'template_hello_world.txt',
-    template: 'Hello {d.simpletextfield}!',
+    template: btoa('Hello {d.simpletextfield}!'),
   };
 
   const mockCdogsResponse = {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We want to allow the user to select the output file type when they generate a document using CDOGS. The frontend is what is restricting the output file type - it always chooses PDF. The backend, as the frontend is right now, needs no changes. However, the new endpoint that takes a `submissionId` and a `documentTemplateId` is not being used by the frontend, and probably a good thing.
- fixed a bug where the file would never generate correctly
- added the `convertTo` query parameter.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
