### PR TITLE
refactor: FORMS-1407 move orm code to service

### DIFF
--- a/app/src/forms/common/middleware/validateParameter.js
+++ b/app/src/forms/common/middleware/validateParameter.js
@@ -1,9 +1,9 @@
 const Problem = require('api-problem');
 const uuid = require('uuid');
 
+const externalApiService = require('../../form/externalApi/service');
 const formService = require('../../form/service');
 const submissionService = require('../../submission/service');
-const { ExternalAPI } = require('../models');
 
 /**
  * Throws a 400 problem if the parameter is not a valid UUID.
@@ -51,6 +51,32 @@ const validateDocumentTemplateId = async (req, _res, next, documentTemplateId) =
     if (!documentTemplate || documentTemplate.formId !== formId) {
       throw new Problem(404, {
         detail: 'documentTemplateId does not exist on this form',
+      });
+    }
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Validates that the :externalApiId route parameter exists and is a UUID. This
+ * validator requires that the :formId route parameter also exists.
+ *
+ * @param {*} req the Express object representing the HTTP request.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} externalAPIId the :externalAPIId value from the route.
+ */
+const validateExternalAPIId = async (req, _res, next, externalAPIId) => {
+  try {
+    _validateUuid(externalAPIId, 'externalAPIId');
+
+    const externalApi = await externalApiService.readExternalAPI(externalAPIId);
+    if (!externalApi || externalApi.formId !== req.params.formId) {
+      throw new Problem(404, {
+        detail: 'externalAPIId does not exist on this form',
       });
     }
 
@@ -148,37 +174,11 @@ const validateFormVersionId = async (req, _res, next, formVersionId) => {
   }
 };
 
-/**
- * Validates that the :externalApiId route parameter exists and is a UUID. This
- * validator requires that the :formId route parameter also exists.
- *
- * @param {*} req the Express object representing the HTTP request.
- * @param {*} _res the Express object representing the HTTP response - unused.
- * @param {*} next the Express chaining function.
- * @param {*} externalAPIId the :externalAPIId value from the route.
- */
-const validateExternalAPIId = async (req, _res, next, externalAPIId) => {
-  try {
-    _validateUuid(externalAPIId, 'externalAPIId');
-
-    const externalApi = await ExternalAPI.query().findById(externalAPIId);
-    if (!externalApi || externalApi.formId !== req.params.formId) {
-      throw new Problem(404, {
-        detail: 'externalAPIId does not exist on this form',
-      });
-    }
-
-    next();
-  } catch (error) {
-    next(error);
-  }
-};
-
 module.exports = {
   validateDocumentTemplateId,
+  validateExternalAPIId,
   validateFileId,
   validateFormId,
   validateFormVersionId,
   validateFormVersionDraftId,
-  validateExternalAPIId,
 };

--- a/app/src/forms/form/externalApi/service.js
+++ b/app/src/forms/form/externalApi/service.js
@@ -99,6 +99,10 @@ const service = {
     await ExternalAPI.query().modify('findByIdAndFormId', externalAPIId, formId).first().throwIfNotFound();
     await ExternalAPI.query().deleteById(externalAPIId);
   },
+
+  readExternalAPI: (externalAPIId) => {
+    return ExternalAPI.query().findById(externalAPIId);
+  },
 };
 
 module.exports = service;


### PR DESCRIPTION
# Description

A new validator called validateExternalAPIId was added to validateParameter. Instead of putting ORM calls in a service and then calling the service, the validator middleware directly calls the ORM. Ideally only the service layer should be making ORM calls - this sort of abstraction makes it easier to re-use code and reduces interconnectedness of the layers.

Also (and what brought this issue up) add testing of this new middleware. The tests should mimic the other middleware tests in mocking the service layer, and shouldn’t have to deal with mocking the ORM layer. Also re-arrange the file to restore the alphabetization of the functions.

## Types of changes

refactor (change to improve code quality)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request