### PR TITLE
fix: FORMS-1302 contributing link correction

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ This is a breaking change because ...
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
-- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [ ] I have checked that unit tests pass locally with my changes
 - [ ] I have run the npm script lint on the frontend and backend
 - [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
# Description
Just trying to fix the "CONTRIBUTING" link, as it's going to https://github.com/bcgov/common-hosted-form-service/pull/CONTRIBUTING.md, which produces:
![image](https://github.com/bcgov/common-hosted-form-service/assets/35532993/6876cf2e-c32a-4609-8b7b-849453ea373e)

## Types of changes
fix (a bug fix)

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request