### PR TITLE
fix: FORMS-1303 rate limit admin, permission, and role

### DIFF
--- a/app/src/forms/admin/routes.js
+++ b/app/src/forms/admin/routes.js
@@ -2,9 +2,12 @@ const routes = require('express').Router();
 
 const jwtService = require('../../components/jwtService');
 const currentUser = require('../auth/middleware/userAccess').currentUser;
+const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 const validateParameter = require('../common/middleware/validateParameter');
 const userController = require('../user/controller');
 const controller = require('./controller');
+
+routes.use(rateLimiter);
 
 // Routes under /admin fetch data without doing form permission checks. All
 // routes in this file should remain under the "admin" role check, with the

--- a/app/src/forms/permission/routes.js
+++ b/app/src/forms/permission/routes.js
@@ -2,9 +2,11 @@ const routes = require('express').Router();
 
 const jwtService = require('../../components/jwtService');
 const currentUser = require('../auth/middleware/userAccess').currentUser;
+const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 const validateParameter = require('../common/middleware/validateParameter');
 const controller = require('./controller');
 
+routes.use(rateLimiter);
 routes.use(jwtService.protect('admin'));
 routes.use(currentUser);
 

--- a/app/src/forms/role/routes.js
+++ b/app/src/forms/role/routes.js
@@ -2,9 +2,11 @@ const routes = require('express').Router();
 
 const jwtService = require('../../components/jwtService');
 const currentUser = require('../auth/middleware/userAccess').currentUser;
+const rateLimiter = require('../common/middleware').apiKeyRateLimiter;
 const validateParameter = require('../common/middleware/validateParameter');
 const controller = require('./controller');
 
+routes.use(rateLimiter);
 routes.use(currentUser);
 
 routes.param('code', validateParameter.validateRoleCode);


### PR DESCRIPTION
# Description

The CodeQL security scan recommends having rate limiting on all routes that touch the database. This is to prevent denial of service attacks by calling these “resource heavy” routes repeatedly.

This work will be split into a few Pull Requests so that we can monitor behaviour. This PR will apply API rate limiting to the currently non-limited routes in /admin, /permission, and /role.

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
fix (a bug fix)

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

> Note: no tests for this. The end goal is to have the rate limiter applied in the root app.js, and removed from each of these route.js files. No point in writing tests for the route.js files only to turf them later.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
