### PR TITLE
revert: FORMS-1140 disable new dev zap scan

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -57,12 +57,12 @@ jobs:
           route_path: /app
           route_prefix: ${{ vars.ROUTE_PREFIX }}
 
-  scan-dev:
-    name: Scan Dev
-    needs: deploy-dev
-    uses: ./.github/workflows/reusable-owasp-zap.yaml
-    with:
-      url: https://${{ env.ACRONYM }}-dev.apps.silver.devops.gov.bc.ca/app
+  # scan-dev:
+  #   name: Scan Dev
+  #   needs: deploy-dev
+  #   uses: ./.github/workflows/reusable-owasp-zap.yaml
+  #   with:
+  #     url: https://${{ env.ACRONYM }}-dev.apps.silver.devops.gov.bc.ca/app
 
   deploy-test:
     name: Deploy to Test


### PR DESCRIPTION
# Description

Temporarily revert the new dev OWASP ZAP scan, for some reason the url substitution isn't happening.

## Types of changes

<!-- Uncomment the main reason for the change (for example, all feat PRs should include docs and test, but only uncomment feat): -->

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request