### PR TITLE
fix: FORMS-1140 run zap on dev

### DIFF
--- a/.github/workflows/.deploy.yaml
+++ b/.github/workflows/.deploy.yaml
@@ -85,7 +85,7 @@ jobs:
           pr_number: ${{ github.event.inputs.pr-number }}
 
   deploy:
-    name: Deploys to selected environment
+    name: Deploy
     environment:
       name: pr
       url: ${{ needs.set-vars.outputs.URL }}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build & Push
         uses: ./.github/actions/build-push-container
         with:
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Deploy to Dev
         uses: ./.github/actions/deploy-to-environment
         with:
@@ -57,6 +57,13 @@ jobs:
           route_path: /app
           route_prefix: ${{ vars.ROUTE_PREFIX }}
 
+  scan-dev:
+    name: Scan Dev
+    needs: deploy-dev
+    uses: ./.github/workflows/reusable-owasp-zap.yaml
+    with:
+      url: https://${{ env.ACRONYM }}-dev.apps.silver.devops.gov.bc.ca/app
+
   deploy-test:
     name: Deploy to Test
     environment:
@@ -69,7 +76,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Deploy to Test
         uses: ./.github/actions/deploy-to-environment
         with:
@@ -98,7 +105,7 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Deploy to Prod
         uses: ./.github/actions/deploy-to-environment
         with:


### PR DESCRIPTION
# Description

The OWASP ZAP Scan stopped running when we changed the CI/CD pipeline away from the "feature branch" way of doing things. As part of our STRA SoAR we need to run the scan and handle any problems that are identified.

The scan was previously set up as a reusable workflow and is working for PR scans. This PR is to also scan dev after deployment, which is what we had for the old scans.

> Note: GitHub Actions are tricky to test, but this should work. Perhaps best to not merge it until I'm available to deal with problems?

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request