### PR TITLE
refactor: FORMS-1348 consistently use sendStatus

### DIFF
--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -33,7 +33,7 @@ module.exports = {
   documentTemplateDelete: async (req, res, next) => {
     try {
       await service.documentTemplateDelete(req.params.documentTemplateId, req.currentUser.usernameIdp);
-      res.status(204).send();
+      res.sendStatus(204);
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/form/externalApi/controller.js
+++ b/app/src/forms/form/externalApi/controller.js
@@ -44,7 +44,7 @@ module.exports = {
   deleteExternalAPI: async (req, res, next) => {
     try {
       await service.deleteExternalAPI(req.params.formId, req.params.externalAPIId);
-      res.status(204).send();
+      res.sendStatus(204);
     } catch (error) {
       next(error);
     }

--- a/app/src/forms/user/controller.js
+++ b/app/src/forms/user/controller.js
@@ -57,7 +57,7 @@ module.exports = {
   deleteUserPreferences: async (req, res, next) => {
     try {
       await service.deleteUserPreferences(req.currentUser);
-      res.status(204).send();
+      res.sendStatus(204);
     } catch (error) {
       next(error);
     }
@@ -93,7 +93,7 @@ module.exports = {
   deleteUserFormPreferences: async (req, res, next) => {
     try {
       await service.deleteUserFormPreferences(req.currentUser, req.params.formId);
-      res.status(204).send();
+      res.sendStatus(204);
     } catch (error) {
       next(error);
     }

--- a/app/tests/unit/forms/form/controller.spec.js
+++ b/app/tests/unit/forms/form/controller.spec.js
@@ -152,7 +152,7 @@ describe('documentTemplateDelete', () => {
 
       expect(service.documentTemplateDelete).toBeCalledWith(validRequest.params.documentTemplateId, validRequest.currentUser.usernameIdp);
       expect(res.json).not.toBeCalled();
-      expect(res.status).toBeCalledWith(204);
+      expect(res.sendStatus).toBeCalledWith(204);
       expect(next).not.toBeCalled();
     });
   });

--- a/app/tests/unit/forms/form/externalApi/controller.spec.js
+++ b/app/tests/unit/forms/form/externalApi/controller.spec.js
@@ -337,7 +337,8 @@ describe('deleteExternalAPI', () => {
       await controller.deleteExternalAPI(req, res, next);
 
       expect(service.deleteExternalAPI).toBeCalledWith(validRequest.params.formId, validRequest.params.externalAPIId);
-      expect(res.status).toBeCalledWith(204);
+      expect(res.json).not.toBeCalled();
+      expect(res.sendStatus).toBeCalledWith(204);
       expect(next).not.toBeCalled();
     });
   });


### PR DESCRIPTION
# Description

We sometimes return an HTTP response with a status code and no body, such as for a DELETE verb. There are two ways to do this:
```javascript
res.status(204).send();
```
and
```javascript
res.sendStatus(204);
```
We should always standardize the code to always do things in a single way. Since Express gives `sendStatus` to both set the status and send the response, standardize on using it.

## Types of changes

refactor (change to improve code quality)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request