### PR TITLE
fix/FORMS-1385 data grid export

### DIFF
--- a/app/src/forms/form/exportService.js
+++ b/app/src/forms/form/exportService.js
@@ -114,14 +114,7 @@ const service = {
 
     if (fields) {
       return formSchemaheaders.filter((header) => {
-        // In the 'fields' sent from the caller we'll have something like
-        // 'datagrid.input', but in the actual submission data in the
-        // 'formSchemaheaders' we'll have things like 'datagrid.0.input',
-        // 'datagrid.1.input', etc. Remove the '.0' array index to get
-        // 'datagrid.input' and then do the comparison.
-        const flattenedHeader = header.replace(/\.\d+\./gi, '.');
-
-        if (Array.isArray(fields) && fields.includes(flattenedHeader)) {
+        if (Array.isArray(fields) && fields.includes(header)) {
           return header;
         }
       });

--- a/app/tests/fixtures/submission/kitchen_sink_submission_data_export_datagrid_fields_selection.json
+++ b/app/tests/fixtures/submission/kitchen_sink_submission_data_export_datagrid_fields_selection.json
@@ -10,10 +10,13 @@
   "email",
   "forWhichBcLakeRegionAreYouCompletingTheseQuestions",
   "didYouFishAnyBcLakesThisYear",
-  "oneRowPerLake.lakeName",
-  "oneRowPerLake.closestTown",
-  "oneRowPerLake.numberOfDays",
-  "oneRowPerLake.dataGrid.fishType",
-  "oneRowPerLake.dataGrid.numberCaught",
-  "oneRowPerLake.dataGrid.numberKept"
+  "oneRowPerLake.0.lakeName",
+  "oneRowPerLake.0.closestTown",
+  "oneRowPerLake.0.numberOfDays",
+  "oneRowPerLake.0.dataGrid.0.fishType",
+  "oneRowPerLake.0.dataGrid.1.fishType",
+  "oneRowPerLake.0.dataGrid.0.numberCaught",
+  "oneRowPerLake.0.dataGrid.1.numberCaught",
+  "oneRowPerLake.0.dataGrid.0.numberKept",
+  "oneRowPerLake.0.dataGrid.1.numberKept"
 ]

--- a/app/tests/unit/forms/form/exportService.spec.js
+++ b/app/tests/unit/forms/form/exportService.spec.js
@@ -126,7 +126,8 @@ describe('export', () => {
           'form.username',
           'form.email',
           'dataGrid',
-          'dataGrid.simpletextfield',
+          'dataGrid.0.simpletextfield',
+          'dataGrid.1.simpletextfield',
         ],
         template: 'singleRowCSVExport',
       };
@@ -515,7 +516,7 @@ describe('_buildCsvHeaders', () => {
     // get result columns if we need to filter out the columns
     const result = await exportService._buildCsvHeaders(form, submissionsExport, 1, fields, true);
 
-    expect(result).toHaveLength(29);
+    expect(result).toHaveLength(20);
     expect(result).toEqual(
       expect.arrayContaining([
         'form.confirmationId',


### PR DESCRIPTION
# Description

Users reported that datagrid exports are not working. The problem is that the changes from FORMS-1215 are now causing the exports to fail again.

Will revert the 1215 changes.

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request