### PR TITLE
test: FORMS-1448 expand jwt service tests

### DIFF
--- a/app/tests/unit/README.md
+++ b/app/tests/unit/README.md
@@ -1,6 +1,6 @@
 # Unit Tests
 
-The backend unit tests can be run in VSCode by going to `Terminal` -> `Run Task...` -> `Unit Tests - API`.
+The backend unit tests are run in VSCode by going to `Terminal` -> `Run Task...` -> `Unit Tests - API`. Once the tests complete, the backend code coverage report is in `/app/coverage/lcov-report/index.html`.
 
 ## Running on the Command Line
 
@@ -84,5 +84,6 @@ The tests for the `route.js` files should:
 
 Note:
 
-- Some middleware is called when the `routes.js` is loaded, not when the route is called. For example, the parameters to `userAccess.hasFormPermissions` cannot be tested by calling the route using it. Even if we reload the `routes.js` for each route test, it would be hard to tell which call to `hasFormPermissions` was the call for the route under test
+- The order that middleware is called is very important, but we are not testing this. Perhaps integration tests are the best solution for this
+- Some middleware takes parameters and is created when a route is created. This means that, for example, the parameters to `jwtService.protect` or `userAccess.hasFormPermissions` cannot be tested by calling the route using it. Even if we reload the `routes.js` for each route test, it would be hard to tell which call to create the middleware was the call for the route under test
 - Maybe we should refactor and create a set of standard middleware mocks that live outside the `routes.spec.js` files

--- a/app/tests/unit/forms/admin/routes.spec.js
+++ b/app/tests/unit/forms/admin/routes.spec.js
@@ -13,9 +13,6 @@ const userController = require('../../../../src/forms/user/controller');
 // correctly, not the functionality of the middleware.
 //
 
-// TODO: Add a test the confirms that jwtService.protect is called with "admin"
-// when the file is loaded.
-
 const mockJwtServiceProtect = jest.fn((_req, _res, next) => {
   next();
 });
@@ -38,6 +35,25 @@ const appRequest = request(app);
 
 afterEach(() => {
   jest.clearAllMocks();
+});
+
+// jwtService.protect is tricky to test. This test is fragile as the file could
+// change and have routes that need admin and others that don't. This test only
+// works when we use(protect) at the file level, not individually in the routes.
+// However, this does test that we don't accidentally turn off the protection.
+describe('jwtService.protect', () => {
+  it('should be called with admin', () => {
+    jest.resetModules();
+    const jwtService = require('../../../../src/components/jwtService');
+    jwtService.protect = jest.fn(() => {
+      return jest.fn((_req, _res, next) => {
+        next();
+      });
+    });
+    require('../../../../src/forms/admin/routes');
+
+    expect(jwtService.protect).toBeCalledWith('admin');
+  });
 });
 
 describe(`${basePath}/externalAPIs`, () => {

--- a/app/tests/unit/forms/form/routes.spec.js
+++ b/app/tests/unit/forms/form/routes.spec.js
@@ -22,10 +22,11 @@ apiAccess.mockImplementation(
   })
 );
 
+const mockJwtServiceProtect = jest.fn((_req, _res, next) => {
+  next();
+});
 jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
+  return mockJwtServiceProtect;
 });
 
 rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
