### PR TITLE
fix/FORMS-1336 use fileId for the file id

### DIFF
--- a/app/src/forms/auth/middleware/apiAccess.js
+++ b/app/src/forms/auth/middleware/apiAccess.js
@@ -28,8 +28,8 @@ const _getFormId = async (params) => {
     }
   } else if (params.formSubmissionId) {
     formId = await _getFormIdFromSubmissionId(params.formSubmissionId);
-  } else if (params.id) {
-    formId = await _getFormIdFromFileId(params.id);
+  } else if (params.fileId) {
+    formId = await _getFormIdFromFileId(params.fileId);
   }
 
   return formId;
@@ -94,7 +94,7 @@ module.exports = async (req, res, next) => {
         throw new Problem(401, { detail: HTTP_401_DETAIL });
       }
 
-      if (params.id && apiKey.filesApiAccess === false) {
+      if (params.fileId && apiKey.filesApiAccess === false) {
         throw new Problem(403, { detail: HTTP_403_DETAIL });
       }
 

--- a/app/src/forms/file/controller.js
+++ b/app/src/forms/file/controller.js
@@ -55,7 +55,7 @@ module.exports = {
     try {
       // Permissions checked on this at the route level with middleware
       // ok, let's remove the file...
-      await service.delete(req.params.id);
+      await service.delete(req.params.fileId);
       res.sendStatus(202);
     } catch (error) {
       next(error);

--- a/app/src/forms/file/middleware/filePermissions.js
+++ b/app/src/forms/file/middleware/filePermissions.js
@@ -9,16 +9,16 @@ const service = require('../service');
  * Get the DB record for this file being accessed and store in request for use further down the chain
  * @returns {Function} a middleware function
  */
-const currentFileRecord = async (req, res, next) => {
-  let fileRecord = undefined;
+const currentFileRecord = async (req, _res, next) => {
+  let fileRecord;
   try {
     // Check if authed, can expand for API key access if needed
-    if (req.params.id && (req.currentUser || req.apiUser)) {
+    if (req.params.fileId && (req.currentUser || req.apiUser)) {
       // expanded for api user
-      fileRecord = await service.read(req.params.id);
+      fileRecord = await service.read(req.params.fileId);
     }
   } catch (error) {
-    log.error(`Failed to find file record for id ${req.params.id}. Error ${error}`);
+    log.error(`Failed to find file record for id ${req.params.fileId}. Error ${error}`);
   }
 
   if (!fileRecord) {

--- a/app/src/forms/file/routes.js
+++ b/app/src/forms/file/routes.js
@@ -14,11 +14,11 @@ routes.post('/', hasFileCreate, fileUpload.upload, async (req, res, next) => {
   await controller.create(req, res, next);
 });
 
-routes.get('/:id', rateLimiter, apiAccess, currentFileRecord, hasFilePermissions([P.SUBMISSION_READ]), async (req, res, next) => {
+routes.get('/:fileId', rateLimiter, apiAccess, currentFileRecord, hasFilePermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.read(req, res, next);
 });
 
-routes.delete('/:id', currentFileRecord, hasFilePermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
+routes.delete('/:fileId', currentFileRecord, hasFilePermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
   await controller.delete(req, res, next);
 });
 

--- a/app/tests/unit/forms/auth/middleware/apiAccess.spec.js
+++ b/app/tests/unit/forms/auth/middleware/apiAccess.spec.js
@@ -263,7 +263,7 @@ describe('apiAccess', () => {
     it('should be bad request with non-uuid file id', async () => {
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: 'invalidFileId' },
+        params: { fileId: 'invalidFileId' },
       });
       const { res, next } = getMockRes();
 
@@ -280,7 +280,7 @@ describe('apiAccess', () => {
       fileService.read = jest.fn().mockRejectedValue(new NotFoundError());
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -297,7 +297,7 @@ describe('apiAccess', () => {
       fileService.read = jest.fn().mockReturnValue({});
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -314,7 +314,7 @@ describe('apiAccess', () => {
       fileService.read = jest.fn().mockReturnValue({ formSubmissionId: undefined });
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -332,7 +332,7 @@ describe('apiAccess', () => {
       submissionService.read = jest.fn().mockReturnValue();
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -350,7 +350,7 @@ describe('apiAccess', () => {
       submissionService.read = jest.fn().mockReturnValue({});
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -368,7 +368,7 @@ describe('apiAccess', () => {
       submissionService.read = jest.fn().mockReturnValue({ form: {} });
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -387,7 +387,7 @@ describe('apiAccess', () => {
       submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -405,7 +405,7 @@ describe('apiAccess', () => {
       submissionService.read = jest.fn().mockReturnValue({ form: { id: formId } });
       const req = getMockReq({
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -424,7 +424,7 @@ describe('apiAccess', () => {
       submissionService.read = jest.fn().mockResolvedValue({ form: { id: formId } });
       const req = {
         headers: { authorization: authHeader },
-        params: { id: fileId },
+        params: { fileId: fileId },
       };
       const { res, next } = getMockRes();
 

--- a/app/tests/unit/forms/file/controller.spec.js
+++ b/app/tests/unit/forms/file/controller.spec.js
@@ -81,7 +81,7 @@ describe('create', () => {
 describe('delete', () => {
   const validRequest = {
     params: {
-      id: fileStorage.id,
+      fileId: fileStorage.id,
     },
   };
 
@@ -93,7 +93,7 @@ describe('delete', () => {
 
       await controller.delete(req, res, next);
 
-      expect(service.delete).toBeCalledWith(validRequest.params.id);
+      expect(service.delete).toBeCalledWith(validRequest.params.fileId);
       expect(res.json).not.toBeCalled();
       expect(res.status).not.toBeCalled();
       expect(next).toBeCalledWith(error);
@@ -108,7 +108,7 @@ describe('delete', () => {
 
       await controller.delete(req, res, next);
 
-      expect(service.delete).toBeCalledWith(validRequest.params.id);
+      expect(service.delete).toBeCalledWith(validRequest.params.fileId);
       expect(res.json).not.toBeCalled();
       expect(res.send).not.toBeCalled();
       expect(res.sendStatus).toBeCalledWith(202);

--- a/app/tests/unit/forms/file/middleware/filePermissions.spec.js
+++ b/app/tests/unit/forms/file/middleware/filePermissions.spec.js
@@ -28,7 +28,7 @@ describe('currentFileRecord', () => {
     test('there is no current user on the request', async () => {
       const req = getMockReq({
         params: {
-          id: fileId,
+          fileId: fileId,
         },
       });
       const { res, next } = getMockRes();
@@ -73,7 +73,7 @@ describe('currentFileRecord', () => {
       const req = getMockReq({
         currentUser: currentUserIdp,
         params: {
-          id: fileId,
+          fileId: fileId,
         },
       });
       const { res, next } = getMockRes();
@@ -99,7 +99,7 @@ describe('currentFileRecord', () => {
       const req = getMockReq({
         currentUser: currentUserIdp,
         params: {
-          id: fileId,
+          fileId: fileId,
         },
       });
       const { res, next } = getMockRes();
@@ -130,7 +130,7 @@ describe('currentFileRecord', () => {
       });
       const req = getMockReq({
         currentUser: currentUserIdp,
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 
@@ -149,7 +149,7 @@ describe('currentFileRecord', () => {
       });
       const req = getMockReq({
         apiUser: true,
-        params: { id: fileId },
+        params: { fileId: fileId },
       });
       const { res, next } = getMockRes();
 


### PR DESCRIPTION
# Description

The `GET /app/api/v1/files/XXX` had an error that the id was not a UUID. This is probably due to custom API calls, rather than bugs in the CHEFS frontend.

Pre-work before adding the validator:
- Rename the `id` parameter to `fileId` - `id` is too generic

## Types of changes

refactor (change to improve code quality)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request