### PR TITLE
fix: FORMS-1304 securely fetch local files

### DIFF
--- a/app/src/forms/file/middleware/upload.js
+++ b/app/src/forms/file/middleware/upload.js
@@ -5,13 +5,15 @@ const os = require('os');
 
 const Problem = require('api-problem');
 
-let uploader = undefined;
-let storage = undefined;
+let fileUploadsDir = os.tmpdir();
 let maxFileSize = bytes.parse('25MB');
 let maxFileCount = 1;
 
+let storage = undefined;
+let uploader = undefined;
+
 const fileSetup = (options) => {
-  const fileUploadsDir = (options && options.dir) || process.env.FILE_UPLOADS_DIR || fs.realpathSync(os.tmpdir());
+  fileUploadsDir = (options && options.dir) || process.env.FILE_UPLOADS_DIR || fs.realpathSync(os.tmpdir());
   try {
     fs.ensureDirSync(fileUploadsDir);
   } catch (error) {
@@ -59,6 +61,15 @@ module.exports.fileUpload = {
         limits: { fileSize: maxFileSize, files: maxFileCount },
       }).single(formFieldName);
     }
+  },
+
+  /**
+   * Gets the directory where the files are uploaded to.
+   *
+   * @returns the file uploads directory.
+   */
+  getFileUploadsDir() {
+    return fileUploadsDir;
   },
 
   async upload(req, res, next) {

--- a/app/src/forms/file/middleware/upload.js
+++ b/app/src/forms/file/middleware/upload.js
@@ -9,8 +9,8 @@ let fileUploadsDir = os.tmpdir();
 let maxFileSize = bytes.parse('25MB');
 let maxFileCount = 1;
 
-let storage = undefined;
-let uploader = undefined;
+let storage;
+let uploader;
 
 const fileSetup = (options) => {
   fileUploadsDir = (options && options.dir) || process.env.FILE_UPLOADS_DIR || fs.realpathSync(os.tmpdir());

--- a/app/src/forms/file/storage/objectStorageService.js
+++ b/app/src/forms/file/storage/objectStorageService.js
@@ -9,6 +9,8 @@ const StorageTypes = require('../../common/constants').StorageTypes;
 const errorToProblem = require('../../../components/errorToProblem');
 const log = require('../../../components/log')(module.filename);
 
+const fileUpload = require('../middleware/upload').fileUpload;
+
 const SERVICE = 'ObjectStorage';
 const TEMP_DIR = 'uploads';
 const Delimiter = '/';
@@ -58,9 +60,29 @@ class ObjectStorageService {
     return '';
   }
 
+  /**
+   * Gets the contents of a file from the local filesystem. Will error if the
+   * requested file is not in the allowed file uploads directory.
+   *
+   * @param {string} filename the filename of the file to be read.
+   * @returns a Buffer containing the file contents.
+   * @throws an Error if the filename is not within the allowed directory.
+   */
+  _readLocalFile(filename) {
+    const fileUploadsDir = fileUpload.getFileUploadsDir();
+    console.log('-----------------------------> fileUploadsDir', fileUploadsDir);
+    const resolvedFilename = fs.realpathSync(path.resolve(fileUploadsDir, filename));
+    console.log('-----------------------------> resolvedFilename', resolvedFilename);
+    if (!resolvedFilename.startsWith(fileUploadsDir)) {
+      throw new Error(`Invalid path '${filename}'`);
+    }
+
+    return fs.readFileSync(resolvedFilename);
+  }
+
   async uploadFile(fileStorage) {
     try {
-      const fileContent = fs.readFileSync(fileStorage.path);
+      const fileContent = this._readLocalFile(fileStorage.path);
 
       // uploads can go to a 'holding' area, we can shuffle it later if we want to.
       const key = this._join(this._key, TEMP_DIR, fileStorage.id);

--- a/app/src/forms/file/storage/objectStorageService.js
+++ b/app/src/forms/file/storage/objectStorageService.js
@@ -73,9 +73,8 @@ class ObjectStorageService {
     if (!fileUploadsDir.endsWith('/')) {
       fileUploadsDir += '/';
     }
-    console.log('-----------------------------> fileUploadsDir', fileUploadsDir);
+
     const resolvedFilename = fs.realpathSync(path.resolve(fileUploadsDir, filename));
-    console.log('-----------------------------> resolvedFilename', resolvedFilename);
     if (!resolvedFilename.startsWith(fileUploadsDir)) {
       throw new Error(`Invalid path '${filename}'`);
     }

--- a/app/src/forms/file/storage/objectStorageService.js
+++ b/app/src/forms/file/storage/objectStorageService.js
@@ -69,9 +69,12 @@ class ObjectStorageService {
    * @throws an Error if the filename is not within the allowed directory.
    */
   _readLocalFile(filename) {
-    const fileUploadsDir = fileUpload.getFileUploadsDir();
+    let fileUploadsDir = fileUpload.getFileUploadsDir();
+    if (!fileUploadsDir.endsWith('/')) {
+      fileUploadsDir += '/';
+    }
     console.log('-----------------------------> fileUploadsDir', fileUploadsDir);
-    const resolvedFilename = fs.realpathSync(path.resolve(fileUploadsDir + '/', filename));
+    const resolvedFilename = fs.realpathSync(path.resolve(fileUploadsDir, filename));
     console.log('-----------------------------> resolvedFilename', resolvedFilename);
     if (!resolvedFilename.startsWith(fileUploadsDir)) {
       throw new Error(`Invalid path '${filename}'`);

--- a/app/src/forms/file/storage/objectStorageService.js
+++ b/app/src/forms/file/storage/objectStorageService.js
@@ -71,7 +71,7 @@ class ObjectStorageService {
   _readLocalFile(filename) {
     const fileUploadsDir = fileUpload.getFileUploadsDir();
     console.log('-----------------------------> fileUploadsDir', fileUploadsDir);
-    const resolvedFilename = fs.realpathSync(path.resolve(fileUploadsDir, filename));
+    const resolvedFilename = fs.realpathSync(path.resolve(fileUploadsDir + '/', filename));
     console.log('-----------------------------> resolvedFilename', resolvedFilename);
     if (!resolvedFilename.startsWith(fileUploadsDir)) {
       throw new Error(`Invalid path '${filename}'`);

--- a/app/tests/unit/forms/file/middleware/upload.spec.js
+++ b/app/tests/unit/forms/file/middleware/upload.spec.js
@@ -236,6 +236,20 @@ describe('fileUpload.init', () => {
   });
 });
 
+describe('fileUpload.getFileUploadsDir', () => {
+  const mockOs = '/mock_os_tmpdir';
+
+  test('uses os.tmpdir when there is no config or environment variable', async () => {
+    fs.realpathSync.mockReturnValueOnce(mockOs);
+    os.tmpdir.mockReturnValueOnce(mockOs);
+    fileUpload.init();
+
+    const result = fileUpload.getFileUploadsDir();
+
+    expect(result).toBe(mockOs);
+  });
+});
+
 describe('fileUpload.upload', () => {
   // These are for the sake of completeness but there isn't much value here.
   describe('400 response when', () => {


### PR DESCRIPTION
# Description

CodeQL is complaining about how a file path is used in the file storage code. There is no way to exploit this, as we define the path and it cannot be changed by the user. However, will correct it just to be safe and to make the tooling happy.

https://github.com/bcgov/common-hosted-form-service/security/code-scanning/1 

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

Want to get this in quickly so it has time to get used. There are currently no tests for the storage, but will work on them as a followup PR.