### PR TITLE
fix: FORMS-1448 validate admin route parameters

### DIFF
--- a/app/src/forms/admin/controller.js
+++ b/app/src/forms/admin/controller.js
@@ -100,7 +100,7 @@ module.exports = {
   },
   updateExternalAPI: async (req, res, next) => {
     try {
-      const response = await service.updateExternalAPI(req.params.id, req.body);
+      const response = await service.updateExternalAPI(req.params.externalApiId, req.body);
       res.status(200).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/admin/routes.js
+++ b/app/src/forms/admin/routes.js
@@ -1,22 +1,28 @@
 const routes = require('express').Router();
 
-const currentUser = require('../auth/middleware/userAccess').currentUser;
-
-const controller = require('./controller');
-const userController = require('../user/controller');
 const jwtService = require('../../components/jwtService');
+const currentUser = require('../auth/middleware/userAccess').currentUser;
+const validateParameter = require('../common/middleware/validateParameter');
+const userController = require('../user/controller');
+const controller = require('./controller');
 
-// Always have this applied to all routes here
+// Routes under /admin fetch data without doing form permission checks. All
+// routes in this file should remain under the "admin" role check, with the
+// "admin" role only given to people who have permission to read all data.
 routes.use(jwtService.protect('admin'));
+
 routes.use(currentUser);
 
-// Routes under the /admin pathing will fetch data without doing Form permission checks in the database
-// As such, this should ALWAYS remain under the :admin role check and that KC role should not be given out
-// other than to people who have permission to read all data
+routes.param('componentId', validateParameter.validateComponentId);
+routes.param('externalApiId', validateParameter.validateExternalAPIId);
+routes.param('formId', validateParameter.validateFormId);
+routes.param('formVersionId', validateParameter.validateFormVersionId);
+routes.param('userId', validateParameter.validateUserId);
 
 //
 // Forms
 //
+
 routes.get('/forms', async (req, res, next) => {
   await controller.listForms(req, res, next);
 });
@@ -52,6 +58,7 @@ routes.put('/forms/:formId/addUser', async (req, res, next) => {
 //
 // Users
 //
+
 routes.get('/users', async (req, res, next) => {
   await controller.getUsers(req, res, next);
 });
@@ -61,21 +68,23 @@ routes.get('/users/:userId', async (req, res, next) => {
 });
 
 //
-// APIs
+// External APIs
 //
+
 routes.get('/externalAPIs', async (req, res, next) => {
   await controller.getExternalAPIs(req, res, next);
 });
 
-routes.put('/externalAPIs/:id', async (req, res, next) => {
+routes.put('/externalAPIs/:externalApiId', async (req, res, next) => {
   await controller.updateExternalAPI(req, res, next);
 });
 
 routes.get('/externalAPIs/statusCodes', async (req, res, next) => {
   await controller.getExternalAPIStatusCodes(req, res, next);
 });
+
 //
-//Form componets help info
+// Form Components Help
 //
 
 routes.post('/formcomponents/proactivehelp/object', async (req, res, next) => {

--- a/app/src/forms/common/middleware/validateParameter.js
+++ b/app/src/forms/common/middleware/validateParameter.js
@@ -21,6 +21,24 @@ const _validateUuid = (parameter, parameterName) => {
 };
 
 /**
+ * Validates that the :componentId route parameter exists and is a UUID.
+ *
+ * @param {*} _req the Express object representing the HTTP request - unused.
+ * @param {*} _res the Express object representing the HTTP response - unused.
+ * @param {*} next the Express chaining function.
+ * @param {*} componentId the :componentId value from the route.
+ */
+const validateComponentId = async (_req, _res, next, componentId) => {
+  try {
+    _validateUuid(componentId, 'componentId');
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
  * Validates that the :documentTemplateId route parameter exists and is a UUID.
  * This validator requires that either the :formId or :formSubmissionId route
  * parameter also exists.
@@ -211,6 +229,7 @@ const validateUserId = async (_req, _res, next, userId) => {
 };
 
 module.exports = {
+  validateComponentId,
   validateDocumentTemplateId,
   validateExternalAPIId,
   validateFileId,

--- a/app/tests/unit/forms/admin/routes.spec.js
+++ b/app/tests/unit/forms/admin/routes.spec.js
@@ -6,6 +6,7 @@ const { expressHelper } = require('../../../common/helper');
 const jwtService = require('../../../../src/components/jwtService');
 const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
 const controller = require('../../../../src/forms/admin/controller');
+const validateParameter = require('../../../../src/forms/common/middleware/validateParameter');
 const userController = require('../../../../src/forms/user/controller');
 
 //
@@ -21,6 +22,22 @@ jwtService.protect = jest.fn(() => {
 });
 
 userAccess.currentUser = jest.fn((_req, _res, next) => {
+  next();
+});
+
+validateParameter.validateComponentId = jest.fn((_req, _res, next) => {
+  next();
+});
+validateParameter.validateExternalAPIId = jest.fn((_req, _res, next) => {
+  next();
+});
+validateParameter.validateFormId = jest.fn((_req, _res, next) => {
+  next();
+});
+validateParameter.validateFormVersionId = jest.fn((_req, _res, next) => {
+  next();
+});
+validateParameter.validateUserId = jest.fn((_req, _res, next) => {
   next();
 });
 
@@ -69,6 +86,11 @@ describe(`${basePath}/externalAPIs`, () => {
     expect(controller.getExternalAPIs).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -86,6 +108,11 @@ describe(`${basePath}/externalAPIs/:externalApiId`, () => {
     expect(controller.updateExternalAPI).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -102,6 +129,11 @@ describe(`${basePath}/externalAPIs/statusCodes`, () => {
     expect(controller.getExternalAPIStatusCodes).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -119,6 +151,11 @@ describe(`${basePath}/formcomponents/proactivehelp/:publishStatus/:componentId`,
     expect(controller.updateFormComponentsProactiveHelp).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(1);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -136,6 +173,11 @@ describe(`${basePath}/formcomponents/proactivehelp/imageUrl/:componentId`, () =>
     expect(controller.getFCProactiveHelpImageUrl).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(1);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -152,6 +194,11 @@ describe(`${basePath}/formcomponents/proactivehelp/list`, () => {
     expect(controller.listFormComponentsProactiveHelp).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -168,6 +215,11 @@ describe(`${basePath}/formcomponents/proactivehelp/object`, () => {
     expect(controller.createFormComponentsProactiveHelp).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -184,6 +236,11 @@ describe(`${basePath}/forms`, () => {
     expect(controller.listForms).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -201,6 +258,11 @@ describe(`${basePath}/forms/:formId`, () => {
     expect(controller.readForm).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -218,6 +280,11 @@ describe(`${basePath}/forms/:formId/addUser`, () => {
     expect(controller.setFormUserRoles).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -235,6 +302,11 @@ describe(`${basePath}/forms/:formId/apiKey`, () => {
     expect(controller.deleteApiKey).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 
   it('should have correct middleware for GET', async () => {
@@ -247,6 +319,11 @@ describe(`${basePath}/forms/:formId/apiKey`, () => {
     expect(controller.readApiDetails).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -264,6 +341,11 @@ describe(`${basePath}/forms/:formId/formUsers`, () => {
     expect(controller.getFormUserRoles).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -281,6 +363,11 @@ describe(`${basePath}/forms/:formId/restore`, () => {
     expect(controller.restoreForm).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -299,6 +386,11 @@ describe(`${basePath}/forms/:formId/versions/:formVersionId`, () => {
     expect(controller.readVersion).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(1);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -315,6 +407,11 @@ describe(`${basePath}/users`, () => {
     expect(controller.getUsers).toBeCalledTimes(1);
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(0);
   });
 });
 
@@ -332,5 +429,10 @@ describe(`${basePath}/users/:userId`, () => {
     expect(mockJwtServiceProtect).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);
     expect(userController.read).toBeCalledTimes(1);
+    expect(validateParameter.validateComponentId).toBeCalledTimes(0);
+    expect(validateParameter.validateExternalAPIId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+    expect(validateParameter.validateUserId).toBeCalledTimes(1);
   });
 });

--- a/app/tests/unit/routes/v1/admin.spec.js
+++ b/app/tests/unit/routes/v1/admin.spec.js
@@ -1,16 +1,16 @@
-const request = require('supertest');
 const Problem = require('api-problem');
+const request = require('supertest');
+const uuid = require('uuid');
 
 const { expressHelper } = require('../../../common/helper');
+
+const jwtService = require('../../../../src/components/jwtService');
+const validateParameter = require('../../../../src/forms/common/middleware/validateParameter');
 
 //
 // mock middleware
 //
-const jwtService = require('../../../../src/components/jwtService');
 
-//
-// test assumes that caller has appropriate token, we are not testing middleware here...
-//
 jwtService.protect = jest.fn(() => {
   return jest.fn((_req, _res, next) => {
     next();
@@ -19,6 +19,10 @@ jwtService.protect = jest.fn(() => {
 
 const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
 userAccess.currentUser = jest.fn((_req, _res, next) => {
+  next();
+});
+
+validateParameter.validateFormVersionId = jest.fn((_req, _res, next) => {
   next();
 });
 
@@ -46,7 +50,8 @@ afterEach(() => {
 });
 
 describe(`${basePath}/formcomponents/proactivehelp/imageUrl/:componentId`, () => {
-  const path = `${basePath}/formcomponents/proactivehelp/imageUrl/:componentId`;
+  const componentId = uuid.v4();
+  const path = `${basePath}/formcomponents/proactivehelp/imageUrl/${componentId}`;
 
   describe('GET', () => {
     it('should return 200', async () => {
@@ -176,7 +181,8 @@ describe(`${basePath}/formcomponents/proactivehelp/object`, () => {
 });
 
 describe(`${basePath}/formcomponents/proactivehelp/:publishStatus/:componentId`, () => {
-  const path = `${basePath}/formcomponents/proactivehelp/:publishStatus/:componentId`;
+  const componentId = uuid.v4();
+  const path = `${basePath}/formcomponents/proactivehelp/:publishStatus/${componentId}`;
 
   describe('PUT', () => {
     it('should return 200', async () => {
@@ -266,7 +272,8 @@ describe(`${basePath}/forms`, () => {
 });
 
 describe(`${basePath}/forms/:formId`, () => {
-  const path = `${basePath}/forms/:formId`;
+  const formId = uuid.v4();
+  const path = `${basePath}/forms/${formId}`;
 
   describe('GET', () => {
     it('should return 200', async () => {
@@ -306,7 +313,8 @@ describe(`${basePath}/forms/:formId`, () => {
 });
 
 describe(`${basePath}/forms/:formId/addUser`, () => {
-  const path = `${basePath}/forms/:formId/addUser`;
+  const formId = uuid.v4();
+  const path = `${basePath}/forms/${formId}/addUser`;
 
   describe('PUT', () => {
     it('should return 200', async () => {
@@ -315,7 +323,7 @@ describe(`${basePath}/forms/:formId/addUser`, () => {
 
       const response = await appRequest.put(path).query({ userId: '123' }).send({ userId: '123' });
 
-      expect(rbacService.setFormUsers).toBeCalledWith(':formId', '123', { userId: '123' }, undefined);
+      expect(rbacService.setFormUsers).toBeCalledWith(formId, '123', { userId: '123' }, undefined);
       expect(response.statusCode).toBe(200);
       expect(response.body).toBeTruthy();
     });
@@ -357,7 +365,8 @@ describe(`${basePath}/forms/:formId/addUser`, () => {
 });
 
 describe(`${basePath}/forms/:formId/apiKey`, () => {
-  const path = `${basePath}/forms/:formId/apiKey`;
+  const formId = uuid.v4();
+  const path = `${basePath}/forms/${formId}/apiKey`;
 
   describe('DELETE', () => {
     it('should return 204', async () => {
@@ -433,7 +442,8 @@ describe(`${basePath}/forms/:formId/apiKey`, () => {
 });
 
 describe(`${basePath}/forms/:formId/formUsers`, () => {
-  const path = `${basePath}/forms/:formId/formUsers`;
+  const formId = uuid.v4();
+  const path = `${basePath}/forms/${formId}/formUsers`;
 
   describe('GET', () => {
     it('should return 200', async () => {
@@ -473,7 +483,8 @@ describe(`${basePath}/forms/:formId/formUsers`, () => {
 });
 
 describe(`${basePath}/forms/:formId/restore`, () => {
-  const path = `${basePath}/forms/:formId/restore`;
+  const formId = uuid.v4();
+  const path = `${basePath}/forms/${formId}/restore`;
 
   describe('PUT', () => {
     it('should return 200', async () => {
@@ -513,7 +524,9 @@ describe(`${basePath}/forms/:formId/restore`, () => {
 });
 
 describe(`${basePath}/forms/:formId/versions/:formVersionId`, () => {
-  const path = `${basePath}/forms/:formId/versions/:formVersionId`;
+  const formId = uuid.v4();
+  const formVersionId = uuid.v4();
+  const path = `${basePath}/forms/${formId}/versions/${formVersionId}`;
 
   describe('GET', () => {
     it('should return 200', async () => {
@@ -593,7 +606,8 @@ describe(`${basePath}/users`, () => {
 });
 
 describe(`${basePath}/users/:userId`, () => {
-  const path = `${basePath}/users/:userId`;
+  const userId = uuid.v4();
+  const path = `${basePath}/users/${userId}`;
 
   describe('GET', () => {
     it('should return 200', async () => {

--- a/app/tests/unit/routes/v1/form.spec.js
+++ b/app/tests/unit/routes/v1/form.spec.js
@@ -1,5 +1,5 @@
-const request = require('supertest');
 const Problem = require('api-problem');
+const request = require('supertest');
 const uuid = require('uuid');
 
 const { expressHelper } = require('../../../common/helper');


### PR DESCRIPTION
# Description

Now that we have good unit tests for the admin routes, did some additional work on the routes:
- changed the `:id` parameter to something more specific (`externalApiId`) and validate it with existing validator
- validated `componentId` (new validator needed), `formId`, `formVersionId`, and `userId`
- extended unit tests to ensure that validators are being called
- did a bit of comment clarification/formatting
- organized the imports

## Types of changes

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

> Note: the `publishStatus` parameter is not being validated - not even sure what it is, possibly a boolean? Will leave it for now until it's better understood.