### PR TITLE
fix: FORMS-1661 - Update API Spec for Preferences Parameter Format

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -619,7 +619,7 @@ paths:
           name: preference
           schema:
             type: object
-          example: '{minDate=2020-12-17T08:00:00Z,maxDate=2020-12-18T08:00:00Z,updatedMinDate=2020-12-17T08:00:00Z,updatedMaxDate=2020-12-18T08:00:00Z}'
+          example: '{"minDate":"2020-12-17T08:00:00Z","maxDate":"2020-12-18T08:00:00Z","updatedMinDate":"2020-12-17T08:00:00Z","updatedMaxDate":"2020-12-18T08:00:00Z"}'
           description: form submissions export preferences
         - in: query
           name: deleted


### PR DESCRIPTION
# Description

The preference parameter in the API specification is currently formatted incorrectly as follows 

![image](https://github.com/user-attachments/assets/a4142c51-fce3-4f08-8d21-ed63bf4cba5a)
 

This format should be updated to a valid JSON format.

 

{"minDate":"2020-12-17T08:00:00Z","maxDate":"2020-12-18T08:00:00Z","updatedMinDate":"2020-12-17T08:00:00Z","updatedMaxDate":"2020-12-18T08:00:00Z"}


## Type of Change

docs (change to documentation) 

## Checklist


- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request
