### PR TITLE
FORMS-1707: decouple forms from current user, optimize performance

### DIFF
--- a/app/frontend/src/components/admin/Developer.vue
+++ b/app/frontend/src/components/admin/Developer.vue
@@ -25,7 +25,8 @@ onBeforeMount(async () => {
 async function getUser() {
   try {
     const user = await rbacService.getCurrentUser();
-    apiRes.value = user.data;
+    const forms = await rbacService.getCurrentUserForms();
+    apiRes.value = { ...user.data, forms: forms.data };
   } catch (error) {
     notificationStore.addNotification({
       text: t('trans.developer.notificationMsg'),

--- a/app/frontend/src/services/rbacService.js
+++ b/app/frontend/src/services/rbacService.js
@@ -15,8 +15,16 @@ export default {
    * Get the current user details from the rbac endpoint
    * @returns {Promise} An axios response
    */
-  getCurrentUser(params = {}) {
-    return appAxios().get(`${ApiRoutes.RBAC}/current`, { params });
+  getCurrentUser() {
+    return appAxios().get(`${ApiRoutes.RBAC}/current`, {});
+  },
+  /**
+   * @function getCurrentUserForms
+   * Get the current user's forms from the rbac endpoint
+   * @returns {Promise} An axios response
+   */
+  getCurrentUserForms(params = {}) {
+    return appAxios().get(`${ApiRoutes.RBAC}/current/forms`, { params });
   },
 
   /**

--- a/app/frontend/src/store/form.js
+++ b/app/frontend/src/store/form.js
@@ -156,10 +156,10 @@ export const useFormStore = defineStore('form', {
     async getFormsForCurrentUser() {
       try {
         // Get the forms based on the user's permissions
-        const response = await rbacService.getCurrentUser();
+        const response = await rbacService.getCurrentUserForms();
         const data = response.data;
         // Build up the list of forms for the table
-        const forms = data.forms.map((f) => ({
+        const forms = data.map((f) => ({
           currentVersionId: f.formVersionId,
           id: f.formId,
           idps: f.idps,
@@ -183,10 +183,12 @@ export const useFormStore = defineStore('form', {
       try {
         this.permissions = [];
         // Get the forms based on the user's permissions
-        const response = await rbacService.getCurrentUser({ formId: formId });
+        const response = await rbacService.getCurrentUserForms({
+          formId: formId,
+        });
         const data = response.data;
-        if (data.forms[0]) {
-          this.permissions = data.forms[0].permissions;
+        if (data[0]) {
+          this.permissions = data[0].permissions;
         } else {
           throw new Error('No form found');
         }
@@ -205,10 +207,12 @@ export const useFormStore = defineStore('form', {
       try {
         this.roles = [];
         // Get the forms based on the user's permissions
-        const response = await rbacService.getCurrentUser({ formId: formId });
+        const response = await rbacService.getCurrentUserForms({
+          formId: formId,
+        });
         const data = response.data;
-        if (data.forms[0]) {
-          this.roles = data.forms[0].roles;
+        if (data[0]) {
+          this.roles = data[0].roles;
         } else {
           throw new Error('No form found');
         }

--- a/app/frontend/tests/unit/components/admin/Developer.spec.js
+++ b/app/frontend/tests/unit/components/admin/Developer.spec.js
@@ -11,6 +11,7 @@ import Developer from '~/components/admin/Developer.vue';
 describe('Developer.vue', () => {
   const mockConsoleError = vi.spyOn(console, 'error');
   const getCurrentUserSpy = vi.spyOn(rbacService, 'getCurrentUser');
+  const getCurrentUserFormsSpy = vi.spyOn(rbacService, 'getCurrentUserForms');
 
   const pinia = createTestingPinia();
   setActivePinia(pinia);
@@ -28,7 +29,12 @@ describe('Developer.vue', () => {
   });
 
   it('renders without error', async () => {
-    const data = {};
+    const userData = { id: 'a' };
+    const formsData = [];
+    const resData = {
+      ...userData,
+      forms: formsData,
+    };
     authStore.keycloak = {
       tokenParsed: {
         email: 'email@email.com',
@@ -38,7 +44,8 @@ describe('Developer.vue', () => {
       token: 'token',
       fullName: 'fullName',
     };
-    getCurrentUserSpy.mockImplementation(() => ({ data: data }));
+    getCurrentUserSpy.mockImplementation(() => ({ data: userData }));
+    getCurrentUserFormsSpy.mockImplementation(() => ({ data: formsData }));
     const wrapper = mount(Developer, {
       global: {
         props: {
@@ -56,7 +63,7 @@ describe('Developer.vue', () => {
 
     expect(wrapper.text()).toMatch('Developer Resources');
     expect(getCurrentUserSpy).toHaveBeenCalledTimes(1);
-    expect(wrapper.vm.apiRes).toEqual(data);
+    expect(wrapper.vm.apiRes).toEqual(resData);
   });
 
   it('renders with error', async () => {

--- a/app/frontend/tests/unit/services/rbacService.spec.js
+++ b/app/frontend/tests/unit/services/rbacService.spec.js
@@ -25,7 +25,19 @@ describe('RBAC Service', () => {
     it('calls rbac/current endpoint', async () => {
       mockAxios.onGet(endpoint).reply(200);
 
-      const result = await rbacService.getCurrentUser({ idp: 'idir' });
+      const result = await rbacService.getCurrentUser();
+      expect(result).toBeTruthy();
+      expect(mockAxios.history.get).toHaveLength(1);
+    });
+  });
+
+  describe('rbac/current/forms', () => {
+    const endpoint = `${ApiRoutes.RBAC}/current/forms`;
+
+    it('calls rbac/current endpoint', async () => {
+      mockAxios.onGet(endpoint).reply(200);
+
+      const result = await rbacService.getCurrentUserForms({ idp: 'idir' });
       expect(result).toBeTruthy();
       expect(mockAxios.history.get).toHaveLength(1);
       expect(Object.keys(mockAxios.history.get[0].params)).toEqual(['idp']);

--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -2351,8 +2351,32 @@ paths:
                 $ref: '#/components/schemas/Error'
   /rbac/current:
     get:
-      summary: Get forms/roles/permissions for current user
+      summary: Get current user details
       operationId: getCurrentUser
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/CurrentUser'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /rbac/current/forms:
+    get:
+      summary: Get forms/roles/permissions for current user
+      operationId: getCurrentUserForms
       tags:
         - RBAC
       parameters:
@@ -2385,7 +2409,6 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/CurrentUser'
                   - type: array
                     items:
                       $ref: '#/components/schemas/UserForm'

--- a/app/src/forms/rbac/controller.js
+++ b/app/src/forms/rbac/controller.js
@@ -44,9 +44,15 @@ module.exports = {
   },
   getCurrentUser: async (req, res, next) => {
     try {
-      const response = await service.getCurrentUser(req.currentUser, req.query);
-      // don't want this going out, only need deleted forms on current user in middleware.
-      delete response.deletedForms;
+      const response = await service.getCurrentUser(req.currentUser);
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  },
+  getCurrentUserForms: async (req, res, next) => {
+    try {
+      const response = await service.getCurrentUserForms(req.currentUser, req.query);
       res.status(200).json(response);
     } catch (error) {
       next(error);

--- a/app/src/forms/rbac/routes.js
+++ b/app/src/forms/rbac/routes.js
@@ -12,6 +12,10 @@ routes.get('/current', jwtService.protect(), async (req, res, next) => {
   await controller.getCurrentUser(req, res, next);
 });
 
+routes.get('/current/forms', jwtService.protect(), async (req, res, next) => {
+  await controller.getCurrentUserForms(req, res, next);
+});
+
 routes.get('/current/submissions', jwtService.protect(), async (req, res, next) => {
   await controller.getCurrentUserSubmissions(req, res, next);
 });

--- a/app/src/forms/rbac/service.js
+++ b/app/src/forms/rbac/service.js
@@ -66,25 +66,32 @@ const service = {
     return User.query().findById(id).throwIfNotFound();
   },
 
-  getCurrentUser: async (currentUser, params) => {
+  getCurrentUser: async (currentUser) => {
     const user = Object.assign({}, currentUser);
-    const accessLevels = [];
-    if (user.public) {
-      accessLevels.push('public');
-    } else {
-      if (params.public) accessLevels.push('public');
-      if (params.idp) accessLevels.push('idp');
-      if (params.team) accessLevels.push('team');
-    }
-
-    const forms = await authService.getUserForms(user, {
-      ...params,
-      active: true,
-    });
-    const filteredForms = authService.filterForms(user, forms, accessLevels);
-    user.forms = filteredForms;
-
     return user;
+  },
+
+  getCurrentUserForms: async (currentUser, params = {}) => {
+    if (!currentUser) return [];
+    try {
+      const accessLevels = [];
+      if (currentUser.public) {
+        accessLevels.push('public');
+      } else {
+        if (params.public) accessLevels.push('public');
+        if (params.idp) accessLevels.push('idp');
+        if (params.team) accessLevels.push('team');
+      }
+
+      const forms = await authService.getUserForms(currentUser, {
+        ...params,
+        active: true,
+      });
+      const filteredForms = authService.filterForms(currentUser, forms, accessLevels);
+      return filteredForms;
+    } catch {
+      return [];
+    }
   },
 
   getCurrentUserSubmissions: async (currentUser, params) => {

--- a/app/tests/unit/forms/rbac/controller.spec.js
+++ b/app/tests/unit/forms/rbac/controller.spec.js
@@ -36,3 +36,19 @@ describe('setSubmissionUserPermissions', () => {
     expect(service.modifySubmissionUser).toBeCalledWith(req.query.formSubmissionId, req.query.userId, req.body, req.currentUser);
   });
 });
+
+describe('getCurrentUserForms', () => {
+  const req = {
+    query: { formId: '1' },
+    body: { permissions: [] },
+    currentUser: {},
+    headers: { referer: 'a' },
+  };
+  it('should call the service with the query params', async () => {
+    service.getCurrentUserForms = jest.fn().mockReturnValue([]);
+    await controller.getCurrentUserForms(req, {}, jest.fn());
+
+    expect(service.getCurrentUserForms).toBeCalledTimes(1);
+    expect(service.getCurrentUserForms).toBeCalledWith(req.currentUser, req.query);
+  });
+});

--- a/app/tests/unit/forms/rbac/routes.spec.js
+++ b/app/tests/unit/forms/rbac/routes.spec.js
@@ -83,6 +83,27 @@ describe(`${basePath}/current`, () => {
   });
 });
 
+describe(`${basePath}/current/forms`, () => {
+  const path = `${basePath}/current/forms`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.getCurrentUserForms = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(controller.getCurrentUserForms).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(0);
+    expect(hasFormRolesMock).toBeCalledTimes(0);
+    expect(hasSubmissionPermissionsMock).toBeCalledTimes(0);
+    expect(mockJwtServiceProtect).toBeCalledTimes(1);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(userAccess.hasRoleDeletePermissions).toBeCalledTimes(0);
+    expect(userAccess.hasRoleModifyPermissions).toBeCalledTimes(0);
+  });
+});
+
 describe(`${basePath}/current/submissions`, () => {
   const path = `${basePath}/current/submissions`;
 

--- a/app/tests/unit/forms/rbac/service.spec.js
+++ b/app/tests/unit/forms/rbac/service.spec.js
@@ -1,0 +1,101 @@
+const service = require('../../../../src/forms/rbac/service');
+const authService = require('../../../../src/forms/auth/service');
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('getCurrentUser', () => {
+  it('should return a current user', async () => {
+    const userInfo = {
+      idpUserId: undefined,
+      keycloakId: undefined,
+      username: 'public',
+      firstName: undefined,
+      lastName: undefined,
+      fullName: 'public',
+      email: undefined,
+      idp: 'public',
+      public: true,
+    };
+    const result = await service.getCurrentUser(userInfo);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject(userInfo);
+  });
+
+  it('should return an empty object', async () => {
+    const userInfo = undefined;
+    const result = await service.getCurrentUser(userInfo);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject({});
+  });
+});
+
+describe('getCurrentUserForms', () => {
+  it('should return empty list without currentUser', async () => {
+    const userInfo = undefined;
+    const result = await service.getCurrentUserForms(userInfo);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject([]);
+  });
+  it('should return empty list with invalid currentUser', async () => {
+    const userInfo = { msg: 'no valid currentUser attributes' };
+    const result = await service.getCurrentUserForms(userInfo);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject([]);
+  });
+  it('should use public access level for public user', async () => {
+    authService.getUserForms = jest.fn().mockResolvedValueOnce([]);
+    authService.filterForms = jest.fn().mockResolvedValueOnce([]);
+    const userInfo = { public: true };
+    const result = await service.getCurrentUserForms(userInfo);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject([]);
+    expect(authService.getUserForms).toBeCalledWith(userInfo, { active: true }); // current user, no params (always active)
+    expect(authService.filterForms).toBeCalledWith(userInfo, [], ['public']); // current user, forms, public access level
+  });
+  it('should use public access level for public param', async () => {
+    authService.getUserForms = jest.fn().mockResolvedValueOnce([]);
+    authService.filterForms = jest.fn().mockResolvedValueOnce([]);
+    const userInfo = { public: false };
+    const params = { public: true };
+    const result = await service.getCurrentUserForms(userInfo, params);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject([]);
+    expect(authService.getUserForms).toBeCalledWith(userInfo, { ...params, active: true }); // current user, params + active
+    expect(authService.filterForms).toBeCalledWith(userInfo, [], ['public']); // current user, forms, public access level
+  });
+  it('should use idp access level for idp param', async () => {
+    authService.getUserForms = jest.fn().mockResolvedValueOnce([]);
+    authService.filterForms = jest.fn().mockResolvedValueOnce([]);
+    const userInfo = { public: false };
+    const params = { idp: true };
+    const result = await service.getCurrentUserForms(userInfo, params);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject([]);
+    expect(authService.getUserForms).toBeCalledWith(userInfo, { ...params, active: true }); // current user, params + active
+    expect(authService.filterForms).toBeCalledWith(userInfo, [], ['idp']); // current user, forms, idp access level
+  });
+  it('should use team access level for team param', async () => {
+    authService.getUserForms = jest.fn().mockResolvedValueOnce([]);
+    authService.filterForms = jest.fn().mockResolvedValueOnce([]);
+    const userInfo = { public: false };
+    const params = { team: true };
+    const result = await service.getCurrentUserForms(userInfo, params);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject([]);
+    expect(authService.getUserForms).toBeCalledWith(userInfo, { ...params, active: true }); // current user, params + active
+    expect(authService.filterForms).toBeCalledWith(userInfo, [], ['team']); // current user, forms, team access level
+  });
+  it('should use no access level with invalid params', async () => {
+    authService.getUserForms = jest.fn().mockResolvedValueOnce([]);
+    authService.filterForms = jest.fn().mockResolvedValueOnce([]);
+    const userInfo = { public: false };
+    const params = { bogus: true };
+    const result = await service.getCurrentUserForms(userInfo, params);
+    expect(result).toBeTruthy();
+    expect(result).toMatchObject([]);
+    expect(authService.getUserForms).toBeCalledWith(userInfo, { ...params, active: true }); // current user, params + active
+    expect(authService.filterForms).toBeCalledWith(userInfo, [], []); // current user, forms, no access level filters
+  });
+});


### PR DESCRIPTION
Get Current User always returns form data even when not used. Make the fetch of user form data explicit by adding new API to fetch the current user forms.

<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
See JIRA tickets: [FORMS-1000](https://bcdevex.atlassian.net/browse/FORMS-1000) and [FORMS-1677](https://bcdevex.atlassian.net/browse/FORMS-1677).

We want to eliminate fetching and returning the current user's forms on each call to `getCurrentUser`. The forms are not always needed and the list can be pretty large (when having access to IDIR forms, for instance).

Where we need the forms, we make an explicit call to a new endpoint. Note that the current user form list is different than other form list APIs. This new endpoint is to return the exact same data in the exact same structure as it appeared previously.

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

feat (a new feature)
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
perf (change to improve performance)
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
test (add missing tests or correct existing tests)

<!--
This is a breaking change because ...
-->
This is (potentially) a breaking change because the API has changed. If someone was leveraging `getCurrentUser` and using the forms returned, then they will have to add in the new call to `getCurrentUserForms`.

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
