### PR TITLE
fix: FORMS-1140 run zap on dev

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -38,6 +38,8 @@ jobs:
       url: https://${{ env.ACRONYM }}-dev.apps.silver.devops.gov.bc.ca/app
     runs-on: ubuntu-latest
     needs: build
+    outputs:
+      url: https://${{ env.ACRONYM }}-dev.apps.silver.devops.gov.bc.ca/app
     timeout-minutes: 12
     steps:
       - name: Checkout
@@ -57,12 +59,12 @@ jobs:
           route_path: /app
           route_prefix: ${{ vars.ROUTE_PREFIX }}
 
-  # scan-dev:
-  #   name: Scan Dev
-  #   needs: deploy-dev
-  #   uses: ./.github/workflows/reusable-owasp-zap.yaml
-  #   with:
-  #     url: https://${{ env.ACRONYM }}-dev.apps.silver.devops.gov.bc.ca/app
+  scan-dev:
+    name: Scan Dev
+    needs: deploy-dev
+    uses: ./.github/workflows/reusable-owasp-zap.yaml
+    with:
+      url: ${{ needs.deploy-dev.outputs.url }}
 
   deploy-test:
     name: Deploy to Test


### PR DESCRIPTION
# Description

Do an OWASP ZAP scan of the dev environment after the application has been deployed.

> Note: this is some rework because the "env" is not available to `jobs.<job_id>.with`. Instead make the `url` an output of the dev deployment.

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request