### PR TITLE
build: FORMS-887 update backup images

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -255,6 +255,6 @@ oc process -f backup-cronjob-verify.yaml \
     -p JOB_NAME=backup-postgres-verify \
     -p JOB_PERSISTENT_STORAGE_NAME=$PVC \
     -p SCHEDULE="0 9 * * *" \
-    -p TAG_NAME=2.6.1 \
+    -p TAG_NAME=2.8.0 \
     | oc -n $NAMESPACE apply -f -
 ```

--- a/openshift/redash/README.md
+++ b/openshift/redash/README.md
@@ -26,7 +26,7 @@ oc process -f backup-cronjob.yaml \
     -p JOB_PERSISTENT_STORAGE_NAME=backup-chefs-redash-postgresql \
     -p MONTHLY_BACKUPS=3 \
     -p SCHEDULE="0 8 * * *" \
-    -p TAG_NAME=2.6.1 \
+    -p TAG_NAME=2.9.0 \
     -p WEEKLY_BACKUPS=8 \
     | oc -n a12c97-tools apply -f -
 ```
@@ -42,7 +42,7 @@ oc process -f backup-cronjob-verify.yaml \
     -p JOB_NAME=backup-chefs-redash-postgres-verify \
     -p JOB_PERSISTENT_STORAGE_NAME=backup-chefs-redash-postgresql \
     -p SCHEDULE="0 9 * * *" \
-    -p TAG_NAME=2.6.1 \
+    -p TAG_NAME=2.9.0 \
     | oc -n a12c97-tools apply -f -
 ```
 

--- a/openshift/redash/README.md
+++ b/openshift/redash/README.md
@@ -26,7 +26,7 @@ oc process -f backup-cronjob.yaml \
     -p JOB_PERSISTENT_STORAGE_NAME=backup-chefs-redash-postgresql \
     -p MONTHLY_BACKUPS=3 \
     -p SCHEDULE="0 8 * * *" \
-    -p TAG_NAME=2.9.0 \
+    -p TAG_NAME=2.8.0 \
     -p WEEKLY_BACKUPS=8 \
     | oc -n a12c97-tools apply -f -
 ```
@@ -42,7 +42,7 @@ oc process -f backup-cronjob-verify.yaml \
     -p JOB_NAME=backup-chefs-redash-postgres-verify \
     -p JOB_PERSISTENT_STORAGE_NAME=backup-chefs-redash-postgresql \
     -p SCHEDULE="0 9 * * *" \
-    -p TAG_NAME=2.9.0 \
+    -p TAG_NAME=2.8.0 \
     | oc -n a12c97-tools apply -f -
 ```
 


### PR DESCRIPTION
# Description

On 2024-05-10 version 2.9.0 of the BCDevOps backup-container was released. We should update all of our backup containers to use this latest version:

1. Redash backup; Redash verify
1. Fider backup; Fider verify
1. CHEFS Dev backup; CHEFS Dev verify
1. CHEFS Test backup; CHEFS Test verify
1. CHEFS Prod backup; CHEFS Prod verify

## Types of changes

build (change in build system or dependencies)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request