### PR TITLE
fix: FORMS-1008 add address lookup url

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,11 +21,12 @@
     {
       "cwd": "${workspaceFolder}/app/frontend",
       "env": {
-        "VITE_TITLE": "Common Hosted Forms - Local",
+        "VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL": "http://localhost:8080/app/api/v1/bcgeoaddress/address",
+        "VITE_CHEFSTOURURL": "https://www.youtube.com/embed/obOhyYusMjM",
         "VITE_CONTACT": "submit.digital@gov.bc.ca",
         "VITE_FRONTEND_BASEPATH": "/app",
-        "VITE_CHEFSTOURURL": "https://www.youtube.com/embed/obOhyYusMjM",
-        "VITE_HOWTOURL": "https://www.youtube.com/playlist?list=PL9CV_8JBQHirsQAShw45PZeU1CkU88Q53"
+        "VITE_HOWTOURL": "https://www.youtube.com/playlist?list=PL9CV_8JBQHirsQAShw45PZeU1CkU88Q53",
+        "VITE_TITLE": "Common Hosted Forms - Local"
       },
       "name": "CHEFS Frontend",
       "outputCapture": "std",


### PR DESCRIPTION
# Description

Fix a problem where the address lookup components are not calling the backend. The URL for the backend route was missing from the environment variables, so added it into the devcontainers launcher.

> Note: This is not a complete fix to get the address components working in localhost, it's just enough to call the backend so that work on other bugs is unblocked. There is a bigger problem with CORS errors to be figured out in FORMS-1364.

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request