### PR TITLE
refactor: FORMS-1007 geo address env variables

### DIFF
--- a/.github/actions/build-push-container/action.yaml
+++ b/.github/actions/build-push-container/action.yaml
@@ -51,15 +51,11 @@ inputs:
   app_chefs_geo_address_apiurl:
     description: Proxy URL to BC Geo Address API URL
     required: true
-    default: "../api/v1/bcgeoaddress/address"
-  app_chefs_advance_geo_address_apiurl:
-    description: Proxy URL to BC Geo Address API URL for advance search
-    required: true
     default: "../api/v1/bcgeoaddress/advance/address"
   ref:
     description: The checkout ref id
     required: false
-    default: ''
+    default: ""
   pr_number:
     description: Pull request number
     required: false
@@ -98,7 +94,6 @@ runs:
         VITE_CHEFSTOURURL: ${{ inputs.app_chefstoururl }}
         VITE_FRONTEND_BASEPATH: ${{ inputs.route_path }}
         VITE_CHEFS_GEO_ADDRESS_APIURL: ${{ inputs.app_chefs_geo_address_apiurl }}
-        VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL: ${{ inputs.app_chefs_advance_geo_address_apiurl }}
         VITE_BC_GEO_ADDRESS_APIURL: ${{ inputs.app_bc_geo_address_apiurl }}
         ENV_PATH: ./app/frontend/.env
       shell: bash
@@ -109,7 +104,6 @@ runs:
         echo VITE_HOWTOURL=$VITE_HOWTOURL >> $ENV_PATH
         echo VITE_CHEFSTOURURL=$VITE_CHEFSTOURURL >> $ENV_PATH
         echo VITE_CHEFS_GEO_ADDRESS_APIURL=$VITE_CHEFS_GEO_ADDRESS_APIURL >> $ENV_PATH
