### PR TITLE
fix: FORMS-995 handle address responses

### DIFF
--- a/app/src/components/errorToProblem.js
+++ b/app/src/components/errorToProblem.js
@@ -2,28 +2,46 @@ const Problem = require('api-problem');
 
 const log = require('./log')(module.filename);
 
-module.exports = function (service, e) {
-  if (e.response) {
-    // Handle raw data
-    let data;
-    if (typeof e.response.data === 'string' || e.response.data instanceof String) {
-      data = JSON.parse(e.response.data);
-    } else {
-      data = e.response.data;
-    }
+/**
+ * Try to convert response data to JSON, but failing that just return it as-is.
+ *
+ * @param {*} data the data to attempt to parse into JSON.
+ * @returns an object if data is JSON, otherwise data itself
+ */
+const _parseResponseData = (data) => {
+  let parsedData;
 
-    log.error(`Error from ${service}: status = ${e.response.status}, data : ${JSON.stringify(data)}`, e);
+  try {
+    parsedData = JSON.parse(data);
+  } catch (error) {
+    // Syntax Error: It's not valid JSON.
+    parsedData = data;
+  }
+
+  return parsedData;
+};
+
+module.exports = function (service, error) {
+  if (error.response) {
+    const data = _parseResponseData(error.response.data);
+
+    log.error(`Error from ${service}: status = ${error.response.status}, data : ${JSON.stringify(data)}`, error);
+
     // Validation Error
-    if (e.response.status === 422) {
-      throw new Problem(e.response.status, {
+    if (error.response.status === 422) {
+      throw new Problem(error.response.status, {
         detail: data.detail,
         errors: data.errors,
       });
     }
+
     // Something else happened but there's a response
-    throw new Problem(e.response.status, { detail: e.response.data.toString() });
+    throw new Problem(error.response.status, { detail: error.response.data.toString() });
   } else {
-    log.error(`Unknown error calling ${service}: ${e.message}`, e);
-    throw new Problem(502, `Unknown ${service} Error`, { detail: e.message });
+    log.error(`Unknown error calling ${service}: ${error.message}`, error);
+
+    throw new Problem(502, `Unknown ${service} Error`, {
+      detail: error.message,
+    });
   }
 };

--- a/app/src/components/errorToProblem.js
+++ b/app/src/components/errorToProblem.js
@@ -25,7 +25,7 @@ module.exports = function (service, error) {
   if (error.response) {
     const data = _parseResponseData(error.response.data);
 
-    log.error(`Error from ${service}: status = ${error.response.status}, data : ${JSON.stringify(data)}`, error);
+    log.error(`Error from ${service}: status = ${error.response.status}, data: ${JSON.stringify(data)}`, error);
 
     // Validation Error
     if (error.response.status === 422) {

--- a/app/tests/unit/components/errorToProblem.spec.js
+++ b/app/tests/unit/components/errorToProblem.spec.js
@@ -3,20 +3,32 @@ const errorToProblem = require('../../../src/components/errorToProblem');
 const SERVICE = 'TESTSERVICE';
 
 describe('errorToProblem', () => {
+  it('should throw a 404', () => {
+    const error = {
+      response: {
+        status: 404,
+      },
+    };
+
+    expect(() => errorToProblem(SERVICE, error)).toThrow('404');
+  });
+
   it('should throw a 422', () => {
-    const e = {
+    const error = {
       response: {
         data: { detail: 'detail' },
         status: 422,
       },
     };
-    expect(() => errorToProblem(SERVICE, e)).toThrow('422');
+
+    expect(() => errorToProblem(SERVICE, error)).toThrow('422');
   });
 
   it('should throw a 502', () => {
-    const e = {
+    const error = {
       message: 'msg',
     };
-    expect(() => errorToProblem(SERVICE, e)).toThrow('502');
+
+    expect(() => errorToProblem(SERVICE, error)).toThrow('502');
   });
 });

--- a/app/tests/unit/components/errorToProblem.spec.js
+++ b/app/tests/unit/components/errorToProblem.spec.js
@@ -6,6 +6,7 @@ describe('errorToProblem', () => {
   it('should throw a 404', () => {
     const error = {
       response: {
+        data: { detail: 'detail' },
         status: 404,
       },
     };


### PR DESCRIPTION
# Description

When the external BC Geo Address service was returning HTML instead of JSON we were having JSON parse failures and no indication what was in the HTML. Turns out that it was the error handling code assuming that all string responses are JSON.
- Made the error handler more lenient
- Added a missing test to bring the error handler coverage up to 100%
- Refactored the JSON conversion into its own method to hopefully resolve a code climate complaint

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request