### PR TITLE
refactor: FORMS-1408 remove unnecessary if

### DIFF
--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -356,15 +356,9 @@ const hasRoleModifyPermissions = async (req, _res, next) => {
 
       if (userRoles.includes(Roles.OWNER)) {
         // Can't remove a different user's owner role unless you are an owner.
-        //
-        // TODO: Remove this if statement and just throw the exception. It's not
-        // possible for userId === currentUser.id since we're in an if that we
-        // are !isOwner but also that userRoles.includes(Roles.OWNER).
-        if (userId !== currentUser.id) {
-          throw new Problem(401, {
-            detail: "You can't update an owner's roles.",
-          });
-        }
+        throw new Problem(401, {
+          detail: "You can't update an owner's roles.",
+        });
       } else if (futureRoles.includes(Roles.OWNER)) {
         // Can't add an owner role unless you are an owner.
         throw new Problem(401, {


### PR DESCRIPTION
# Description

During the writing of tests for `userAccess.hasRoleModifyPermissions` it was noticed that one condition could not be fully tested. This was because an `if` clause contained a test for something that was impossible given previous tests - so it could never be untrue. Remove the extra if clause so that we have complete code coverage with the unit tests.

## Types of changes

refactor (change to improve code quality)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request