-        echo VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL=$VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL >> $ENV_PATH
         echo VITE_BC_GEO_ADDRESS_APIURL=$VITE_BC_GEO_ADDRESS_APIURL >> $ENV_PATH
         echo VITE_FRONTEND_BASEPATH=$VITE_FRONTEND_BASEPATH >> $ENV_PATH
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
     {
       "cwd": "${workspaceFolder}/app/frontend",
       "env": {
-        "VITE_CHEFS_GEO_ADDRESS_APIURL": "http://localhost:8080/app/api/v1/bcgeoaddress/address",
+        "VITE_CHEFS_GEO_ADDRESS_APIURL": "http://localhost:8080/app/api/v1/bcgeoaddress/advance/address",
         "VITE_CHEFSTOURURL": "https://www.youtube.com/embed/obOhyYusMjM",
         "VITE_CONTACT": "submit.digital@gov.bc.ca",
         "VITE_FRONTEND_BASEPATH": "/app",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
     {
       "cwd": "${workspaceFolder}/app/frontend",
       "env": {
-        "VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL": "http://localhost:8080/app/api/v1/bcgeoaddress/address",
+        "VITE_CHEFS_GEO_ADDRESS_APIURL": "http://localhost:8080/app/api/v1/bcgeoaddress/address",
         "VITE_CHEFSTOURURL": "https://www.youtube.com/embed/obOhyYusMjM",
         "VITE_CONTACT": "submit.digital@gov.bc.ca",
         "VITE_FRONTEND_BASEPATH": "/app",

--- a/components/src/components/BCAddress/Component.ts
+++ b/components/src/components/BCAddress/Component.ts
@@ -1,6 +1,5 @@
-
 /* tslint:disable */
-import {Components} from 'formiojs';
+import { Components } from 'formiojs';
 import { Constants } from '../Common/Constants';
 import editForm from './Component.form';
 import _ from 'lodash';
@@ -16,80 +15,82 @@ const ID = 'bcaddress';
 const DISPLAY = 'BC Address';
 
 export default class Component extends (ParentComponent as any) {
-    static schema(...extend) {
+  static schema(...extend) {
+    return ParentComponent.schema(
+      {
+        label: DISPLAY,
+        type: ID,
+        key: ID,
+        provider: 'custom',
+        providerOptions: {
+          queryProperty: 'addressString',
+          url: import.meta.env.VITE_CHEFS_GEO_ADDRESS_APIURL,
+        },
 
-        return ParentComponent.schema({
-            label: DISPLAY,
-            type: ID,
-            key: ID,
-            provider: 'custom',
-            providerOptions: {
-                queryProperty: 'addressString',
+        queryParameters: {
+          echo: false,
+          brief: true,
+          minScore: 55,
+          onlyCivic: true,
+          maxResults: 15,
+          autocomplete: true,
+          matchAccuracy: 100,
+          matchPrecision:
+            'occupant, unit, site, civic_number, intersection, block, street, locality, province',
+          precisionPoints: 100,
+        },
+      },
+      ...extend
+    );
+  }
 
-              url: import.meta.env.VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL},
+  static get builderInfo() {
+    return {
+      title: DISPLAY,
+      group: 'advanced',
+      icon: 'address-book',
+      weight: 90,
+      documentation: Constants.DEFAULT_HELP_LINK,
+      schema: Component.schema(),
+    };
+  }
 
-            queryParameters:{"echo": false,
-            "brief": true,
-            "minScore": 55,
-            "onlyCivic": true,
-            "maxResults": 15,
-            "autocomplete": true,
-            "matchAccuracy": 100,
-            "matchPrecision": "occupant, unit, site, civic_number, intersection, block, street, locality, province",
-            "precisionPoints": 100,}
+  mergeSchema(component = {}) {
+    let components = component['components'];
 
-        }, ...extend);
+    if (components) {
+      return _.omit(component, 'components');
     }
 
-    static get builderInfo() {
-        return {
-            title: DISPLAY,
-            group: 'advanced',
-            icon: 'address-book',
-            weight: 90,
-            documentation: Constants.DEFAULT_HELP_LINK,
-            schema: Component.schema()
-        };
-    }
+    return component;
+  }
 
-    mergeSchema(component = {}) {
+  public static editForm = editForm;
 
-      let components = component['components'];
+  async init() {
+    super.init();
+  }
 
-      if (components) {
-        return _.omit(component, 'components');
-      }
-
-      return component;
-    }
-
-    public static editForm = editForm;
-
-    async init(){
-        super.init();
-    }
-
-    async attach(element) {
-        super.attach(element);
-        try {
-
-            let {
-                providerOptions,
-                queryParameters,
-            } = this.component;
-            if(providerOptions) {
-                if(!providerOptions.params) {
-                    providerOptions["params"]={}
-                }
-                if(queryParameters) {
-                    providerOptions.params ={...providerOptions.params,...queryParameters}
-                }
-            }
-
-        } catch (err) {
-            console.log(`This error is from Custom BC Address component in form.io: Failed to acquire configuration: ${err.message}`);
+  async attach(element) {
+    super.attach(element);
+    try {
+      let { providerOptions, queryParameters } = this.component;
+      if (providerOptions) {
+        if (!providerOptions.params) {
+          providerOptions['params'] = {};
         }
+        if (queryParameters) {
+          providerOptions.params = {
+            ...providerOptions.params,
+            ...queryParameters,
+          };
+        }
+      }
+    } catch (err) {
+      console.log(
+        `This error is from Custom BC Address component in form.io: Failed to acquire configuration: ${err.message}`
+      );
     }
-
+  }
 }
 export {};

--- a/components/src/components/SimpleBCAddress/Component.ts
+++ b/components/src/components/SimpleBCAddress/Component.ts
@@ -1,6 +1,5 @@
-
 /* tslint:disable */
-import {Components} from 'formiojs';
+import { Components } from 'formiojs';
 import { Constants } from '../Common/Constants';
 import editForm from './Component.form';
 import _ from 'lodash';
@@ -16,83 +15,83 @@ const ID = 'simplebcaddress';
 const DISPLAY = 'Simple BC Address';
 
 export default class Component extends (ParentComponent as any) {
-    static schema(...extend) {
+  static schema(...extend) {
+    return ParentComponent.schema(
+      {
+        label: DISPLAY,
+        type: ID,
+        key: ID,
+        provider: 'custom',
+        providerOptions: {
+          queryProperty: 'addressString',
+          url: import.meta.env.VITE_CHEFS_GEO_ADDRESS_APIURL,
+        },
 
-        return ParentComponent.schema({
-            label: DISPLAY,
-            type: ID,
-            key: ID,
-            provider: 'custom',
-            providerOptions: {
-                queryProperty: 'addressString',
-              url:import.meta.env.VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL},
+        queryParameters: {
+          echo: false,
+          brief: true,
+          minScore: 55,
+          onlyCivic: true,
+          maxResults: 15,
+          autocomplete: true,
+          matchAccuracy: 100,
+          matchPrecision:
+            'occupant, unit, site, civic_number, intersection, block, street, locality, province',
+          precisionPoints: 100,
+        },
+      },
+      ...extend
+    );
+  }
 
-            queryParameters:{"echo": false,
-            "brief": true,
-            "minScore": 55,
-            "onlyCivic": true,
-            "maxResults": 15,
-            "autocomplete": true,
-            "matchAccuracy": 100,
-            "matchPrecision": "occupant, unit, site, civic_number, intersection, block, street, locality, province",
-            "precisionPoints": 100,}
+  static get builderInfo() {
+    return {
+      title: DISPLAY,
+      group: 'advanced',
+      icon: 'address-book',
+      weight: 90,
+      documentation: Constants.DEFAULT_HELP_LINK,
+      schema: Component.schema(),
+    };
+  }
 
-        }, ...extend);
-    }
+  public static editForm = editForm;
 
-    static get builderInfo() {
-        return {
-            title: DISPLAY,
-            group: 'advanced',
-            icon: 'address-book',
-            weight: 90,
-            documentation: Constants.DEFAULT_HELP_LINK,
-            schema: Component.schema(),
+  async init() {
+    super.init();
+  }
 
-        };
-    }
+  async attach(element) {
+    super.attach(element);
+    try {
+      let { providerOptions, queryParameters } = this.component;
 
-    public static editForm = editForm;
-
-    async init(){
-        super.init();
-    }
-
-    async attach(element) {
-        super.attach(element);
-        try {
-
-            let {
-                providerOptions,
-                queryParameters,
-
-            } = this.component;
-
-            if(providerOptions) {
-                if(!providerOptions.params) {
-                    providerOptions["params"]={}
-                }
-                if(queryParameters) {
-                    providerOptions.params ={...providerOptions.params,...queryParameters}
-                }
-            }
-
-        } catch (err) {
-            console.log(`This error is from Custom BC Address component in form.io: Failed to acquire configuration: ${err.message}`);
+      if (providerOptions) {
+        if (!providerOptions.params) {
+          providerOptions['params'] = {};
         }
-    }
-
-    mergeSchema(component = {}) {
-
-      let components = component['components'];
-
-      if (components) {
-        return _.omit(component, 'components');
+        if (queryParameters) {
+          providerOptions.params = {
+            ...providerOptions.params,
+            ...queryParameters,
+          };
+        }
       }
+    } catch (err) {
+      console.log(
+        `This error is from Custom BC Address component in form.io: Failed to acquire configuration: ${err.message}`
+      );
+    }
+  }
 
-      return component;
+  mergeSchema(component = {}) {
+    let components = component['components'];
+
+    if (components) {
+      return _.omit(component, 'components');
     }
 
-
+    return component;
+  }
 }
 export {};

--- a/openshift/app.dc.yaml
+++ b/openshift/app.dc.yaml
@@ -166,7 +166,6 @@ objects:
                     secretKeyRef:
                       key: email
                       name: "${APP_NAME}-contact-secret"
-
                 - name: VITE_HOWTOURL
                   valueFrom:
                     secretKeyRef:
@@ -177,16 +176,6 @@ objects:
                     secretKeyRef:
                       key: chefstourvideourl
                       name: "${APP_NAME}-landingpagevideourls-secret"
-                - name: VITE_CHEFS_GEO_ADDRESS_APIURL
-                  valueFrom:
-                    secretKeyRef:
-                      key: chefsgeoaddressapiurl
-                      name: "${APP_NAME}-bcgeoaddress-secret"
-                - name: VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL
-                  valueFrom:
-                    secretKeyRef:
-                      key: chefsadvancegeoaddressapiurl
-                      name: "${APP_NAME}-bcgeoaddress-secret"
                 - name: VITE_BC_GEO_ADDRESS_APIURL
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
# Description

Refactoring to simplify the environment variables used for the BC Geo Address lookup.

Before refactoring:
- Two environment variables, `VITE_CHEFS_GEO_ADDRESS_APIURL` and `VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL`
- The two form.io Components both use `VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL`
- `VITE_CHEFS_GEO_ADDRESS_APIURL` is not used
- The environment variables in the deployed pods are not being used - the variables are only needed for the GitHub Actions build

After refactoring:
- Remove the unused `VITE_CHEFS_GEO_ADDRESS_APIURL` variable
- Rename `VITE_CHEFS_ADVANCE_GEO_ADDRESS_APIURL` to `VITE_CHEFS_GEO_ADDRESS_APIURL` because it doesn't really make sense to have an "advanced" if there is no non-advanced
- Remove the two environment variables from the DeploymentConfig, since the environment variables are needed for OpenShift builds, not runtime

## Types of changes

refactor (change to improve code quality)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

- Will need to remove the values from the secrets, to prevent future questions about what they're used for
- Will eventually remove the "non-advanced" route from the backend and rename "advanced", since we only need one route