### PR TITLE
fix: FORMS-1336 validate fileId parameters

### DIFF
--- a/app/src/forms/common/middleware/validateParameter.js
+++ b/app/src/forms/common/middleware/validateParameter.js
@@ -63,10 +63,10 @@ const validateDocumentTemplateId = async (req, _res, next, documentTemplateId) =
 /**
  * Validates that the :fileId route parameter exists and is a UUID.
  *
- * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _req the Express object representing the HTTP request - unused.
  * @param {*} _res the Express object representing the HTTP response - unused.
  * @param {*} next the Express chaining function.
- * @param {*} externalAPIId the :fileId value from the route.
+ * @param {*} fileId the :fileId value from the route.
  */
 const validateFileId = async (_req, _res, next, fileId) => {
   try {

--- a/app/src/forms/common/middleware/validateParameter.js
+++ b/app/src/forms/common/middleware/validateParameter.js
@@ -66,11 +66,11 @@ const validateDocumentTemplateId = async (req, _res, next, documentTemplateId) =
  * @param {*} req the Express object representing the HTTP request.
  * @param {*} _res the Express object representing the HTTP response - unused.
  * @param {*} next the Express chaining function.
- * @param {*} externalAPIId the :externalAPIId value from the route.
+ * @param {*} externalAPIId the :fileId value from the route.
  */
-const validateFileId = async (_req, _res, next, formId) => {
+const validateFileId = async (_req, _res, next, fileId) => {
   try {
-    _validateUuid(formId, 'formId');
+    _validateUuid(fileId, 'fileId');
 
     next();
   } catch (error) {

--- a/app/src/forms/common/middleware/validateParameter.js
+++ b/app/src/forms/common/middleware/validateParameter.js
@@ -25,10 +25,10 @@ const _validateUuid = (parameter, parameterName) => {
  * This validator requires that either the :formId or :formSubmissionId route
  * parameter also exists.
  *
- * @param {*} req the Express object representing the HTTP request
- * @param {*} _res the Express object representing the HTTP response - unused
- * @param {*} next the Express chaining function
- * @param {*} documentTemplateId the :documentTemplateId value from the route
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} documentTemplateId the :documentTemplateId value from the route.
  */
 const validateDocumentTemplateId = async (req, _res, next, documentTemplateId) => {
   try {
@@ -61,12 +61,30 @@ const validateDocumentTemplateId = async (req, _res, next, documentTemplateId) =
 };
 
 /**
+ * Validates that the :fileId route parameter exists and is a UUID.
+ *
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} externalAPIId the :externalAPIId value from the route.
+ */
+const validateFileId = async (_req, _res, next, formId) => {
+  try {
+    _validateUuid(formId, 'formId');
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
  * Validates that the :formId route parameter exists and is a UUID.
  *
- * @param {*} _req the Express object representing the HTTP request - unused
- * @param {*} _res the Express object representing the HTTP response - unused
- * @param {*} next the Express chaining function
- * @param {*} formId the :formId value from the route
+ * @param {*} _req the Express object representing the HTTP request - unused.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} formId the :formId value from the route.
  */
 const validateFormId = async (_req, _res, next, formId) => {
   try {
@@ -82,10 +100,10 @@ const validateFormId = async (_req, _res, next, formId) => {
  * Validates that the :formVersionDraftId route parameter exists and is a UUID.
  * This validator requires that the :formId route parameter also exists.
  *
- * @param {*} req the Express object representing the HTTP request
- * @param {*} _res the Express object representing the HTTP response - unused
- * @param {*} next the Express chaining function
- * @param {*} formVersionDraftId the :formVersionDraftId value from the route
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} formVersionDraftId the :formVersionDraftId value from the route.
  */
 const validateFormVersionDraftId = async (req, _res, next, formVersionDraftId) => {
   try {
@@ -108,10 +126,10 @@ const validateFormVersionDraftId = async (req, _res, next, formVersionDraftId) =
  * Validates that the :formVersionId route parameter exists and is a UUID. This
  * validator requires that the :formId route parameter also exists.
  *
- * @param {*} req the Express object representing the HTTP request
- * @param {*} _res the Express object representing the HTTP response - unused
- * @param {*} next the Express chaining function
- * @param {*} formVersionId the :formVersionId value from the route
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} formVersionId the :formVersionId value from the route.
  */
 const validateFormVersionId = async (req, _res, next, formVersionId) => {
   try {
@@ -134,10 +152,10 @@ const validateFormVersionId = async (req, _res, next, formVersionId) => {
  * Validates that the :externalApiId route parameter exists and is a UUID. This
  * validator requires that the :formId route parameter also exists.
  *
- * @param {*} req the Express object representing the HTTP request
- * @param {*} _res the Express object representing the HTTP response - unused
- * @param {*} next the Express chaining function
- * @param {*} externalAPIId the :externalAPIId value from the route
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} externalAPIId the :externalAPIId value from the route.
  */
 const validateExternalAPIId = async (req, _res, next, externalAPIId) => {
   try {
@@ -158,6 +176,7 @@ const validateExternalAPIId = async (req, _res, next, externalAPIId) => {
 
 module.exports = {
   validateDocumentTemplateId,
+  validateFileId,
   validateFormId,
   validateFormVersionId,
   validateFormVersionDraftId,

--- a/app/src/forms/file/routes.js
+++ b/app/src/forms/file/routes.js
@@ -1,6 +1,7 @@
 const routes = require('express').Router();
 const controller = require('./controller');
 const apiAccess = require('../auth/middleware/apiAccess');
+const validateParameter = require('../common/middleware/validateParameter');
 
 const P = require('../common/constants').Permissions;
 const { currentFileRecord, hasFileCreate, hasFilePermissions } = require('./middleware/filePermissions');
@@ -9,6 +10,8 @@ const { currentUser } = require('../auth/middleware/userAccess');
 const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 
 routes.use(currentUser);
+
+routes.param('fileId', validateParameter.validateFileId);
 
 routes.post('/', hasFileCreate, fileUpload.upload, async (req, res, next) => {
   await controller.create(req, res, next);

--- a/app/tests/unit/forms/common/middleware/validateParameter.spec.js
+++ b/app/tests/unit/forms/common/middleware/validateParameter.spec.js
@@ -5,6 +5,7 @@ const validateParameter = require('../../../../../src/forms/common/middleware/va
 const formService = require('../../../../../src/forms/form/service');
 const submissionService = require('../../../../../src/forms/submission/service');
 
+const fileId = uuidv4();
 const formId = uuidv4();
 const formSubmissionId = uuidv4();
 
@@ -192,6 +193,49 @@ describe('validateDocumentTemplateId', () => {
 
       expect(formService.documentTemplateRead).toBeCalledTimes(1);
       expect(submissionService.read).toBeCalledTimes(1);
+      expect(next).toBeCalledWith();
+    });
+  });
+});
+
+describe('validateFileId', () => {
+  describe('400 response when', () => {
+    const expectedStatus = { status: 400 };
+
+    test('fileId is missing', async () => {
+      const req = getMockReq({
+        params: {},
+      });
+      const { res, next } = getMockRes();
+
+      await validateParameter.validateFileId(req, res, next);
+
+      expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
+    });
+
+    test.each(invalidUuids)('fileId is "%s"', async (eachFileId) => {
+      const req = getMockReq({
+        params: { fileId: eachFileId },
+      });
+      const { res, next } = getMockRes();
+
+      await validateParameter.validateFileId(req, res, next, eachFileId);
+
+      expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
+    });
+  });
+
+  describe('allows', () => {
+    test('uuid for fileId', async () => {
+      const req = getMockReq({
+        params: {
+          fileId: fileId,
+        },
+      });
+      const { res, next } = getMockRes();
+
+      await validateParameter.validateFileId(req, res, next, fileId);
+
       expect(next).toBeCalledWith();
     });
   });

--- a/app/tests/unit/forms/file/routes.spec.js
+++ b/app/tests/unit/forms/file/routes.spec.js
@@ -81,6 +81,7 @@ describe(`${basePath}`, () => {
   it('should have correct middleware for POST', async () => {
     await appRequest.post(path);
 
+    expect(validateParameter.validateFileId).toBeCalledTimes(0);
     expect(apiAccess).toBeCalledTimes(0);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(0);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(1);
@@ -99,7 +100,7 @@ describe(`${basePath}/:id`, () => {
   it('should have correct middleware for DELETE', async () => {
     await appRequest.delete(path);
 
-    // expect(validateParameter.validateFileId).toBeCalledTimes(1);
+    expect(validateParameter.validateFileId).toBeCalledTimes(1);
     expect(apiAccess).toBeCalledTimes(0);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(1);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(0);
@@ -113,7 +114,7 @@ describe(`${basePath}/:id`, () => {
   it('should have correct middleware for GET', async () => {
     await appRequest.get(path);
 
-    // expect(validateParameter.validateFileId).toBeCalledTimes(1);
+    expect(validateParameter.validateFileId).toBeCalledTimes(1);
     expect(apiAccess).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(1);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(0);


### PR DESCRIPTION
# Description

The `GET /app/api/v1/files/XXX` had an error that the id was not a UUID. This is probably due to custom API calls, rather than bugs in the CHEFS frontend.
- Add a new `fileId` validator to the route(s) that use it

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request