### PR TITLE
FORMS-1920: BCeID User search fails

### DIFF
--- a/app/src/components/idpService.js
+++ b/app/src/components/idpService.js
@@ -169,7 +169,7 @@ class IdpService {
           groupValid = false;
         } else {
           // only one of the filters in this group is required.
-          groupValid = isNotEmpty(value);
+          groupValid = groupValid || isNotEmpty(value);
         }
       }
       valid = groupValid;

--- a/app/tests/unit/components/idpService.spec.js
+++ b/app/tests/unit/components/idpService.spec.js
@@ -142,13 +142,22 @@ describe('idpService', () => {
     expect(MockModel.modify).toBeCalledWith('filterEmail', 'em@il.com', false, false);
   });
 
-  it('should return a customized user search', async () => {
+  it('should pass when customized user search for required > 1 (one of group required, first param)', async () => {
+    // test passing in first param
+    const s = await idpService.userSearch({ idpCode: 'bceid-business', username: 'bceidbiz' });
+    expect(s).toBeFalsy();
+    expect(MockModel.query).toBeCalledTimes(1);
+    expect(MockModel.modify).toBeCalledWith('filterIdpCode', 'bceid-business', false, true);
+    expect(MockModel.modify).toBeCalledWith('filterUsername', 'bceidbiz', true, false);
+  });
+
+  it('should pass when customized user search for required > 1 (one of group required, second param)', async () => {
+    // pass in second param
     const s = await idpService.userSearch({ idpCode: 'bceid-business', email: 'em@il.com' });
     expect(s).toBeFalsy();
     expect(MockModel.query).toBeCalledTimes(1);
     expect(MockModel.modify).toBeCalledWith('filterIdpCode', 'bceid-business', false, true);
     expect(MockModel.modify).toBeCalledWith('filterEmail', 'em@il.com', true, false);
-    expect(MockModel.modify).toBeCalledTimes(9);
   });
 
   it('should throw error when customized user search fails validation for required > 1 (one of group required)', async () => {
@@ -190,7 +199,7 @@ describe('idpService', () => {
     expect(e.message).toBe('searchtestonly userSearch failed.');
   });
 
-  it('should throw pass when customized user searchfor required = 1 (all in group required, all passed in)', async () => {
+  it('should pass when customized user searchfor required = 1 (all in group required, all passed in)', async () => {
     // passing both should succeed
     const s = await idpService.userSearch({ idpCode: 'searchtestonly', firstName: 'first', lastName: 'last' });
     expect(s).toBeFalsy();


### PR DESCRIPTION
Fix logic and hole in unit tests, user search failing for required=2 when passing the first param (works when passing the second).

<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description

Seeing errors in log for user search...

```
{"component":"app","level":"error","message":"Could not retrieve BCeID users. Invalid options provided.","stack":"Error: Could not retrieve BCeID users. Invalid options provided.\n    at IdpService.userSearch (/opt/app-root/src/app/src/components/idpService.js:190:17)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Object.list (/opt/app-root/src/app/src/forms/user/controller.js:9:24)\n    at async /opt/app-root/src/app/src/forms/user/routes.js:45:3","timestamp":"2025-02-24T17:55:42.013Z"}
```

For BCeID user searches, one of: `username` or `email` is required. The unit test used the `email` param, which was last in the list of params, and passed when only `email` was provided. However this did not test the logic if only `username` was provided (first param). This failed after a refactoring. 

This PR corrects the logic bug AND adds tests for the 2 params.

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
 fix (a bug fix)

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
