### PR TITLE
ci: FORMS-1228 update actions deps

### DIFF
--- a/.github/actions/build-push-container/action.yaml
+++ b/.github/actions/build-push-container/action.yaml
@@ -117,7 +117,7 @@ runs:
         echo "HAS_DOCKERHUB=${{ fromJson(inputs.dockerhub_username != '' && inputs.dockerhub_token != '') }}" >> $GITHUB_ENV
 
     - name: Login to Github Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ env.GH_USERNAME }}
@@ -125,7 +125,7 @@ runs:
 
     - name: Login to Dockerhub Container Registry
       if: env.HAS_DOCKERHUB == 'true'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: docker.io
         username: ${{ inputs.dockerhub_username }}
@@ -133,7 +133,7 @@ runs:
 
     - name: Prepare Container Metadata tags
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: |
           ghcr.io/${{ env.GH_USERNAME }}/${{ inputs.image_name }}
@@ -151,7 +151,7 @@ runs:
 
     - name: Build and Push to Container Registry
       id: builder
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.context }}
         push: true

--- a/.github/actions/deploy-to-environment/action.yaml
+++ b/.github/actions/deploy-to-environment/action.yaml
@@ -38,22 +38,22 @@ inputs:
   ref:
     description: The checkout ref id
     required: false
-    default: ''
+    default: ""
 
 runs:
   using: composite
   steps:
     - name: Checkout repository from pull request
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
       if: ${{ inputs.ref != '' }}
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ inputs.ref == '' }}
 
     - name: Login to OpenShift Cluster
-      uses: jasonchung1871/oc-login@v1.1.2
+      uses: redhat-actions/oc-login@v1
 
       with:
         openshift_server_url: ${{ inputs.openshift_server }}

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,16 +21,16 @@ jobs:
         version: [18]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check CodeClimate Secrets
         id: check-secrets
         run: echo "HAS_CC_SECRETS=${{ secrets.CC_TEST_REPORTER_ID != '' }}" >> $GITHUB_OUTPUT
       - name: Use Node.js ${{ matrix.version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-app
         env:
           cache-name: cache-node-modules
@@ -50,7 +50,7 @@ jobs:
           CI: true
       - name: Save Coverage Results
         if: matrix.version == 18
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-app
           path: ${{ github.workspace }}/app/coverage
@@ -81,13 +81,13 @@ jobs:
         version: [18]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-frontend
         env:
           cache-name: cache-node-modules
@@ -107,7 +107,7 @@ jobs:
           CI: true
       - name: Save Coverage Results
         if: matrix.version == 18
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-frontend
           path: ${{ github.workspace }}/app/frontend/coverage
@@ -133,11 +133,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Restore Coverage Results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Publish code coverage
-        uses: paambaati/codeclimate-action@v3.2.0
+        uses: paambaati/codeclimate-action@v8
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:


### PR DESCRIPTION
# Description

The Github actions pipeline needs to be updated: many of the external Actions that we use are still using Node 16, which has been deprecated by GitHub. We should update to the latest versions of the external Actions.

## Types of changes

ci (change in continuous integration / deployment)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request