### PR TITLE
fix: FORMS-1209 add user id validation

### DIFF
--- a/app/src/forms/common/middleware/validateParameter.js
+++ b/app/src/forms/common/middleware/validateParameter.js
@@ -192,6 +192,24 @@ const validateFormVersionId = async (req, _res, next, formVersionId) => {
   }
 };
 
+/**
+ * Validates that the :userId route parameter exists and is a UUID.
+ *
+ * @param {*} _req the Express object representing the HTTP request - unused.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} userId the :userId value from the route.
+ */
+const validateUserId = async (_req, _res, next, userId) => {
+  try {
+    _validateUuid(userId, 'userId');
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
 module.exports = {
   validateDocumentTemplateId,
   validateExternalAPIId,
@@ -200,4 +218,5 @@ module.exports = {
   validateFormSubmissionId,
   validateFormVersionDraftId,
   validateFormVersionId,
+  validateUserId,
 };

--- a/app/src/forms/user/routes.js
+++ b/app/src/forms/user/routes.js
@@ -1,11 +1,15 @@
 const routes = require('express').Router();
-const controller = require('./controller');
 
-const currentUser = require('../auth/middleware/userAccess').currentUser;
 const jwtService = require('../../components/jwtService');
+const currentUser = require('../auth/middleware/userAccess').currentUser;
+const validateParameter = require('../common/middleware/validateParameter');
+const controller = require('./controller');
 
 routes.use(jwtService.protect());
 routes.use(currentUser);
+
+routes.param('formId', validateParameter.validateFormId);
+routes.param('userId', validateParameter.validateUserId);
 
 //
 // User Preferences

--- a/app/tests/unit/forms/common/middleware/validateParameter.spec.js
+++ b/app/tests/unit/forms/common/middleware/validateParameter.spec.js
@@ -9,6 +9,7 @@ const submissionService = require('../../../../../src/forms/submission/service')
 const fileId = uuid.v4();
 const formId = uuid.v4();
 const formSubmissionId = uuid.v4();
+const userId = uuid.v4();
 
 // Various types of invalid UUIDs that we see in API calls.
 const invalidUuids = [[''], ['undefined'], ['{{id}}'], ['${id}'], [uuid.v4() + '.'], [' ' + uuid.v4() + ' ']];
@@ -668,6 +669,49 @@ describe('validateFormVersionId', () => {
       await validateParameter.validateFormVersionId(req, res, next, formVersionId);
 
       expect(formService.readVersion).toBeCalledTimes(1);
+      expect(next).toBeCalledWith();
+    });
+  });
+});
+
+describe('validateUserId', () => {
+  describe('400 response when', () => {
+    const expectedStatus = { status: 400 };
+
+    test('userId is missing', async () => {
+      const req = getMockReq({
+        params: {},
+      });
+      const { res, next } = getMockRes();
+
+      await validateParameter.validateUserId(req, res, next);
+
+      expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
+    });
+
+    test.each(invalidUuids)('userId is "%s"', async (eachUserId) => {
+      const req = getMockReq({
+        params: { userId: eachUserId },
+      });
+      const { res, next } = getMockRes();
+
+      await validateParameter.validateUserId(req, res, next, eachUserId);
+
+      expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
+    });
+  });
+
+  describe('allows', () => {
+    test('uuid for userId', async () => {
+      const req = getMockReq({
+        params: {
+          userId: userId,
+        },
+      });
+      const { res, next } = getMockRes();
+
+      await validateParameter.validateUserId(req, res, next, userId);
+
       expect(next).toBeCalledWith();
     });
   });

--- a/app/tests/unit/forms/user/routes.spec.js
+++ b/app/tests/unit/forms/user/routes.spec.js
@@ -1,0 +1,180 @@
+const request = require('supertest');
+const uuid = require('uuid');
+
+const { expressHelper } = require('../../../common/helper');
+
+const jwtService = require('../../../../src/components/jwtService');
+const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
+const validateParameter = require('../../../../src/forms/common/middleware/validateParameter');
+const controller = require('../../../../src/forms/user/controller');
+
+//
+// Mock out all the middleware - we're testing that the routes are set up
+// correctly, not the functionality of the middleware.
+//
+
+jwtService.protect = jest.fn(() => {
+  return jest.fn((_req, _res, next) => {
+    next();
+  });
+});
+
+userAccess.currentUser = jest.fn((_req, _res, next) => {
+  next();
+});
+
+validateParameter.validateFormId = jest.fn((_req, _res, next) => {
+  next();
+});
+validateParameter.validateUserId = jest.fn((_req, _res, next) => {
+  next();
+});
+
+// Mock the controller functions with happy path results.
+
+controller.deleteUserFormPreferences = jest.fn((_req, res) => {
+  res.sendStatus(204);
+});
+controller.deleteUserPreferences = jest.fn((_req, res) => {
+  res.sendStatus(204);
+});
+controller.list = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+controller.read = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+controller.readUserFormPreferences = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+controller.readUserLabels = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+controller.readUserPreferences = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+controller.updateUserFormPreferences = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+controller.updateUserLabels = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+controller.updateUserPreferences = jest.fn((_req, res) => {
+  res.status(200).json({});
+});
+
+const formId = uuid.v4();
+const userId = uuid.v4();
+
+//
+// Create the router and a simple Express server.
+//
+
+const router = require('../../../../src/forms/user/routes');
+const basePath = '/users';
+const app = expressHelper(basePath, router);
+const appRequest = request(app);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe(`${basePath}/`, () => {
+  const path = `${basePath}/`;
+
+  it('should have correct middleware for GET', async () => {
+    await appRequest.get(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.list).toBeCalledTimes(1);
+  });
+});
+
+describe(`${basePath}/:userId`, () => {
+  const path = `${basePath}/${userId}`;
+
+  it('should have correct middleware for GET', async () => {
+    await appRequest.get(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(1);
+    expect(controller.read).toBeCalledTimes(1);
+  });
+});
+
+describe(`${basePath}/labels`, () => {
+  const path = `${basePath}/labels`;
+
+  it('should have correct middleware for GET', async () => {
+    await appRequest.get(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.readUserLabels).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    await appRequest.put(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.updateUserLabels).toBeCalledTimes(1);
+  });
+});
+
+describe(`${basePath}/preferences`, () => {
+  const path = `${basePath}/preferences`;
+
+  it('should have correct middleware for DELETE', async () => {
+    await appRequest.delete(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.deleteUserPreferences).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for GET', async () => {
+    await appRequest.get(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.readUserPreferences).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    await appRequest.put(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.updateUserPreferences).toBeCalledTimes(1);
+  });
+});
+
+describe(`${basePath}/preferences/forms/:formId`, () => {
+  const path = `${basePath}/preferences/forms/${formId}`;
+
+  it('should have correct middleware for DELETE', async () => {
+    await appRequest.delete(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.deleteUserFormPreferences).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for GET', async () => {
+    await appRequest.get(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.readUserFormPreferences).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    await appRequest.put(path);
+
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
+    expect(controller.updateUserFormPreferences).toBeCalledTimes(1);
+  });
+});

--- a/app/tests/unit/routes/v1/user.spec.js
+++ b/app/tests/unit/routes/v1/user.spec.js
@@ -1,5 +1,6 @@
-const request = require('supertest');
 const Problem = require('api-problem');
+const request = require('supertest');
+const uuid = require('uuid');
 
 const { expressHelper } = require('../../../common/helper');
 
@@ -26,6 +27,9 @@ userAccess.currentUser = jest.fn((_req, _res, next) => {
 // we will mock the underlying data service calls...
 //
 const service = require('../../../../src/forms/user/service');
+
+const formId = uuid.v4();
+const userId = uuid.v4();
 
 //
 // mocks are in place, create the router
@@ -82,7 +86,7 @@ describe(`${basePath}`, () => {
 });
 
 describe(`${basePath}/:userId`, () => {
-  const path = `${basePath}/:userId`;
+  const path = `${basePath}/${userId}`;
 
   describe('GET', () => {
     it('should return 200', async () => {
@@ -234,7 +238,7 @@ describe(`${basePath}/preferences`, () => {
 });
 
 describe(`${basePath}/preferences/forms/:formId`, () => {
-  const path = `${basePath}/preferences/forms/:formId`;
+  const path = `${basePath}/preferences/forms/${formId}`;
 
   describe('DELETE', () => {
     it('should return 204', async () => {


### PR DESCRIPTION
# Description

FORMS-1204 was tracking the most common database errors that we have due to bad requests. The `GET /app/api/v1/users/preferences/forms/XXX` endpoint is one place to fix the problem. This error is the most common and is probably due to CHEFS frontend bug(s) rather than third-party calls to the API. See FORMS-996.

- Add `formId` validation to the three routes that use it
- There is one route that takes a `userId` parameter - for the sake of completeness of the tests, while we’re in this file add this as a new validator
- The `/user` routes are very simple in terms of middleware use, so it won’t take too much effort to write unit tests for all the routes. Current coverage is high, but we have “route” tests that are actually only testing the controller.
  - 92.59% Statements 25/27
  - 100% Branches 0/0
  - 80% Functions 8/10
  - 92.59% Lines 25/27

## Types of changes

fix (a bug fix)

> This is a _potentially_ breaking change because the API will now return the correct 400 response for bad UUIDs, rather than 422. Any calling code should hopefully be robust in its error handling and this change will not cause problems.

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request