### PR TITLE
ci: FORMS-1449 code climate exclude components

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,6 @@
 version: "2"
 exclude_patterns:
+  - components/
   - config/
   - dist/
   - features/


### PR DESCRIPTION
# Description

Code Climate currently has a lot of reports about duplicate code in the form.io component. Since this isn't our code we want to be making as few changes as possible. By removing /components from Code Climate we will get a more accurate maintainability score.

## Types of changes

ci (change in continuous integration / deployment)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

No tests for this. Not even sure that it'll work.