### PR TITLE
revert: FORMS-1139 urlencoded extended setting

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -24,7 +24,7 @@ let probeId;
 const app = express();
 app.use(compression());
 app.use(express.json({ limit: config.get('server.bodyLimit') }));
-app.use(express.urlencoded());
+app.use(express.urlencoded({ extended: true }));
 
 // Express needs to know about the OpenShift proxy. With this setting Express
 // pulls the IP address from the headers, rather than use the proxy IP address.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In PR 1139 I removed the setting of `extended: true` for `express.urlencoded`, as true is the default value. It turns out that Express complains if you do not set it to the default value:

```
body-parser deprecated undefined extended: provide extended option at app.js:27:17
```

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Revert (non-breaking change that fixes an issue)
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
<!--
## Further comments
-->
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
