### PR TITLE
build: FORMS-1476 use backup container v2.9.0

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -255,7 +255,7 @@ oc process -f backup-cronjob-verify.yaml \
     -p JOB_NAME=backup-postgres-verify \
     -p JOB_PERSISTENT_STORAGE_NAME=$PVC \
     -p SCHEDULE="0 9 * * *" \
-    -p TAG_NAME=2.8.0 \
+    -p TAG_NAME=2.9.0 \
     | oc -n $NAMESPACE apply -f -
 ```
 
@@ -275,6 +275,6 @@ oc process -f backup-cronjob-verify.yaml \
     -p RESOURCE_LIMIT_CPU="1500m" \
     -p RESOURCE_LIMIT_MEMORY="1Gi" \
     -p SCHEDULE="0 9 * * *" \
-    -p TAG_NAME=2.8.0 \
+    -p TAG_NAME=2.9.0 \
     | oc -n $NAMESPACE apply -f -
 ```

--- a/openshift/redash/README.md
+++ b/openshift/redash/README.md
@@ -26,7 +26,7 @@ oc process -f backup-cronjob.yaml \
     -p JOB_PERSISTENT_STORAGE_NAME=backup-chefs-redash-postgresql \
     -p MONTHLY_BACKUPS=3 \
     -p SCHEDULE="0 8 * * *" \
-    -p TAG_NAME=2.8.0 \
+    -p TAG_NAME=2.9.0 \
     -p WEEKLY_BACKUPS=8 \
     | oc -n a12c97-tools apply -f -
 ```
@@ -42,7 +42,7 @@ oc process -f backup-cronjob-verify.yaml \
     -p JOB_NAME=backup-chefs-redash-postgres-verify \
     -p JOB_PERSISTENT_STORAGE_NAME=backup-chefs-redash-postgresql \
     -p SCHEDULE="0 9 * * *" \
-    -p TAG_NAME=2.8.0 \
+    -p TAG_NAME=2.9.0 \
     | oc -n a12c97-tools apply -f -
 ```
 

--- a/openshift/redash/backup-cronjob-verify.yaml
+++ b/openshift/redash/backup-cronjob-verify.yaml
@@ -193,7 +193,7 @@ objects:
                   command:
                     - "/bin/bash"
                     - "-c"
-                    - "/backup.sh -v all"
+                    - "/backup.sh -I -v all"
                   volumeMounts:
                     - mountPath: "${BACKUP_DIR}"
                       name: "backup"


### PR DESCRIPTION
# Description

In https://bcdevex.atlassian.net/browse/FORMS-887 most of the images were updated from 2.6.1 to 2.8.0. The production backup failed due to space issues, even though we have 7.8G of space for a 4G database that has 1.7G compressed backups.

### Acceptance Criteria
- Backups succeed
- Backup verifications succeed
- All backups and verifications run the same container version

### Solution

Going through the version history of the backup container:
- 2.6.1: where we started
- 2.7.0: changed from gzip to tar; stop ignoring errors
- 2.8.0: mongodb support
- 2.8.1: reverted the gzip to tar change in v2.7.0
- 2.9.0: postgresql 15 support

So the problem is that using tar took up too much space, but fixing it changed the way backups are stored and now that errors aren’t ignored the backup errors actually cause the verify to fail.

Will switch to v2.9.0 and use the `-I` flag to ignore errors when verifying the backups. This is not ideal but it is the way that v2.6.1 worked. Hopefully in the future the bug will get fixed and we can remove this flag.

## Type of Change

build (change in build system or dependencies)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

Follow https://github.com/BCDevOps/backup-container/issues/132 to see when we can remove the `-I` flag.