### PR TITLE
Fix: Extend Form Submitter permissions for GET /documentTemplates

### DIFF
--- a/app/src/db/migrations/20240904140843_047-extend-submitter-role.js
+++ b/app/src/db/migrations/20240904140843_047-extend-submitter-role.js
@@ -1,0 +1,34 @@
+const uuid = require('uuid');
+
+const { Permissions, Roles } = require('../../forms/common/constants');
+
+const CREATED_BY = 'migration-047';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+    return Promise.resolve().then(() => {
+        const rolePermission = {
+          id: uuid.v4(),
+          createdBy: CREATED_BY,
+          role: Roles.FORM_SUBMITTER,
+          permission: Permissions.DOCUMENT_TEMPLATE_READ,
+        };
+        return knex('role_permission').insert(rolePermission);
+      });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+    return Promise.resolve().then(() =>
+        knex('role_permission')
+            .where({
+                createdBy: CREATED_BY,
+            })
+            .del()
+    );  
+};

--- a/app/src/forms/common/constants.js
+++ b/app/src/forms/common/constants.js
@@ -29,7 +29,7 @@ module.exports = Object.freeze({
     FORM_API_UPDATE: 'form_api_update',
     FORM_DELETE: 'form_delete',
     FORM_READ: 'form_read',
-    FORM_SUBMITTER: ['form_read', 'submission_create'],
+    FORM_SUBMITTER: ['form_read', 'submission_create', 'document_template_read'],
     FORM_UPDATE: 'form_update',
     SUBMISSION_CREATE: 'submission_create',
     SUBMISSION_DELETE: 'submission_delete',

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -27,7 +27,7 @@ routes.get('/:formId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ])
   await controller.readForm(req, res, next);
 });
 
-routes.get('/:formId/documentTemplates', rateLimiter, apiAccess, async (req, res, next) => {
+routes.get('/:formId/documentTemplates', rateLimiter, apiAccess, hasFormPermissions([P.DOCUMENT_TEMPLATE_READ]), async (req, res, next) => {
   await controller.documentTemplateList(req, res, next);
 });
 
@@ -39,7 +39,7 @@ routes.delete('/:formId/documentTemplates/:documentTemplateId', rateLimiter, api
   await controller.documentTemplateDelete(req, res, next);
 });
 
-routes.get('/:formId/documentTemplates/:documentTemplateId', rateLimiter, apiAccess, async (req, res, next) => {
+routes.get('/:formId/documentTemplates/:documentTemplateId', rateLimiter, apiAccess, hasFormPermissions([P.DOCUMENT_TEMPLATE_READ]), async (req, res, next) => {
   await controller.documentTemplateRead(req, res, next);
 });
 

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -27,7 +27,7 @@ routes.get('/:formId', rateLimiter, apiAccess, hasFormPermissions([P.FORM_READ])
   await controller.readForm(req, res, next);
 });
 
-routes.get('/:formId/documentTemplates', rateLimiter, apiAccess, hasFormPermissions([P.DOCUMENT_TEMPLATE_READ]), async (req, res, next) => {
+routes.get('/:formId/documentTemplates', rateLimiter, apiAccess, async (req, res, next) => {
   await controller.documentTemplateList(req, res, next);
 });
 
@@ -39,7 +39,7 @@ routes.delete('/:formId/documentTemplates/:documentTemplateId', rateLimiter, api
   await controller.documentTemplateDelete(req, res, next);
 });
 
-routes.get('/:formId/documentTemplates/:documentTemplateId', rateLimiter, apiAccess, hasFormPermissions([P.DOCUMENT_TEMPLATE_READ]), async (req, res, next) => {
+routes.get('/:formId/documentTemplates/:documentTemplateId', rateLimiter, apiAccess, async (req, res, next) => {
   await controller.documentTemplateRead(req, res, next);
 });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This fixes an incomplete functionality that prevented form submitters from accessing an uploaded document template for CDOGS print.

In the print options dialog, the GET /documentTemplate route is called which requires the `document_template_read` permission, previously only granted to form owners. The intended functionality is that form submitters can use the template while printing a form or a submission, so I have assigned that permission to the `form_submitter` role. 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Bug reported on Confluence:
https://bcdevex.atlassian.net/wiki/spaces/CCP/pages/1550909456/Permissions+on+CDOGS+Print+Template+feature

Jira ticket:
https://bcdevex.atlassian.net/browse/FORMS-1471

## Types of changes

<!-- Uncomment the main reason for the change (for example, all feat PRs should include docs and test, but only uncomment feat): -->

<!-- feat (a new feature) -->
fix (a bug fix)

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request



<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
