### PR TITLE
test: FORMS-1444 add rbac routes tests

### DIFF
--- a/app/tests/unit/forms/admin/routes.spec.js
+++ b/app/tests/unit/forms/admin/routes.spec.js
@@ -50,9 +50,9 @@ describe(`${basePath}/externalAPIs`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.getExternalAPIs).toHaveBeenCalledTimes(1);
+    expect(controller.getExternalAPIs).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -67,9 +67,9 @@ describe(`${basePath}/externalAPIs/:externalApiId`, () => {
 
     await appRequest.put(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.updateExternalAPI).toHaveBeenCalledTimes(1);
+    expect(controller.updateExternalAPI).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -83,9 +83,9 @@ describe(`${basePath}/externalAPIs/statusCodes`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.getExternalAPIStatusCodes).toHaveBeenCalledTimes(1);
+    expect(controller.getExternalAPIStatusCodes).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -100,9 +100,9 @@ describe(`${basePath}/formcomponents/proactivehelp/:publishStatus/:componentId`,
 
     await appRequest.put(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.updateFormComponentsProactiveHelp).toHaveBeenCalledTimes(1);
+    expect(controller.updateFormComponentsProactiveHelp).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -117,9 +117,9 @@ describe(`${basePath}/formcomponents/proactivehelp/imageUrl/:componentId`, () =>
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.getFCProactiveHelpImageUrl).toHaveBeenCalledTimes(1);
+    expect(controller.getFCProactiveHelpImageUrl).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -133,9 +133,9 @@ describe(`${basePath}/formcomponents/proactivehelp/list`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.listFormComponentsProactiveHelp).toHaveBeenCalledTimes(1);
+    expect(controller.listFormComponentsProactiveHelp).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -149,9 +149,9 @@ describe(`${basePath}/formcomponents/proactivehelp/object`, () => {
 
     await appRequest.post(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.createFormComponentsProactiveHelp).toHaveBeenCalledTimes(1);
+    expect(controller.createFormComponentsProactiveHelp).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -165,9 +165,9 @@ describe(`${basePath}/forms`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.listForms).toHaveBeenCalledTimes(1);
+    expect(controller.listForms).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -182,9 +182,9 @@ describe(`${basePath}/forms/:formId`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.readForm).toHaveBeenCalledTimes(1);
+    expect(controller.readForm).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -199,9 +199,9 @@ describe(`${basePath}/forms/:formId/addUser`, () => {
 
     await appRequest.put(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.setFormUserRoles).toHaveBeenCalledTimes(1);
+    expect(controller.setFormUserRoles).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -216,9 +216,9 @@ describe(`${basePath}/forms/:formId/apiKey`, () => {
 
     await appRequest.delete(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.deleteApiKey).toHaveBeenCalledTimes(1);
+    expect(controller.deleteApiKey).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
@@ -228,9 +228,9 @@ describe(`${basePath}/forms/:formId/apiKey`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.readApiDetails).toHaveBeenCalledTimes(1);
+    expect(controller.readApiDetails).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -245,9 +245,9 @@ describe(`${basePath}/forms/:formId/formUsers`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.getFormUserRoles).toHaveBeenCalledTimes(1);
+    expect(controller.getFormUserRoles).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -262,9 +262,9 @@ describe(`${basePath}/forms/:formId/restore`, () => {
 
     await appRequest.put(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.restoreForm).toHaveBeenCalledTimes(1);
+    expect(controller.restoreForm).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -280,9 +280,9 @@ describe(`${basePath}/forms/:formId/versions/:formVersionId`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.readVersion).toHaveBeenCalledTimes(1);
+    expect(controller.readVersion).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -296,9 +296,9 @@ describe(`${basePath}/users`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(controller.getUsers).toHaveBeenCalledTimes(1);
+    expect(controller.getUsers).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
   });
 });
 
@@ -313,8 +313,8 @@ describe(`${basePath}/users/:userId`, () => {
 
     await appRequest.get(path);
 
-    expect(mockJwtServiceProtect).toHaveBeenCalledTimes(1);
-    expect(userAccess.currentUser).toHaveBeenCalledTimes(1);
-    expect(userController.read).toHaveBeenCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userController.read).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/forms/bcgeoaddress/routes.spec.js
+++ b/app/tests/unit/forms/bcgeoaddress/routes.spec.js
@@ -27,7 +27,7 @@ describe(`${basePath}/address`, () => {
 
     await appRequest.get(path);
 
-    expect(controller.searchBCGeoAddress).toHaveBeenCalledTimes(1);
+    expect(controller.searchBCGeoAddress).toBeCalledTimes(1);
   });
 });
 
@@ -41,6 +41,6 @@ describe(`${basePath}/advance/address`, () => {
 
     await appRequest.get(path);
 
-    expect(controller.advanceSearchBCGeoAddress).toHaveBeenCalledTimes(1);
+    expect(controller.advanceSearchBCGeoAddress).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/forms/file/routes.spec.js
+++ b/app/tests/unit/forms/file/routes.spec.js
@@ -75,15 +75,15 @@ describe(`${basePath}`, () => {
 
     await appRequest.post(path);
 
-    expect(validateParameter.validateFileId).toBeCalledTimes(0);
     expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.create).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(0);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(1);
     expect(hasFilePermissionsMock).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(upload.fileUpload.upload).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
-    expect(controller.create).toBeCalledTimes(1);
+    expect(validateParameter.validateFileId).toBeCalledTimes(0);
   });
 });
 
@@ -98,15 +98,15 @@ describe(`${basePath}/:id`, () => {
 
     await appRequest.delete(path);
 
-    expect(validateParameter.validateFileId).toBeCalledTimes(1);
     expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.delete).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(1);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(0);
     expect(hasFilePermissionsMock).toBeCalledTimes(1);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(upload.fileUpload.upload).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
-    expect(controller.delete).toBeCalledTimes(1);
+    expect(validateParameter.validateFileId).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
@@ -116,14 +116,14 @@ describe(`${basePath}/:id`, () => {
 
     await appRequest.get(path);
 
-    expect(validateParameter.validateFileId).toBeCalledTimes(1);
     expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.read).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(1);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(0);
     expect(hasFilePermissionsMock).toBeCalledTimes(1);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(upload.fileUpload.upload).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
-    expect(controller.read).toBeCalledTimes(1);
+    expect(validateParameter.validateFileId).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/forms/form/externalApi/routes.spec.js
+++ b/app/tests/unit/forms/form/externalApi/routes.spec.js
@@ -15,18 +15,18 @@ const controller = require('../../../../../src/forms/form/externalApi/controller
 // correctly, not the functionality of the middleware.
 //
 
-jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
-});
-
 jest.mock('../../../../../src/forms/auth/middleware/apiAccess');
 apiAccess.mockImplementation(
   jest.fn((_req, _res, next) => {
     next();
   })
 );
+
+jwtService.protect = jest.fn(() => {
+  return jest.fn((_req, _res, next) => {
+    next();
+  });
+});
 
 rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
   next();
@@ -79,12 +79,12 @@ describe(`${basePath}/:formId/externalAPIs`, () => {
 
     await appRequest.get(path);
 
-    expect(validateParameter.validateFormId).toBeCalledTimes(1);
-    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
     expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(controller.listExternalAPIs).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for POST', async () => {
@@ -94,12 +94,12 @@ describe(`${basePath}/:formId/externalAPIs`, () => {
 
     await appRequest.post(path);
 
-    expect(validateParameter.validateFormId).toBeCalledTimes(1);
-    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
     expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(controller.createExternalAPI).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
   });
 
   it('should return 404 for PUT', async () => {
@@ -121,12 +121,12 @@ describe(`${basePath}/:formId/externalAPIs/:externalAPIId`, () => {
 
     await appRequest.delete(path);
 
-    expect(validateParameter.validateFormId).toBeCalledTimes(1);
-    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(1);
     expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(controller.deleteExternalAPI).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
   });
 
   it('should return 404 for GET', async () => {
@@ -148,12 +148,12 @@ describe(`${basePath}/:formId/externalAPIs/:externalAPIId`, () => {
 
     await appRequest.put(path);
 
-    expect(validateParameter.validateFormId).toBeCalledTimes(1);
-    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(1);
     expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(controller.updateExternalAPI).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
   });
 });
 
@@ -215,12 +215,12 @@ describe(`${basePath}/:formId/externalAPIs/statusCodes`, () => {
 
     await appRequest.get(path);
 
-    expect(validateParameter.validateFormId).toBeCalledTimes(1);
-    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
     expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(controller.listExternalAPIStatusCodes).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
   });
 
   it('should return 404 for POST', async () => {

--- a/app/tests/unit/forms/form/routes.spec.js
+++ b/app/tests/unit/forms/form/routes.spec.js
@@ -15,18 +15,18 @@ const controller = require('../../../../src/forms/form/controller');
 // correctly, not the functionality of the middleware.
 //
 
-jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
-});
-
 jest.mock('../../../../src/forms/auth/middleware/apiAccess');
 apiAccess.mockImplementation(
   jest.fn((_req, _res, next) => {
     next();
   })
 );
+
+jwtService.protect = jest.fn(() => {
+  return jest.fn((_req, _res, next) => {
+    next();
+  });
+});
 
 rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
   next();
@@ -78,14 +78,14 @@ describe(`${basePath}`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.listForms).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(0);
-    expect(controller.listForms).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for POST', async () => {
@@ -95,14 +95,14 @@ describe(`${basePath}`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.createForm).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(0);
-    expect(controller.createForm).toBeCalledTimes(1);
   });
 });
 
@@ -117,14 +117,14 @@ describe(`${basePath}/:formId`, () => {
 
     await appRequest.delete(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.deleteForm).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.deleteForm).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
@@ -134,14 +134,14 @@ describe(`${basePath}/:formId`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.readForm).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readForm).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
@@ -151,14 +151,14 @@ describe(`${basePath}/:formId`, () => {
 
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.updateForm).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.updateForm).toBeCalledTimes(1);
   });
 });
 
@@ -173,14 +173,14 @@ describe(`${basePath}/:formId/apiKey`, () => {
 
     await appRequest.delete(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.deleteApiKey).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.deleteApiKey).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
@@ -190,14 +190,14 @@ describe(`${basePath}/:formId/apiKey`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.readApiKey).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readApiKey).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
@@ -207,14 +207,14 @@ describe(`${basePath}/:formId/apiKey`, () => {
 
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.createOrReplaceApiKey).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.createOrReplaceApiKey).toBeCalledTimes(1);
   });
 });
 
