### PR TITLE
fix: FORMS-1409 fix "mutiple" typos

### DIFF
--- a/app/frontend/src/services/formService.js
+++ b/app/frontend/src/services/formService.js
@@ -320,12 +320,12 @@ export default {
   },
 
   /**
-   * @function restoreMutipleSubmissions
+   * @function restoreMultipleSubmissions
    * Restores an existing submission
    * @param {string} submissionId The form uuid
    * @returns {Promise} An axios response
    */
-  restoreMutipleSubmissions(submissionId, formId, requestBody) {
+  restoreMultipleSubmissions(submissionId, formId, requestBody) {
     return appAxios().put(
       `${ApiRoutes.SUBMISSION}/${submissionId}/${formId}/submissions/restore`,
       requestBody

--- a/app/frontend/src/store/form.js
+++ b/app/frontend/src/store/form.js
@@ -513,7 +513,7 @@ export const useFormStore = defineStore('form', {
       const notificationStore = useNotificationStore();
       try {
         // Get this submission
-        await formService.restoreMutipleSubmissions(submissionIds[0], formId, {
+        await formService.restoreMultipleSubmissions(submissionIds[0], formId, {
           submissionIds: submissionIds,
         });
         notificationStore.addNotification({

--- a/app/frontend/tests/unit/services/formService.spec.js
+++ b/app/frontend/tests/unit/services/formService.spec.js
@@ -491,7 +491,7 @@ describe('Form Service', () => {
         '0715b1ac-4069-4778-a868-b4f71fdea18d',
       ];
 
-      const result = await formService.restoreMutipleSubmissions(
+      const result = await formService.restoreMultipleSubmissions(
         submissionId,
         formId,
         { submissionIds }

--- a/app/frontend/tests/unit/store/modules/form.actions.spec.js
+++ b/app/frontend/tests/unit/store/modules/form.actions.spec.js
@@ -259,7 +259,7 @@ describe('form actions', () => {
     });
 
     it('restoreMultiSubmissions should dispatch to notifications/addNotification', async () => {
-      formService.restoreMutipleSubmissions.mockRejectedValue('');
+      formService.restoreMultipleSubmissions.mockRejectedValue('');
       await mockStore.restoreMultiSubmissions(['sId']);
 
       expect(addNotificationSpy).toHaveBeenCalledTimes(1);

--- a/app/src/forms/submission/controller.js
+++ b/app/src/forms/submission/controller.js
@@ -36,19 +36,19 @@ module.exports = {
       next(error);
     }
   },
-  deleteMutipleSubmissions: async (req, res, next) => {
+  deleteMultipleSubmissions: async (req, res, next) => {
     try {
       let submissionIds = req.body && req.body.submissionIds ? req.body.submissionIds : [];
-      const response = await service.deleteMutipleSubmissions(submissionIds, req.currentUser);
+      const response = await service.deleteMultipleSubmissions(submissionIds, req.currentUser);
       res.status(200).json(response);
     } catch (error) {
       next(error);
     }
   },
-  restoreMutipleSubmissions: async (req, res, next) => {
+  restoreMultipleSubmissions: async (req, res, next) => {
     try {
       let submissionIds = req.body && req.body.submissionIds ? req.body.submissionIds : [];
-      const response = await service.restoreMutipleSubmissions(submissionIds, req.currentUser);
+      const response = await service.restoreMultipleSubmissions(submissionIds, req.currentUser);
       res.status(200).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -27,7 +27,7 @@ routes.delete('/:formSubmissionId', rateLimiter, apiAccess, hasSubmissionPermiss
 });
 
 routes.put('/:formSubmissionId/:formId/submissions/restore', hasSubmissionPermissions([P.SUBMISSION_DELETE]), filterMultipleSubmissions, async (req, res, next) => {
-  await controller.restoreMutipleSubmissions(req, res, next);
+  await controller.restoreMultipleSubmissions(req, res, next);
 });
 
 routes.put('/:formSubmissionId/restore', hasSubmissionPermissions([P.SUBMISSION_DELETE]), async (req, res, next) => {
@@ -71,7 +71,7 @@ routes.post('/:formSubmissionId/template/render', rateLimiter, apiAccess, hasSub
 });
 
 routes.delete('/:formSubmissionId/:formId/submissions', hasSubmissionPermissions([P.SUBMISSION_DELETE]), filterMultipleSubmissions, async (req, res, next) => {
-  await controller.deleteMutipleSubmissions(req, res, next);
+  await controller.deleteMultipleSubmissions(req, res, next);
 });
 
 module.exports = routes;

--- a/app/src/forms/submission/service.js
+++ b/app/src/forms/submission/service.js
@@ -191,7 +191,7 @@ const service = {
     }
   },
 
-  deleteMutipleSubmissions: async (submissionIds, currentUser) => {
+  deleteMultipleSubmissions: async (submissionIds, currentUser) => {
     let trx;
     try {
       trx = await FormSubmission.startTransaction();
@@ -204,7 +204,7 @@ const service = {
     }
   },
 
-  restoreMutipleSubmissions: async (submissionIds, currentUser) => {
+  restoreMultipleSubmissions: async (submissionIds, currentUser) => {
     let trx;
     try {
       trx = await FormSubmission.startTransaction();

--- a/app/tests/unit/forms/submission/controller.spec.js
+++ b/app/tests/unit/forms/submission/controller.spec.js
@@ -357,7 +357,7 @@ describe('template rendering', () => {
   });
 });
 
-describe('deleteMutipleSubmissions', () => {
+describe('deleteMultipleSubmissions', () => {
   const returnValue = {
     submission: [
       { id: 'ac4ef441-43b1-414a-a0d4-1e2f67c2a745', formVersionId: '8d8e24ce-326f-4536-9100-a0844c27d5a0', confirmationId: 'AC4EF441', draft: false, deleted: true },
@@ -373,16 +373,16 @@ describe('deleteMutipleSubmissions', () => {
     currentUser: {},
     headers: {},
   };
-  it('should call deleteMutipleSubmissions service in controller', async () => {
-    service.deleteMutipleSubmissions = jest.fn().mockReturnValue(returnValue);
-    await controller.deleteMutipleSubmissions(req, {}, jest.fn());
+  it('should call deleteMultipleSubmissions service in controller', async () => {
+    service.deleteMultipleSubmissions = jest.fn().mockReturnValue(returnValue);
+    await controller.deleteMultipleSubmissions(req, {}, jest.fn());
 
-    expect(service.deleteMutipleSubmissions).toBeCalledTimes(1);
-    expect(service.deleteMutipleSubmissions).toBeCalledWith(req.body.submissionIds, req.currentUser);
+    expect(service.deleteMultipleSubmissions).toBeCalledTimes(1);
+    expect(service.deleteMultipleSubmissions).toBeCalledWith(req.body.submissionIds, req.currentUser);
   });
 });
 
-describe('restoreMutipleSubmissions', () => {
+describe('restoreMultipleSubmissions', () => {
   const returnValue = {
     submission: [
       { id: 'ac4ef441-43b1-414a-a0d4-1e2f67c2a745', formVersionId: '8d8e24ce-326f-4536-9100-a0844c27d5a0', confirmationId: 'AC4EF441', draft: false, deleted: false },
@@ -398,11 +398,11 @@ describe('restoreMutipleSubmissions', () => {
     currentUser: {},
     headers: {},
   };
-  it('should call restoreMutipleSubmissions service in controller', async () => {
-    service.restoreMutipleSubmissions = jest.fn().mockReturnValue(returnValue);
-    await controller.restoreMutipleSubmissions(req, {}, jest.fn());
+  it('should call restoreMultipleSubmissions service in controller', async () => {
+    service.restoreMultipleSubmissions = jest.fn().mockReturnValue(returnValue);
+    await controller.restoreMultipleSubmissions(req, {}, jest.fn());
 
-    expect(service.restoreMutipleSubmissions).toBeCalledTimes(1);
-    expect(service.restoreMutipleSubmissions).toBeCalledWith(req.body.submissionIds, req.currentUser);
+    expect(service.restoreMultipleSubmissions).toBeCalledTimes(1);
+    expect(service.restoreMultipleSubmissions).toBeCalledWith(req.body.submissionIds, req.currentUser);
   });
 });

--- a/app/tests/unit/forms/submission/routes.spec.js
+++ b/app/tests/unit/forms/submission/routes.spec.js
@@ -40,7 +40,7 @@ controller.addStatus = jest.fn((_req, _res, next) => {
 controller.delete = jest.fn((_req, _res, next) => {
   next();
 });
-controller.deleteMutipleSubmissions = jest.fn((_req, _res, next) => {
+controller.deleteMultipleSubmissions = jest.fn((_req, _res, next) => {
   next();
 });
 controller.email = jest.fn((_req, _res, next) => {
@@ -64,7 +64,7 @@ controller.readOptions = jest.fn((_req, _res, next) => {
 controller.restore = jest.fn((_req, _res, next) => {
   next();
 });
-controller.restoreMutipleSubmissions = jest.fn((_req, _res, next) => {
+controller.restoreMultipleSubmissions = jest.fn((_req, _res, next) => {
   next();
 });
 controller.templateRender = jest.fn((_req, _res, next) => {
@@ -182,7 +182,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions`, () => {
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
     expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(1);
-    expect(controller.deleteMutipleSubmissions).toBeCalledTimes(1);
+    expect(controller.deleteMultipleSubmissions).toBeCalledTimes(1);
   });
 });
 
@@ -200,7 +200,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions/restore`, () => {
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
     expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(1);
-    expect(controller.restoreMutipleSubmissions).toBeCalledTimes(1);
+    expect(controller.restoreMultipleSubmissions).toBeCalledTimes(1);
   });
 });
 

--- a/app/tests/unit/forms/submission/service.spec.js
+++ b/app/tests/unit/forms/submission/service.spec.js
@@ -52,7 +52,7 @@ describe('createStatus', () => {
   });
 });
 
-describe('deleteMutipleSubmissions', () => {
+describe('deleteMultipleSubmissions', () => {
   it('should delete the selected submissions', async () => {
     let submissionId1 = uuid.v4();
     let submissionId2 = uuid.v4();
@@ -70,7 +70,7 @@ describe('deleteMutipleSubmissions', () => {
     const currentUser = { usernameIdp: 'TEST@idir' };
     service.readSubmissionData = jest.fn().mockReturnValue(returnValue);
     const spy = jest.spyOn(service, 'readSubmissionData');
-    const res = await service.deleteMutipleSubmissions(submissionIds, currentUser);
+    const res = await service.deleteMultipleSubmissions(submissionIds, currentUser);
     expect(MockModel.startTransaction).toBeCalledTimes(1);
     expect(MockModel.query).toBeCalledTimes(1);
     expect(MockModel.query).toBeCalledWith(expect.anything());
@@ -83,7 +83,7 @@ describe('deleteMutipleSubmissions', () => {
   });
 });
 
-describe('restoreMutipleSubmissions', () => {
+describe('restoreMultipleSubmissions', () => {
   it('should delete the selected submissions', async () => {
     let submissionId1 = uuid.v4();
     let submissionId2 = uuid.v4();
@@ -101,7 +101,7 @@ describe('restoreMutipleSubmissions', () => {
     const currentUser = { usernameIdp: 'TEST@idir' };
     service.readSubmissionData = jest.fn().mockReturnValue(returnValue);
     const spy = jest.spyOn(service, 'readSubmissionData');
-    const res = await service.restoreMutipleSubmissions(submissionIds, currentUser);
+    const res = await service.restoreMultipleSubmissions(submissionIds, currentUser);
     expect(MockModel.startTransaction).toBeCalledTimes(1);
     expect(MockModel.query).toBeCalledTimes(1);
     expect(MockModel.query).toBeCalledWith(expect.anything());

--- a/app/tests/unit/routes/v1/submission.spec.js
+++ b/app/tests/unit/routes/v1/submission.spec.js
@@ -268,7 +268,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions`, () => {
   describe('DELETE', () => {
     it('should return 200', async () => {
       // mock a success return value...
-      service.deleteMutipleSubmissions = jest.fn().mockReturnValue({});
+      service.deleteMultipleSubmissions = jest.fn().mockReturnValue({});
 
       const response = await appRequest.delete(path);
 
@@ -278,7 +278,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions`, () => {
 
     it('should handle 401', async () => {
       // mock an authentication/permission issue...
-      service.deleteMutipleSubmissions = jest.fn(() => {
+      service.deleteMultipleSubmissions = jest.fn(() => {
         throw new Problem(401);
       });
 
@@ -290,7 +290,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions`, () => {
 
     it('should handle 500', async () => {
       // mock an unexpected error...
-      service.deleteMutipleSubmissions = jest.fn(() => {
+      service.deleteMultipleSubmissions = jest.fn(() => {
         throw new Error();
       });
 
@@ -308,7 +308,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions/restore`, () => {
   describe('PUT', () => {
     it('should return 200', async () => {
       // mock a success return value...
-      service.restoreMutipleSubmissions = jest.fn().mockReturnValue({});
+      service.restoreMultipleSubmissions = jest.fn().mockReturnValue({});
 
       const response = await appRequest.put(path);
 
@@ -318,7 +318,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions/restore`, () => {
 
     it('should handle 401', async () => {
       // mock an authentication/permission issue...
-      service.restoreMutipleSubmissions = jest.fn(() => {
+      service.restoreMultipleSubmissions = jest.fn(() => {
         throw new Problem(401);
       });
 
@@ -330,7 +330,7 @@ describe(`${basePath}/:formSubmissionId/:formId/submissions/restore`, () => {
 
     it('should handle 500', async () => {
       // mock an unexpected error...
-      service.restoreMutipleSubmissions = jest.fn(() => {
+      service.restoreMultipleSubmissions = jest.fn(() => {
         throw new Error();
       });
 


### PR DESCRIPTION
# Description

Some of the backend code has “Mutiple” where it is supposed to be “Multiple”. Most of these are in the tests, but they all should be updated to make it easier to search, and to have fewer surprises for anyone who reads / uses the code.

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request