### PR TITLE
fix: FORMS-1642 - Wide Layout Mode as default when users land on form

### DIFF
--- a/app/frontend/src/components/designer/FormViewerActions.vue
+++ b/app/frontend/src/components/designer/FormViewerActions.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, inject, ref } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import ManageSubmissionUsers from '~/components/forms/submission/ManageSubmissionUsers.vue';
@@ -61,7 +61,7 @@ const properties = defineProps({
   },
 });
 
-const isWideLayout = ref(false);
+const isWideLayout = ref(properties.wideFormLayout);
 
 const formStore = useFormStore();
 
@@ -74,14 +74,19 @@ const showEditToggle = computed(
     properties.permissions.includes(FormPermissions.SUBMISSION_UPDATE)
 );
 
-onMounted(() => {
-  setWideLayout(isWideLayout.value);
-});
-
 function toggleWideLayout() {
   isWideLayout.value = !isWideLayout.value;
   setWideLayout(isWideLayout.value);
 }
+// Sync the local copy with the prop when it changes
+watch(
+  () => properties.wideFormLayout,
+  (newValue) => {
+    isWideLayout.value = newValue;
+    setWideLayout(newValue);
+  },
+  { immediate: true }
+);
 </script>
 
 <template>

--- a/app/frontend/src/components/forms/FormSubmission.vue
+++ b/app/frontend/src/components/forms/FormSubmission.vue
@@ -46,6 +46,7 @@ onMounted(async () => {
   await formStore.getFormPermissionsForUser(form.value.id);
   loading.value = false;
   // set wide layout
+  isWideLayout.value = form.value.wideFormLayout;
   setWideLayout(isWideLayout.value);
 });
 

--- a/app/frontend/tests/unit/components/designer/FormViewerActions.spec.js
+++ b/app/frontend/tests/unit/components/designer/FormViewerActions.spec.js
@@ -73,6 +73,26 @@ describe('FormDisclaimer.vue', () => {
     expect(wrapper.vm.showEditToggle).toBeTruthy();
   });
 
+  it('when props.wideFormLayout is set from parent call setWideLayout', async () => {
+    const setWideLayout = vi.fn();
+    setWideLayout.mockImplementation(() => {});
+    const wrapper = mount(FormViewerActions, {
+      props: {
+        wideFormLayout: true,
+      },
+      global: {
+        plugins: [pinia],
+        provide: {
+          setWideLayout: setWideLayout,
+        },
+        stubs: STUBS,
+      },
+    });
+
+    expect(wrapper.vm.isWideLayout).toBeTruthy();
+    expect(setWideLayout).toBeCalledTimes(1);
+  });
+
   it('toggleWideLayout will toggle isWideLayout and call setWideLayout', async () => {
     const setWideLayout = vi.fn();
     setWideLayout.mockImplementation(() => {});

--- a/app/frontend/tests/unit/components/forms/FormSubmission.spec.js
+++ b/app/frontend/tests/unit/components/forms/FormSubmission.spec.js
@@ -54,6 +54,7 @@ describe('FormSubmission.vue', () => {
     formStore.form = {
       id: 0,
       name: 'This is a form title',
+      wideFormLayout: true,
     };
     const fetchSubmissionSpy = vi.spyOn(formStore, 'fetchSubmission');
     fetchSubmissionSpy.mockImplementation(() => {});
@@ -88,6 +89,8 @@ describe('FormSubmission.vue', () => {
     expect(wrapper.text()).toContain('trans.formSubmission.submitted');
     expect(wrapper.text()).toContain('trans.formSubmission.submission');
     expect(wrapper.html()).toContain(formStore.form.name);
+    expect(setWideLayout).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.isWideLayout).toBeTruthy();
   });
 
   it('onDelete should push to the FormSubmissions page', async () => {


### PR DESCRIPTION
# Description

FORMS-1642 - As a form designer, I want the option to have the form to default to Wide Layout mode when submitters land on the form, so they do not need the additional step to turn it on/off

## Type of Change


fix (a bug fix)

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request