@@ -229,14 +229,14 @@ describe(`${basePath}/:formId/apiKey/filesApiAccess`, () => {
 
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.filesApiKeyAccess).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.filesApiKeyAccess).toBeCalledTimes(1);
   });
 });
 
@@ -251,14 +251,14 @@ describe(`${basePath}/:formId/csvexport/fields`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.readFieldsForCSVExport).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readFieldsForCSVExport).toBeCalledTimes(1);
   });
 });
 
@@ -273,14 +273,14 @@ describe(`${basePath}/:formId/documentTemplates`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.documentTemplateList).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.documentTemplateList).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for POST', async () => {
@@ -290,14 +290,14 @@ describe(`${basePath}/:formId/documentTemplates`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.documentTemplateCreate).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.documentTemplateCreate).toBeCalledTimes(1);
   });
 });
 
@@ -313,14 +313,14 @@ describe(`${basePath}/:formId/documentTemplates/:documentTemplateId`, () => {
 
     await appRequest.delete(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.documentTemplateDelete).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.documentTemplateDelete).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
@@ -330,14 +330,14 @@ describe(`${basePath}/:formId/documentTemplates/:documentTemplateId`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.documentTemplateRead).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.documentTemplateRead).toBeCalledTimes(1);
   });
 });
 
@@ -352,14 +352,14 @@ describe(`${basePath}/:formId/drafts`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.listDrafts).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.listDrafts).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for POST', async () => {
@@ -369,14 +369,14 @@ describe(`${basePath}/:formId/drafts`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.createDraft).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.createDraft).toBeCalledTimes(1);
   });
 });
 
