### PR TITLE
fix: FORMS-1302 PR template link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ This is a breaking change because ...
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
-- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
+- [ ] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
 - [ ] I have checked that unit tests pass locally with my changes
 - [ ] I have run the npm script lint on the frontend and backend
 - [ ] I have added tests that prove my fix is effective or that my feature works

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ This is a breaking change because ...
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
-- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
 - [ ] I have checked that unit tests pass locally with my changes
 - [ ] I have run the npm script lint on the frontend and backend
 - [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
# Description

Another fix for the link - looks like GitHub templates don't do relative URLs the way other files do.

## Types of changes
docs (change to documentation)

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request