@@ -81,6 +82,7 @@ describe(`${basePath}`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.listForms).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -99,6 +101,7 @@ describe(`${basePath}`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.createForm).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -122,6 +125,7 @@ describe(`${basePath}/:formId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.deleteForm).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -140,6 +144,7 @@ describe(`${basePath}/:formId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.readForm).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -158,6 +163,7 @@ describe(`${basePath}/:formId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.updateForm).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -181,6 +187,7 @@ describe(`${basePath}/:formId/apiKey`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.deleteApiKey).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -199,6 +206,7 @@ describe(`${basePath}/:formId/apiKey`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.readApiKey).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -217,6 +225,7 @@ describe(`${basePath}/:formId/apiKey`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.createOrReplaceApiKey).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -240,6 +249,7 @@ describe(`${basePath}/:formId/apiKey/filesApiAccess`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.filesApiKeyAccess).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -263,6 +273,7 @@ describe(`${basePath}/:formId/csvexport/fields`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.readFieldsForCSVExport).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -286,6 +297,7 @@ describe(`${basePath}/:formId/documentTemplates`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.documentTemplateList).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -304,6 +316,7 @@ describe(`${basePath}/:formId/documentTemplates`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.documentTemplateCreate).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -328,6 +341,7 @@ describe(`${basePath}/:formId/documentTemplates/:documentTemplateId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.documentTemplateDelete).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(1);
@@ -346,6 +360,7 @@ describe(`${basePath}/:formId/documentTemplates/:documentTemplateId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.documentTemplateRead).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(1);
@@ -369,6 +384,7 @@ describe(`${basePath}/:formId/drafts`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.listDrafts).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -387,6 +403,7 @@ describe(`${basePath}/:formId/drafts`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.createDraft).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -411,6 +428,7 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.deleteDraft).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -429,6 +447,7 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.readDraft).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -447,6 +466,7 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.updateDraft).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -471,6 +491,7 @@ describe(`${basePath}/:formId/drafts/:formVersionDraftId/publish`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.publishDraft).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -494,6 +515,7 @@ describe(`${basePath}/:formId/emailTemplate`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.createOrUpdateEmailTemplate).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -517,6 +539,7 @@ describe(`${basePath}/:formId/emailTemplates`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.readEmailTemplates).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -540,6 +563,7 @@ describe(`${basePath}/:formId/export`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.export).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -563,6 +587,7 @@ describe(`${basePath}/:formId/export/fields`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.exportWithFields).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -586,6 +611,7 @@ describe(`${basePath}/:formId/options`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.readFormOptions).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -609,6 +635,7 @@ describe(`${basePath}/:formId/statusCodes`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.getStatusCodes).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -632,6 +659,7 @@ describe(`${basePath}/:formId/submissions`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.listFormSubmissions).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -655,6 +683,7 @@ describe(`${basePath}/:formId/subscriptions`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.readFormSubscriptionDetails).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -673,6 +702,7 @@ describe(`${basePath}/:formId/subscriptions`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.createOrUpdateSubscriptionDetails).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -696,6 +726,7 @@ describe(`${basePath}/:formId/version`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.readPublishedForm).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -720,6 +751,7 @@ describe(`${basePath}/:formId/versions/:formVersionId`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.readVersion).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -744,6 +776,7 @@ describe(`${basePath}/:formId/versions/:formVersionId/fields`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.readVersionFields).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -768,6 +801,7 @@ describe(`${basePath}/:formId/versions/:formVersionId/multiSubmission`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.createMultiSubmission).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -792,6 +826,7 @@ describe(`${basePath}/:formId/versions/:formVersionId/publish`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.publishVersion).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -816,6 +851,7 @@ describe(`${basePath}/:formId/versions/:formVersionId/submissions`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.listSubmissions).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -834,6 +870,7 @@ describe(`${basePath}/:formId/versions/:formVersionId/submissions`, () => {
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.createSubmission).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -858,6 +895,7 @@ describe(`${basePath}/:formId/versions/:formVersionId/submissions/discover`, () 
     expect(apiAccess).toBeCalledTimes(1);
     expect(controller.listSubmissionFields).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -881,6 +919,7 @@ describe(`${basePath}/formcomponents/proactivehelp/imageUrl/:componentId`, () =>
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.getFCProactiveHelpImageUrl).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);
@@ -903,6 +942,7 @@ describe(`${basePath}/formcomponents/proactivehelp/list`, () => {
     expect(apiAccess).toBeCalledTimes(0);
     expect(controller.listFormComponentsProactiveHelp).toBeCalledTimes(1);
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(rateLimiter.apiKeyRateLimiter).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateDocumentTemplateId).toBeCalledTimes(0);

--- a/app/tests/unit/forms/permission/routes.spec.js
+++ b/app/tests/unit/forms/permission/routes.spec.js
@@ -1,0 +1,111 @@
+const request = require('supertest');
+
+const { expressHelper } = require('../../../common/helper');
+
+const jwtService = require('../../../../src/components/jwtService');
+const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
+const controller = require('../../../../src/forms/permission/controller');
+
+//
+// Mock out all the middleware - we're testing that the routes are set up
+// correctly, not the functionality of the middleware.
+//
+
+const mockJwtServiceProtect = jest.fn((_req, _res, next) => {
+  next();
+});
+jwtService.protect = jest.fn(() => {
+  return mockJwtServiceProtect;
+});
+
+userAccess.currentUser = jest.fn((_req, _res, next) => {
+  next();
+});
+
+//
+// Create the router and a simple Express server.
+//
+
+const router = require('../../../../src/forms/permission/routes');
+const basePath = '/permission';
+const app = expressHelper(basePath, router);
+const appRequest = request(app);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+// jwtService.protect is tricky to test. This test is fragile as the file could
+// change and have routes that need admin and others that don't. This test only
+// works when we use(protect) at the file level, not individually in the routes.
+// However, this does test that we don't accidentally turn off the protection.
+describe('jwtService.protect', () => {
+  it('should be called with admin', () => {
+    jest.resetModules();
+    const jwtService = require('../../../../src/components/jwtService');
+    jwtService.protect = jest.fn(() => {
+      return jest.fn((_req, _res, next) => {
+        next();
+      });
+    });
+    require('../../../../src/forms/permission/routes');
+
+    expect(jwtService.protect).toBeCalledWith('admin');
+  });
+});
+
+describe(`${basePath}`, () => {
+  const path = `${basePath}`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.list = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.list).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for POST', async () => {
+    controller.create = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.post(path);
+
+    expect(controller.create).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+});
+
+describe(`${basePath}/:code`, () => {
+  const path = `${basePath}/code`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.read = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.read).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    controller.update = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.put(path);
+
+    expect(controller.update).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+});

--- a/app/tests/unit/forms/proxy/routes.spec.js
+++ b/app/tests/unit/forms/proxy/routes.spec.js
@@ -11,7 +11,6 @@ const request = require('supertest');
 
 const { expressHelper } = require('../../../common/helper');
 
-const jwtService = require('../../../../src/components/jwtService');
 const apiAccess = require('../../../../src/forms/auth/middleware/apiAccess');
 const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
 const rateLimiter = require('../../../../src/forms/common/middleware/rateLimiter');
@@ -27,12 +26,6 @@ apiAccess.mockImplementation(
     next();
   })
 );
-
-jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
-});
 
 rateLimiter.apiKeyRateLimiter = jest.fn((_req, _res, next) => {
   next();

--- a/app/tests/unit/forms/rbac/routes.spec.js
+++ b/app/tests/unit/forms/rbac/routes.spec.js
@@ -11,10 +11,11 @@ const controller = require('../../../../src/forms/rbac/controller');
 // correctly, not the functionality of the middleware.
 //
 
+const mockJwtServiceProtect = jest.fn((_req, _res, next) => {
+  next();
+});
 jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
+  return mockJwtServiceProtect;
 });
 
 const hasFormPermissionsMock = jest.fn((_req, _res, next) => {
@@ -75,6 +76,7 @@ describe(`${basePath}/current`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -95,6 +97,7 @@ describe(`${basePath}/current/submissions`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -115,6 +118,7 @@ describe(`${basePath}/forms`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -131,6 +135,7 @@ describe(`${basePath}/forms`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -151,6 +156,7 @@ describe(`${basePath}/idps`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -171,6 +177,7 @@ describe(`${basePath}/submissions`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -187,6 +194,7 @@ describe(`${basePath}/submissions`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -207,6 +215,7 @@ describe(`${basePath}/users`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(hasFormRolesMock).toBeCalledTimes(1);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(1);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -223,6 +232,7 @@ describe(`${basePath}/users`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(0);
     expect(hasFormRolesMock).toBeCalledTimes(0);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
@@ -239,6 +249,7 @@ describe(`${basePath}/users`, () => {
     expect(hasFormPermissionsMock).toBeCalledTimes(1);
     expect(hasFormRolesMock).toBeCalledTimes(1);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
     expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(1);

--- a/app/tests/unit/forms/role/routes.spec.js
+++ b/app/tests/unit/forms/role/routes.spec.js
@@ -1,0 +1,111 @@
+const request = require('supertest');
+
+const { expressHelper } = require('../../../common/helper');
+
+const jwtService = require('../../../../src/components/jwtService');
+const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
+const controller = require('../../../../src/forms/role/controller');
+
+//
+// Mock out all the middleware - we're testing that the routes are set up
+// correctly, not the functionality of the middleware.
+//
+
+const mockJwtServiceProtect = jest.fn((_req, _res, next) => {
+  next();
+});
+jwtService.protect = jest.fn(() => {
+  return mockJwtServiceProtect;
+});
+
+userAccess.currentUser = jest.fn((_req, _res, next) => {
+  next();
+});
+
+//
+// Create the router and a simple Express server.
+//
+
+const router = require('../../../../src/forms/role/routes');
+const basePath = '/role';
+const app = expressHelper(basePath, router);
+const appRequest = request(app);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+// jwtService.protect is tricky to test. This test is fragile as the file could
+// change and have routes that need admin and others that don't. This test only
+// works when we use(protect) at the file level, not individually in the routes.
+// However, this does test that we don't accidentally turn off the protection.
+describe('jwtService.protect', () => {
+  it('should be called with admin', () => {
+    jest.resetModules();
+    const jwtService = require('../../../../src/components/jwtService');
+    jwtService.protect = jest.fn(() => {
+      return jest.fn((_req, _res, next) => {
+        next();
+      });
+    });
+    require('../../../../src/forms/role/routes');
+
+    expect(jwtService.protect).toBeCalledWith('admin');
+  });
+});
+
+describe(`${basePath}`, () => {
+  const path = `${basePath}`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.list = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.list).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for POST', async () => {
+    controller.create = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.post(path);
+
+    expect(controller.create).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+});
+
+describe(`${basePath}/:code`, () => {
+  const path = `${basePath}/code`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.read = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.read).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+
+  it('should have correct middleware for PUT', async () => {
+    controller.update = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.put(path);
+
+    expect(controller.update).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+  });
+});

--- a/app/tests/unit/forms/user/routes.spec.js
+++ b/app/tests/unit/forms/user/routes.spec.js
@@ -13,10 +13,11 @@ const controller = require('../../../../src/forms/user/controller');
 // correctly, not the functionality of the middleware.
 //
 
+const mockJwtServiceProtect = jest.fn((_req, _res, next) => {
+  next();
+});
 jwtService.protect = jest.fn(() => {
-  return jest.fn((_req, _res, next) => {
-    next();
-  });
+  return mockJwtServiceProtect;
 });
 
 userAccess.currentUser = jest.fn((_req, _res, next) => {
@@ -43,6 +44,25 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+// jwtService.protect is tricky to test. This test is fragile as the file could
+// change and have routes that need admin and others that don't. This test only
+// works when we use(protect) at the file level, not individually in the routes.
+// However, this does test that we don't accidentally turn off the protection.
+describe('jwtService.protect', () => {
+  it('should be called with no argument', () => {
+    jest.resetModules();
+    const jwtService = require('../../../../src/components/jwtService');
+    jwtService.protect = jest.fn(() => {
+      return jest.fn((_req, _res, next) => {
+        next();
+      });
+    });
+    require('../../../../src/forms/user/routes');
+
+    expect(jwtService.protect).toBeCalledWith();
+  });
+});
+
 describe(`${basePath}`, () => {
   const path = `${basePath}`;
 
@@ -54,6 +74,7 @@ describe(`${basePath}`, () => {
     await appRequest.get(path);
 
     expect(controller.list).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -72,6 +93,7 @@ describe(`${basePath}/:userId`, () => {
     await appRequest.get(path);
 
     expect(controller.read).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(1);
@@ -89,6 +111,7 @@ describe(`${basePath}/labels`, () => {
     await appRequest.get(path);
 
     expect(controller.readUserLabels).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -102,6 +125,7 @@ describe(`${basePath}/labels`, () => {
     await appRequest.put(path);
 
     expect(controller.updateUserLabels).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -119,6 +143,7 @@ describe(`${basePath}/preferences`, () => {
     await appRequest.delete(path);
 
     expect(controller.deleteUserPreferences).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -132,6 +157,7 @@ describe(`${basePath}/preferences`, () => {
     await appRequest.get(path);
 
     expect(controller.readUserPreferences).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -145,6 +171,7 @@ describe(`${basePath}/preferences`, () => {
     await appRequest.put(path);
 
     expect(controller.updateUserPreferences).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(0);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -163,6 +190,7 @@ describe(`${basePath}/preferences/forms/:formId`, () => {
     await appRequest.delete(path);
 
     expect(controller.deleteUserFormPreferences).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -176,6 +204,7 @@ describe(`${basePath}/preferences/forms/:formId`, () => {
     await appRequest.get(path);
 
     expect(controller.readUserFormPreferences).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);
@@ -189,6 +218,7 @@ describe(`${basePath}/preferences/forms/:formId`, () => {
     await appRequest.put(path);
 
     expect(controller.updateUserFormPreferences).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(validateParameter.validateFormId).toBeCalledTimes(1);
     expect(validateParameter.validateUserId).toBeCalledTimes(0);


### PR DESCRIPTION
# Description

Enhanced and expanded the `jwtService.protect()` tests to be a little more strict about what is being tested.

> Note: this middleware is tricky to test. In some cases it is used at the file level, and in other cases it's used on a per-route basis. We can write some tests for these, but they're going to break if the routes change how they use the middleware. Also, due to the nature of middleware that is created with parameters, it's hard / impossible to robustly test those parameters.

## Types of changes

test (add missing tests or correct existing tests)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

This is the first of a few PRs for this task, but keeping them small and doing the tests first before refactoring.