@@ -392,14 +392,14 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId`, () => {
 
     await appRequest.delete(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.deleteDraft).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.deleteDraft).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
@@ -409,14 +409,14 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.readDraft).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readDraft).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
@@ -426,14 +426,14 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId`, () => {
 
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.updateDraft).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.updateDraft).toBeCalledTimes(1);
   });
 });
 
@@ -449,14 +449,14 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId/publish`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.publishDraft).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.publishDraft).toBeCalledTimes(1);
   });
 });
 
@@ -471,14 +471,14 @@ describe(`${basePath}/:formId/emailTemplate`, () => {
 
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.createOrUpdateEmailTemplate).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.createOrUpdateEmailTemplate).toBeCalledTimes(1);
   });
 });
 
@@ -493,14 +493,14 @@ describe(`${basePath}/:formId/emailTemplates`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.readEmailTemplates).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readEmailTemplates).toBeCalledTimes(1);
   });
 });
 
@@ -515,14 +515,14 @@ describe(`${basePath}/:formId/export`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.export).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.export).toBeCalledTimes(1);
   });
 });
 
@@ -537,14 +537,14 @@ describe(`${basePath}/:formId/export/fields`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.exportWithFields).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.exportWithFields).toBeCalledTimes(1);
   });
 });
 
@@ -559,14 +559,14 @@ describe(`${basePath}/:formId/options`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.readFormOptions).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(0);
-    expect(controller.readFormOptions).toBeCalledTimes(1);
   });
 });
 
@@ -581,14 +581,14 @@ describe(`${basePath}/:formId/statusCodes`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.getStatusCodes).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.getStatusCodes).toBeCalledTimes(1);
   });
 });
 
@@ -603,14 +603,14 @@ describe(`${basePath}/:formId/submissions`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.listFormSubmissions).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.listFormSubmissions).toBeCalledTimes(1);
   });
 });
 
@@ -625,14 +625,14 @@ describe(`${basePath}/:formId/subscriptions`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.readFormSubscriptionDetails).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readFormSubscriptionDetails).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
@@ -642,14 +642,14 @@ describe(`${basePath}/:formId/subscriptions`, () => {
 
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.createOrUpdateSubscriptionDetails).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.createOrUpdateSubscriptionDetails).toBeCalledTimes(1);
   });
 });
 
@@ -664,14 +664,14 @@ describe(`${basePath}/:formId/version`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.readPublishedForm).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readPublishedForm).toBeCalledTimes(1);
   });
 });
 
@@ -687,14 +687,14 @@ describe(`${basePath}/:formId/versions/:formVersionId`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.readVersion).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readVersion).toBeCalledTimes(1);
   });
 });
 
@@ -710,14 +710,14 @@ describe(`${basePath}/:formId/versions/:formVersionId/fields`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.readVersionFields).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.readVersionFields).toBeCalledTimes(1);
   });
 });
 
@@ -733,14 +733,14 @@ describe(`${basePath}/:formId/versions/:formVersionId/multiSubmission`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.createMultiSubmission).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.createMultiSubmission).toBeCalledTimes(1);
   });
 });
 
@@ -756,14 +756,14 @@ describe(`${basePath}/:formId/versions/:formVersionId/publish`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.publishVersion).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.publishVersion).toBeCalledTimes(1);
   });
 });
 
@@ -779,14 +779,14 @@ describe(`${basePath}/:formId/versions/:formVersionId/submissions`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.listSubmissions).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.listSubmissions).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for POST', async () => {
@@ -796,14 +796,14 @@ describe(`${basePath}/:formId/versions/:formVersionId/submissions`, () => {
 
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.createSubmission).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.createSubmission).toBeCalledTimes(1);
   });
 });
 
@@ -819,14 +819,14 @@ describe(`${basePath}/:formId/versions/:formVersionId/submissions/discover`, () 
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.listSubmissionFields).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasFormPermissionsMock).toBeCalledTimes(1);
-    expect(controller.listSubmissionFields).toBeCalledTimes(1);
   });
 });
 
@@ -841,14 +841,14 @@ describe(`${basePath}/formcomponents/proactivehelp/imageUrl/:componentId`, () =>
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.getFCProactiveHelpImageUrl).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(0);
-    expect(controller.getFCProactiveHelpImageUrl).toBeCalledTimes(1);
   });
 });
 
@@ -862,13 +862,13 @@ describe(`${basePath}/formcomponents/proactivehelp/list`, () => {
 
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.listFormComponentsProactiveHelp).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
     expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasFormPermissionsMock).toBeCalledTimes(0);
-    expect(controller.listFormComponentsProactiveHelp).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/forms/proxy/routes.spec.js
+++ b/app/tests/unit/forms/proxy/routes.spec.js
@@ -8,25 +8,18 @@ jest.mock('cors', () =>
 
 const request = require('supertest');
 const Problem = require('api-problem');
+
 const { expressHelper } = require('../../../common/helper');
+
+const jwtService = require('../../../../src/components/jwtService');
 const apiAccess = require('../../../../src/forms/auth/middleware/apiAccess');
-const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
 const rateLimiter = require('../../../../src/forms/common/middleware/rateLimiter');
+const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
 
 //
 // Mock out all the middleware - we're testing that the routes are set up
 // correctly, not the functionality of the middleware.
 //
-const jwtService = require('../../../../src/components/jwtService');
-
-//
-// test assumes that caller has appropriate token, we are not testing middleware here...
-//
-jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
-});
 
 jest.mock('../../../../src/forms/auth/middleware/apiAccess');
 apiAccess.mockImplementation(
@@ -34,6 +27,12 @@ apiAccess.mockImplementation(
     next();
   })
 );
+
+jwtService.protect = jest.fn(() => {
+  return jest.fn((_req, _res, next) => {
+    next();
+  });
+});
 
 rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
   next();

--- a/app/tests/unit/forms/rbac/routes.spec.js
+++ b/app/tests/unit/forms/rbac/routes.spec.js
@@ -1,0 +1,246 @@
+const request = require('supertest');
+
+const { expressHelper } = require('../../../common/helper');
+
+const jwtService = require('../../../../src/components/jwtService');
+const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
+const controller = require('../../../../src/forms/rbac/controller');
+
+//
+// Mock out all the middleware - we're testing that the routes are set up
+// correctly, not the functionality of the middleware.
+//
+
+jwtService.protect = jest.fn(() => {
+  return jest.fn((_req, _res, next) => {
+    next();
+  });
+});
+
+const hasFormPermissionsMock = jest.fn((_req, _res, next) => {
+  next();
+});
+const hasFormRolesMock = jest.fn((_req, _res, next) => {
+  next();
+});
+const hasSubmissionPermissionsMock = jest.fn((_req, _res, next) => {
+  next();
+});
+userAccess.currentUser = jest.fn((_req, _res, next) => {
+  next();
+});
+userAccess.filterMultipleSubmissions = jest.fn((_req, _res, next) => {
+  next();
+});
+userAccess.hasFormPermissions = jest.fn(() => {
+  return hasFormPermissionsMock;
+});
+userAccess.hasFormRoles = jest.fn(() => {
+  return hasFormRolesMock;
+});
+userAccess.hasRoleDeletePermissions = jest.fn((_req, _res, next) => {
+  next();
+});
+userAccess.hasRoleModifyPermissions = jest.fn((_req, _res, next) => {
+  next();
+});
+userAccess.hasSubmissionPermissions = jest.fn(() => {
+  return hasSubmissionPermissionsMock;
+});
+
+//
+// Create the router and a simple Express server.
+//
+
+const router = require('../../../../src/forms/rbac/routes');
+const basePath = '/rbac';
+const app = expressHelper(basePath, router);
+const appRequest = request(app);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe(`${basePath}/current`, () => {
+  const path = `${basePath}/current`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.getCurrentUser = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.getCurrentUser).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+});
+
+describe(`${basePath}/current/submissions`, () => {
+  const path = `${basePath}/current/submissions`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.getCurrentUserSubmissions = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.getCurrentUserSubmissions).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+});
+
+describe(`${basePath}/forms`, () => {
+  const path = `${basePath}/forms`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.getFormUsers = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.getFormUsers).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    controller.setFormUsers = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.put(path);
+
+    expect(controller.setFormUsers).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+});
+
+describe(`${basePath}/idps`, () => {
+  const path = `${basePath}/idps`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.getIdentityProviders = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.getIdentityProviders).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+});
+
+describe(`${basePath}/submissions`, () => {
+  const path = `${basePath}/submissions`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.getSubmissionUsers = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.getSubmissionUsers).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    controller.setSubmissionUserPermissions = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.put(path);
+
+    expect(controller.setSubmissionUserPermissions).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+});
+
+describe(`${basePath}/users`, () => {
+  const path = `${basePath}/users`;
+
+  it('should have correct middleware for DELETE', async () => {
+    controller.removeMultiUsers = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.delete(path);
+
+    expect(controller.removeMultiUsers).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(hasFormRolesMock).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(1);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+
+  it('should have correct middleware for GET', async () => {
+    controller.getUserForms = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.getUserForms).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    controller.setUserForms = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.put(path);
+
+    expect(controller.setUserForms).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(hasFormRolesMock).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(1);
+  });
+});

--- a/app/tests/unit/forms/submission/routes.spec.js
+++ b/app/tests/unit/forms/submission/routes.spec.js
@@ -3,6 +3,7 @@ const uuid = require('uuid');
 
 const { expressHelper } = require('../../../common/helper');
 
+const jwtService = require('../../../../src/components/jwtService');
 const apiAccess = require('../../../../src/forms/auth/middleware/apiAccess');
 const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
 const rateLimiter = require('../../../../src/forms/common/middleware/rateLimiter');
@@ -13,16 +14,6 @@ const controller = require('../../../../src/forms/submission/controller');
 // Mock out all the middleware - we're testing that the routes are set up
 // correctly, not the functionality of the middleware.
 //
-const jwtService = require('../../../../src/components/jwtService');
-
-//
-// test assumes that caller has appropriate token, we are not testing middleware here...
-//
-jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
-});
 
 jest.mock('../../../../src/forms/auth/middleware/apiAccess');
 apiAccess.mockImplementation(
@@ -31,50 +22,10 @@ apiAccess.mockImplementation(
   })
 );
 
-controller.addNote = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.addStatus = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.delete = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.deleteMultipleSubmissions = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.email = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.getNotes = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.getStatus = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.listEdits = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.read = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.readOptions = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.restore = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.restoreMultipleSubmissions = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.templateRender = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.templateUploadAndRender = jest.fn((_req, _res, next) => {
-  next();
-});
-controller.update = jest.fn((_req, _res, next) => {
-  next();
+jwtService.protect = jest.fn(() => {
+  return jest.fn((_req, _res, next) => {
+    next();
+  });
 });
 
 rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
@@ -84,7 +35,6 @@ rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
 const hasSubmissionPermissionsMock = jest.fn((_req, _res, next) => {
   next();
 });
-
 userAccess.currentUser = jest.fn((_req, _res, next) => {
   next();
 });
@@ -105,10 +55,6 @@ validateParameter.validateFormSubmissionId = jest.fn((_req, _res, next) => {
   next();
 });
 
-const documentTemplateId = uuid.v4();
-const formId = uuid.v4();
-const formSubmissionId = uuid.v4();
-
 //
 // Create the router and a simple Express server.
 //
@@ -123,255 +69,329 @@ afterEach(() => {
 });
 
 describe(`${basePath}/:formSubmissionId`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}`;
 
   it('should have correct middleware for DELETE', async () => {
+    controller.delete = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.delete(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.delete).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.delete).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
+    controller.read = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.read).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.read).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
+    controller.update = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.update).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.update).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/:formId/submissions`, () => {
+  const formId = uuid.v4();
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/${formId}/submissions`;
 
   it('should have correct middleware for DELETE', async () => {
+    controller.deleteMultipleSubmissions = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.delete(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.deleteMultipleSubmissions).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(1);
-    expect(controller.deleteMultipleSubmissions).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/:formId/submissions/restore`, () => {
+  const formId = uuid.v4();
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/${formId}/submissions/restore`;
 
   it('should have correct middleware for PUT', async () => {
+    controller.restoreMultipleSubmissions = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.restoreMultipleSubmissions).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(1);
-    expect(controller.restoreMultipleSubmissions).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/edits`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/edits`;
 
   it('should have correct middleware for GET', async () => {
+    controller.listEdits = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.listEdits).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.listEdits).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/email`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/email`;
 
   it('should have correct middleware for POST', async () => {
+    controller.email = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.email).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.email).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/notes`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/notes`;
 
   it('should have correct middleware for GET', async () => {
+    controller.getNotes = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.getNotes).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.getNotes).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for POST', async () => {
+    controller.addNote = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.addNote).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.addNote).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/options`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/options`;
 
   it('should have correct middleware for GET', async () => {
+    controller.readOptions = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.readOptions).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.readOptions).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/restore`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/restore`;
 
   it('should have correct middleware for PUT', async () => {
+    controller.restore = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.put(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.restore).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.restore).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/status`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/status`;
 
   it('should have correct middleware for GET', async () => {
+    controller.getStatus = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.getStatus).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.getStatus).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for POST', async () => {
+    controller.addStatus = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(0);
+    expect(controller.addStatus).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(0);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.addStatus).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/template/:documentTemplateId/render`, () => {
+  const documentTemplateId = uuid.v4();
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/template/${documentTemplateId}/render`;
 
   it('should have correct middleware for GET', async () => {
+    controller.templateRender = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.templateRender).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.templateRender).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:formSubmissionId/template/render`, () => {
+  const formSubmissionId = uuid.v4();
   const path = `${basePath}/${formSubmissionId}/template/render`;
 
   it('should have correct middleware for POST', async () => {
+    controller.templateUploadAndRender = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.post(path);
 
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.templateUploadAndRender).toBeCalledTimes(1);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateFormSubmissionId).toBeCalledTimes(1);
-    expect(apiAccess).toBeCalledTimes(1);
-    expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
-    expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
-    expect(userAccess.filterMultipleSubmissions).toBeCalledTimes(0);
-    expect(controller.templateUploadAndRender).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/forms/user/routes.spec.js
+++ b/app/tests/unit/forms/user/routes.spec.js
@@ -30,42 +30,6 @@ validateParameter.validateUserId = jest.fn((_req, _res, next) => {
   next();
 });
 
-// Mock the controller functions with happy path results.
-
-controller.deleteUserFormPreferences = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.deleteUserPreferences = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.list = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.read = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.readUserFormPreferences = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.readUserLabels = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.readUserPreferences = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.updateUserFormPreferences = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.updateUserLabels = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-controller.updateUserPreferences = jest.fn((_req, res) => {
-  res.sendStatus(200);
-});
-
-const formId = uuid.v4();
-const userId = uuid.v4();
-
 //
 // Create the router and a simple Express server.
 //
@@ -83,23 +47,32 @@ describe(`${basePath}`, () => {
   const path = `${basePath}`;
 
   it('should have correct middleware for GET', async () => {
+    controller.list = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(controller.list).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.list).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/:userId`, () => {
+  const userId = uuid.v4();
   const path = `${basePath}/${userId}`;
 
   it('should have correct middleware for GET', async () => {
+    controller.read = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(controller.read).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(1);
-    expect(controller.read).toBeCalledTimes(1);
   });
 });
 
