### PR TITLE
fix: FORMS-1640 - changes to CSS to Improve error message contrast for accessibility.

### DIFF
--- a/app/frontend/src/assets/scss/style.scss
+++ b/app/frontend/src/assets/scss/style.scss
@@ -210,6 +210,16 @@ a,
     word-break: break-word;
   }
 
+  /**FORMS-1640 - Remove the pink background entirely or change its colour to transparent across the entire CHEFS product 
+  or specifically within the "form submitter" forms to Improve error message contrast for accessibility. **/
+  .formio-error-wrapper {
+    background-color: transparent;
+  }
+  .formio-error-wrapper,
+  .formio-warning-wrapper {
+    padding: 0;
+  }
+
   // tabs component
   .formio-component-simpletabs {
     & > .card {
@@ -554,7 +564,9 @@ a,
   background-color: #eee !important;
 }
 
-.v-data-table, .v-data-table-server, .v-table {
+.v-data-table,
+.v-data-table-server,
+.v-table {
   font-size: 16px !important;
 }
 


### PR DESCRIPTION
# Description

Description of the Problem:
Currently, when mandatory fields are not filled and validation is triggered, the contrast between the background pink colour and red font is not high enough to meet accessibility requirements. See the example below where contrast checker software notes a fail vs a pass.
![image](https://github.com/user-attachments/assets/404dc199-9467-4344-bafd-5ad65b9677b0)
![image](https://github.com/user-attachments/assets/fc363fbf-ed8b-4b06-89ba-d8e857b32388)

Proposed UX Solution: 
Remove the pink background entirely or change its colour to transparent across the entire CHEFS product or specifically within the "form submitter" forms.

How it looks after the CSS changes. 
![image](https://github.com/user-attachments/assets/b04167bd-d3e3-4452-aba2-c2711f7c9d77)



## Type of Change

fix (a bug fix) 

style (change to code style/formatting) 

This is a breaking change because it might 
Removing padding could cause Text/content appearing misaligned compared to neighboring elements.

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request