### PR TITLE
fix: FORMS-1703 Added Tags to port numbers, removed unused port number

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,6 +67,9 @@
     "4224": {
       "label": "NATS Server 3"
     },
+    "5173": {
+      "label": "CHEFS Frontend"
+    },
     "5432": {
       "label": "PostgreSQL"
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,13 +21,12 @@
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [
+    4222, // NATS Server 1
+    4223, // NATS Server 2
+    4224, // NATS Server 3
     5173, // CHEFS Frontend
     5432, // PostgreSQL
-    8080, // CHEFS Backend
-    8081,
-    4222, //nats
-    4223, //nats
-    4224 // nats
+    8080 // CHEFS Backend
   ],
 
   // Use 'postCreateCommand' to run commands after the container is created.
@@ -57,5 +56,22 @@
 
   "containerEnv": {
     "NODE_CONFIG_DIR": "${containerWorkspaceFolder}/.devcontainer/chefs_local"
+  },
+  "portsAttributes": {
+    "4222": {
+      "label": "NATS Server 1"
+    },
+    "4223": {
+      "label": "NATS Server 2"
+    },
+    "4224": {
+      "label": "NATS Server 3"
+    },
+    "5432": {
+      "label": "PostgreSQL"
+    },
+    "8080": {
+      "label": "CHEFS Backend"
+    }
   }
 }


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
In the devcontainers we now have seven ports, but they are not labeled and it’s not obvious what they’re used for.


It would be better if we labeled these ports so that it was obvious what they were used for. It also appears that the 8081 port isn’t being used.

An example of these labels can be found in portsAttributes settings of this repo:
 [queue-management/.devcontainer/devcontainer.json at main · bcgov/queue-management](https://github.com/bcgov/queue-management/blob/main/.devcontainer/devcontainer.json) 

Acceptance Criteria
All of the ports have labels that make it obvious what they are used for.

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
fix (a bug fix)
<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request



<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