@@ -107,19 +80,27 @@ describe(`${basePath}/labels`, () => {
   const path = `${basePath}/labels`;
 
   it('should have correct middleware for GET', async () => {
+    controller.readUserLabels = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(controller.readUserLabels).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.readUserLabels).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
+    controller.updateUserLabels = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.put(path);
 
+    expect(controller.updateUserLabels).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.updateUserLabels).toBeCalledTimes(1);
   });
 });
 
@@ -127,54 +108,79 @@ describe(`${basePath}/preferences`, () => {
   const path = `${basePath}/preferences`;
 
   it('should have correct middleware for DELETE', async () => {
+    controller.deleteUserPreferences = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.delete(path);
 
+    expect(controller.deleteUserPreferences).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.deleteUserPreferences).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
+    controller.readUserPreferences = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(controller.readUserPreferences).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.readUserPreferences).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
+    controller.updateUserPreferences = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.put(path);
 
+    expect(controller.updateUserPreferences).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.updateUserPreferences).toBeCalledTimes(1);
   });
 });
 
 describe(`${basePath}/preferences/forms/:formId`, () => {
+  const formId = uuid.v4();
   const path = `${basePath}/preferences/forms/${formId}`;
 
   it('should have correct middleware for DELETE', async () => {
+    controller.deleteUserFormPreferences = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.delete(path);
 
+    expect(controller.deleteUserFormPreferences).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.deleteUserFormPreferences).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for GET', async () => {
+    controller.readUserFormPreferences = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.get(path);
 
+    expect(controller.readUserFormPreferences).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.readUserFormPreferences).toBeCalledTimes(1);
   });
 
   it('should have correct middleware for PUT', async () => {
+    controller.updateUserFormPreferences = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
     await appRequest.put(path);
 
+    expect(controller.updateUserFormPreferences).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
-    expect(controller.updateUserFormPreferences).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
# Description

Added unit tests for all the routes in `rbac/routes.js`. This is a first step before converting the existing routes tests (which test the controllers, not the routes) into controller tests.

## Types of changes

test (add missing tests or correct existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

Also did some more cleanup:
- for consistency alphabetize imports by module location / name
- for consistency alphabetize the per-file mocks
- for consistency alphabetize the expect clauses
- for consistency use `toBeCalledTimes` not `toHaveBeenCalledTimes`
- for consistency move controller mocks into their specific tests
- for consistency define uuids in their test groups