### PR TITLE
ci: FORMS-1449 code climate test coverage

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,18 +1,18 @@
 version: "2"
 exclude_patterns:
   - config/
-  - "**/db/"
   - dist/
   - features/
-  - "**/node_modules/"
   - script/
+  - Tests/
+  - "**/*.d.ts"
+  - "**/*_test.go"
+  - "**/db/"
+  - "**/node_modules/"
   - "**/spec/"
   - "**/test/"
   - "**/tests/"
-  - Tests/
   - "**/vendor/"
-  - "**/*_test.go"
-  - "**/*.d.ts"
 plugins:
   csslint:
     enabled: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -142,5 +142,5 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
           coverageLocations: |
-            ${{ github.workspace }}/**/lcov.info:lcov
+            ${{ github.workspace }}/**/clover.xml:clover
           prefix: ${{ github.workplace }}


### PR DESCRIPTION
# Description

The Vue (vitest) upgrade broke the code coverage for the frontend. The badge on the repo (65%) represents only the backend coverage.
- Update to use clover for both - may want to back this out and go with lcov for backend and clover for frontend. TBD, no way to test this :(
- Did a bit of alphabetizing in the config file to make things easier to find.

## Types of changes

ci (change in continuous integration / deployment)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request