### PR TITLE
FORMS 2091 vitest stderr fixes

### DIFF
--- a/app/frontend/src/components/designer/FormViewer.vue
+++ b/app/frontend/src/components/designer/FormViewer.vue
@@ -984,7 +984,6 @@ async function doSubmit(sub) {
       );
     }
   } catch (error) {
-    console.error(error); // eslint-disable-line no-console
     errMsg = t('trans.formViewer.errMsg');
   } finally {
     confirmSubmit.value = false;

--- a/app/frontend/src/components/forms/submission/ManageSubmissionUsers.vue
+++ b/app/frontend/src/components/forms/submission/ManageSubmissionUsers.vue
@@ -88,13 +88,7 @@ async function onChangeUserSearchInput(input) {
     const response = await userService.getUsers(params);
     userSearchResults.value = response.data;
   } catch (error) {
-    // userSearchResults.value = [];
-    /* eslint-disable no-console */
-    console.error(
-      t('trans.manageSubmissionUsers.getUsersErrMsg', {
-        error: error,
-      })
-    ); // eslint-disable-line no-console
+    userSearchResults.value = [];
   } finally {
     isLoadingDropdown.value = false;
   }

--- a/app/frontend/tests/unit/components/base/BaseInternationalization.spec.js
+++ b/app/frontend/tests/unit/components/base/BaseInternationalization.spec.js
@@ -54,5 +54,9 @@ describe('BaseInternationalization.vue', () => {
     wrapper.vm.languageSelected('ar');
 
     expect(formStore.isRTL).toBeTruthy();
+
+    wrapper.vm.languageSelected('en');
+
+    expect(formStore.isRTL).toBeFalsy();
   });
 });

--- a/app/frontend/tests/unit/components/designer/FormViewer.spec.js
+++ b/app/frontend/tests/unit/components/designer/FormViewer.spec.js
@@ -63,6 +63,8 @@ describe('FormViewer.vue', () => {
   const alertSpy = vi.spyOn(window, 'alert');
   const downloadFileSpy = vi.spyOn(formStore, 'downloadFile');
   const getDispositionSpy = vi.spyOn(transformUtils, 'getDisposition');
+  const createSubmissionSpy = vi.spyOn(formService, 'createSubmission');
+  const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
 
   beforeEach(() => {
     appStore.$reset();
@@ -100,6 +102,8 @@ describe('FormViewer.vue', () => {
     alertSpy.mockReset();
     downloadFileSpy.mockReset();
     getDispositionSpy.mockReset();
+    createSubmissionSpy.mockReset();
+    updateSubmissionSpy.mockReset();
 
     getProxyHeadersSpy.mockImplementation(() => {
       return {
@@ -167,6 +171,22 @@ describe('FormViewer.vue', () => {
       };
     });
     getDispositionSpy.mockImplementation(() => {});
+    createSubmissionSpy.mockImplementation(() => {
+      return {
+        status: 200,
+        data: {
+          submission: { testKey: 'testValue' },
+        },
+      };
+    });
+    updateSubmissionSpy.mockImplementation(() => {
+      return {
+        status: 201,
+        data: {
+          submission: { testKey: 'testValue' },
+        },
+      };
+    });
   });
 
   it('formScheduleExpireMessage returns the formScheduleExpireMessage translation or custom message', async () => {
@@ -605,14 +625,18 @@ describe('FormViewer.vue', () => {
     readPublishedSpy.mockReset();
     addNotificationSpy.mockReset();
 
+    readPublishedSpy.mockImplementationOnce(() => {
+      return {};
+    });
+
     await wrapper.vm.getFormSchema();
 
     expect(readPublishedSpy).toBeCalledTimes(1);
     expect(readVersionSpy).toBeCalledTimes(0);
     expect(readDraftSpy).toBeCalledTimes(0);
     expect(getUserSubmissionsSpy).toBeCalledTimes(0);
-    expect(addNotificationSpy).toBeCalledTimes(1);
   });
+
   it('calls readPublished by default, and pushes to router if there are no versions', async () => {
     const push = vi.fn();
     useRouter.mockImplementationOnce(() => ({
@@ -1237,7 +1261,7 @@ describe('FormViewer.vue', () => {
   });
 
   it('saveDraft will call createSubmission and push the route if there is a submission id and it is a duplicate', async () => {
-    const createSubmissionSpy = vi.spyOn(formService, 'createSubmission');
+    // override default implementation
     createSubmissionSpy.mockImplementationOnce(() => {
       return {
         data: {
@@ -1272,8 +1296,7 @@ describe('FormViewer.vue', () => {
   });
 
   it('saveDraft will addNotification if an error occurs', async () => {
-    const createSubmissionSpy = vi.spyOn(formService, 'createSubmission');
-    const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+    // override default implementations
     createSubmissionSpy.mockImplementationOnce(() => {
       return {
         data: {
@@ -1547,15 +1570,6 @@ describe('FormViewer.vue', () => {
 
   describe('doSubmit', () => {
     it('if it is not a duplicate it will set the submissionRecord to the responses data submission', async () => {
-      const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
-      updateSubmissionSpy.mockImplementationOnce(() => {
-        return {
-          status: 200,
-          data: {
-            submission: { testKey: 'testValue' },
-          },
-        };
-      });
       const wrapper = shallowMount(FormViewer, {
         props: {
           formId: formId,
@@ -1582,7 +1596,7 @@ describe('FormViewer.vue', () => {
       expect(wrapper.vm.submissionRecord).toEqual({ testKey: 'testValue' });
     });
     it('if status code 200 or 201 is not in the response, it will throw an error', async () => {
-      const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+      // override default implementation
       updateSubmissionSpy.mockImplementationOnce(() => {
         return {
           status: 500,
@@ -1608,16 +1622,12 @@ describe('FormViewer.vue', () => {
 
       await flushPromises();
 
-      const consoleErrorSpy = vi.spyOn(console, 'error');
-      consoleErrorSpy.mockImplementationOnce(() => {});
-
       const errMsg = await wrapper.vm.doSubmit({
         data: {
           lateEntry: false,
         },
       });
 
-      expect(consoleErrorSpy).toBeCalledTimes(1);
       expect(errMsg).toEqual('trans.formViewer.errMsg');
     });
   });
@@ -1651,7 +1661,7 @@ describe('FormViewer.vue', () => {
       expect(wrapper.vm.confirmSubmit).toBeFalsy();
     });
     it('if there are no errors it will call the currentForm.events.emit function', async () => {
-      const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+      // override default implementation
       updateSubmissionSpy.mockImplementationOnce(() => {
         return {
           status: 200,
@@ -1692,7 +1702,7 @@ describe('FormViewer.vue', () => {
       expect(emit).toBeCalledTimes(1);
     });
     it('if there are errors it will addNotification', async () => {
-      const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+      // override default implementation
       updateSubmissionSpy.mockImplementationOnce(() => {
         return {
           status: 500,
@@ -1847,7 +1857,7 @@ describe('FormViewer.vue', () => {
   });
 
   it('yes will call saveDraftFromModal', async () => {
-    const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+    // override default implementation
     updateSubmissionSpy.mockImplementationOnce(() => {});
     const wrapper = shallowMount(FormViewer, {
       props: {
@@ -2071,8 +2081,6 @@ describe('FormViewer.vue', () => {
     useRouter.mockImplementationOnce(() => ({
       push,
     }));
-    const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
-    updateSubmissionSpy.mockImplementationOnce(() => {});
     const wrapper = shallowMount(FormViewer, {
       props: {
         formId: formId,
@@ -2102,7 +2110,7 @@ describe('FormViewer.vue', () => {
     useRouter.mockImplementationOnce(() => ({
       push,
     }));
-    const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+    // override default implementation
     updateSubmissionSpy.mockImplementationOnce(() => {
       throw new Error();
     });
@@ -2135,7 +2143,7 @@ describe('FormViewer.vue', () => {
     useRouter.mockImplementationOnce(() => ({
       push,
     }));
-    const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+    // override default implementation
     updateSubmissionSpy.mockImplementationOnce(() => {
       throw new Error();
     });
@@ -2168,7 +2176,7 @@ describe('FormViewer.vue', () => {
     useRouter.mockImplementationOnce(() => ({
       push,
     }));
-    const updateSubmissionSpy = vi.spyOn(formService, 'updateSubmission');
+    // override default implementation
     updateSubmissionSpy.mockImplementationOnce(() => {
       throw new Error();
     });

--- a/app/frontend/tests/unit/components/forms/ExportSubmissions.spec.js
+++ b/app/frontend/tests/unit/components/forms/ExportSubmissions.spec.js
@@ -380,7 +380,7 @@ describe('ExportSubmissions.vue', () => {
     await flushPromises();
 
     const exportSubmissionsSpy = vi.spyOn(formService, 'exportSubmissions');
-    exportSubmissionsSpy.mockImplementationOnce(() => {
+    exportSubmissionsSpy.mockImplementation(() => {
       return {
         data: {
           simpletextfield: 'some data',

--- a/app/frontend/tests/unit/components/forms/manage/DocumentTemplate.spec.js
+++ b/app/frontend/tests/unit/components/forms/manage/DocumentTemplate.spec.js
@@ -1,6 +1,5 @@
 // @vitest-environment happy-dom
-// happy-dom is required to access window.URL
-
+// happy-dom is required to access window.open
 import { createTestingPinia } from '@pinia/testing';
 import { flushPromises, mount } from '@vue/test-utils';
 import moment from 'moment';
@@ -35,31 +34,26 @@ const STUBS = {
 
 describe('DocumentTemplate.vue', () => {
   let router, pinia, formStore, notificationStore, appStore;
-  let createObjectURLSpy = vi.spyOn(window.URL, 'createObjectURL');
+  pinia = createTestingPinia();
+  setActivePinia(pinia);
+
+  router = createRouter({
+    history: createWebHistory(),
+    routes: getRouter().getRoutes(),
+  });
+
+  formStore = useFormStore(pinia);
+  notificationStore = useNotificationStore(pinia);
+  appStore = useAppStore(pinia);
 
   beforeEach(() => {
-    pinia = createTestingPinia();
-    setActivePinia(pinia);
-
-    router = createRouter({
-      history: createWebHistory(),
-      routes: getRouter().getRoutes(),
-    });
-
-    formStore = useFormStore(pinia);
-    notificationStore = useNotificationStore(pinia);
-    appStore = useAppStore(pinia);
-
     formStore.$reset();
     notificationStore.$reset();
     appStore.$reset();
-
-    // Explicitly mock/spy on global functions
-    createObjectURLSpy.mockImplementation(() => '#');
   });
 
-  afterEach(() => {
-    createObjectURLSpy.mockRestore();
+  afterEach(async () => {
+    await flushPromises();
   });
 
   it('calls fetchDocumentTemplates on mount', async () => {
@@ -386,7 +380,7 @@ describe('DocumentTemplate.vue', () => {
       documentTemplateComposables,
       'fetchDocumentTemplates'
     );
-    fetchDocumentTemplatesSpy.mockImplementationOnce(async () => {
+    fetchDocumentTemplatesSpy.mockImplementation(async () => {
       return Array.from(mockDatabase);
     });
     const documentTemplateDeleteSpy = vi.spyOn(
@@ -398,6 +392,7 @@ describe('DocumentTemplate.vue', () => {
         (item) => !(item.formId === formId && item.templateId === templateId)
       );
     });
+
     const wrapper = mount(DocumentTemplate, {
       global: {
         plugins: [router, pinia],
@@ -410,7 +405,9 @@ describe('DocumentTemplate.vue', () => {
     wrapper.vm.documentTemplates = ref(Array.from(mockDatabase));
 
     await wrapper.vm.handleDelete({ templateId: '1' });
+
     await flushPromises();
+
     expect(
       mockDatabase.find((item) => item.templateId === '1')
     ).toBeUndefined();
@@ -484,10 +481,11 @@ describe('DocumentTemplate.vue', () => {
       return '#';
     });
     const addNotificationSpy = vi.spyOn(notificationStore, 'addNotification');
-
     const windowOpenSpy = vi.spyOn(window, 'open');
-    windowOpenSpy.mockImplementation(() => {});
     const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    addNotificationSpy.mockImplementation(() => {});
+    windowOpenSpy.mockImplementation(() => {});
+    appendChildSpy.mockImplementation(() => {});
 
     const wrapper = mount(DocumentTemplate, {
       global: {
@@ -500,6 +498,9 @@ describe('DocumentTemplate.vue', () => {
     windowOpenSpy.mockReset();
     appendChildSpy.mockReset();
     addNotificationSpy.mockReset();
+    addNotificationSpy.mockImplementation(() => {});
+    windowOpenSpy.mockImplementation(() => {});
+    appendChildSpy.mockImplementation(() => {});
 
     wrapper.vm.handleFileAction(
       { templateId: '1', filename: 'filename.txt' },
@@ -518,21 +519,22 @@ describe('DocumentTemplate.vue', () => {
       documentTemplateComposables,
       'fetchDocumentTemplates'
     );
-    fetchDocumentTemplatesSpy.mockImplementationOnce(async () => {
+    fetchDocumentTemplatesSpy.mockImplementation(async () => {
       return [];
     });
     const getDocumentTemplateSpy = vi.spyOn(
       documentTemplateComposables,
       'getDocumentTemplate'
     );
-    getDocumentTemplateSpy.mockImplementationOnce(async () => {
+    getDocumentTemplateSpy.mockImplementation(async () => {
       return '#';
     });
     const addNotificationSpy = vi.spyOn(notificationStore, 'addNotification');
-
     const windowOpenSpy = vi.spyOn(window, 'open');
-    windowOpenSpy.mockImplementation(() => {});
     const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    addNotificationSpy.mockImplementation(() => {});
+    windowOpenSpy.mockImplementation(() => {});
+    appendChildSpy.mockImplementation(() => {});
 
     const wrapper = mount(DocumentTemplate, {
       global: {
@@ -540,17 +542,22 @@ describe('DocumentTemplate.vue', () => {
         stubs: STUBS,
       },
     });
-
     await flushPromises();
     windowOpenSpy.mockReset();
     appendChildSpy.mockReset();
     addNotificationSpy.mockReset();
+    getDocumentTemplateSpy.mockReset();
+    addNotificationSpy.mockImplementation(() => {});
+    windowOpenSpy.mockImplementation(() => {});
+    appendChildSpy.mockImplementation(() => {});
+    getDocumentTemplateSpy.mockImplementation(async () => {
+      return '#';
+    });
 
     wrapper.vm.handleFileAction(
       { templateId: '1', filename: 'filename.txt' },
       'download'
     );
-
     await flushPromises();
 
     expect(windowOpenSpy).toHaveBeenCalledTimes(0);

--- a/app/frontend/tests/unit/components/forms/manage/ManageVersions.spec.js
+++ b/app/frontend/tests/unit/components/forms/manage/ManageVersions.spec.js
@@ -34,11 +34,35 @@ describe('ManageVersions.vue', () => {
   const formStore = useFormStore(pinia);
   const notificationStore = useNotificationStore(pinia);
   const appStore = useAppStore(pinia);
+  const readVersionSpy = vi.spyOn(formService, 'readVersion');
+  const readDraftSpy = vi.spyOn(formService, 'readDraft');
 
   beforeEach(() => {
     formStore.$reset();
     notificationStore.$reset();
     appStore.$reset();
+    readVersionSpy.mockReset();
+    readVersionSpy.mockImplementationOnce(() => {
+      return {
+        data: {
+          schema: {
+            id: '1',
+            projectId: '123',
+          },
+        },
+      };
+    });
+    readDraftSpy.mockReset();
+    readDraftSpy.mockImplementationOnce(() => {
+      return {
+        data: {
+          schema: {
+            id: '1',
+            projectId: '123',
+          },
+        },
+      };
+    });
   });
 
   it('renders', async () => {
@@ -546,28 +570,6 @@ describe('ManageVersions.vue', () => {
 
   it('getFormSchema should set the form schema for a version', async () => {
     const addNotificationSpy = vi.spyOn(notificationStore, 'addNotification');
-    const readVersionSpy = vi.spyOn(formService, 'readVersion');
-    readVersionSpy.mockImplementationOnce(() => {
-      return {
-        data: {
-          schema: {
-            id: '1',
-            projectId: '123',
-          },
-        },
-      };
-    });
-    const readDraftSpy = vi.spyOn(formService, 'readDraft');
-    readDraftSpy.mockImplementationOnce(() => {
-      return {
-        data: {
-          schema: {
-            id: '1',
-            projectId: '123',
-          },
-        },
-      };
-    });
     let VERSION_ONE = {
       version: 1,
       published: true,
@@ -613,28 +615,6 @@ describe('ManageVersions.vue', () => {
 
   it('getFormSchema should set the form schema for a draft', async () => {
     const addNotificationSpy = vi.spyOn(notificationStore, 'addNotification');
-    const readVersionSpy = vi.spyOn(formService, 'readVersion');
-    readVersionSpy.mockImplementationOnce(() => {
-      return {
-        data: {
-          schema: {
-            id: '1',
-            projectId: '123',
-          },
-        },
-      };
-    });
-    const readDraftSpy = vi.spyOn(formService, 'readDraft');
-    readDraftSpy.mockImplementationOnce(() => {
-      return {
-        data: {
-          schema: {
-            id: '1',
-            projectId: '123',
-          },
-        },
-      };
-    });
     let VERSION_ONE = {
       version: 1,
       published: true,

--- a/app/frontend/tests/unit/components/forms/manage/TeamManagement.spec.js
+++ b/app/frontend/tests/unit/components/forms/manage/TeamManagement.spec.js
@@ -293,6 +293,12 @@ describe('TeamManagement.vue', () => {
     notificationStore.$reset();
     fetchFormSpy.mockReset();
     listRolesSpy.mockReset();
+
+    listRolesSpy.mockImplementation(async () => {
+      return {
+        data: ROLES,
+      };
+    });
   });
 
   it('renders', () => {
@@ -311,11 +317,6 @@ describe('TeamManagement.vue', () => {
     });
     getFormPermissionsForUserSpy.mockImplementationOnce(async () => {
       return [FormPermissions.TEAM_UPDATE];
-    });
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
     });
     getFormUsersSpy.mockImplementationOnce(async () => {
       return {
@@ -428,6 +429,15 @@ describe('TeamManagement.vue', () => {
         data: [IDIR_USER],
       };
     });
+
+    // don't include roles in this test, only testing DEFAULT_HEADERS
+    listRolesSpy.mockReset();
+    listRolesSpy.mockImplementationOnce(async () => {
+      return {
+        data: [],
+      };
+    });
+
     const wrapper = shallowMount(TeamManagement, {
       props: {
         formId: formId,
@@ -502,11 +512,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('getFormUsers should throw an error if the user can not manage the team', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [];
     const addNotificationSpy = vi.spyOn(notificationStore, 'addNotification');
     const getFormPermissionsForUserSpy = vi.spyOn(
@@ -624,11 +629,6 @@ describe('TeamManagement.vue', () => {
 
   it('disableRole returns false if the header is not in the IDPs roles', async () => {
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     const idpStoreListRolesSpy = vi.spyOn(idpStore, 'listRoles');
     idpStoreListRolesSpy.mockImplementationOnce(() => {
       return [FormRoleCodes.OWNER];
@@ -704,11 +704,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('setUserForms should addNotification with detailed error if an error is thrown', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
     setUserFormsSpy.mockImplementationOnce(async () => {
@@ -760,11 +755,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('setUserForms should addNotification if an error is thrown', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
     setUserFormsSpy.mockImplementationOnce(async () => {
@@ -879,11 +869,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('addNewUsers will addNotification if user is already in the table', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const getFormUsersSpy = vi.spyOn(rbacService, 'getFormUsers');
     getFormUsersSpy.mockImplementation(async () => {
@@ -920,11 +905,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('addNewUsers will add users to the table if they are not there using roles', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -973,11 +953,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('addNewUsers will add users to the table if they are not there', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1018,11 +993,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('onShowColumnDialog will sort FILTER_HEADERS then set showColumnsDialog to true', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1152,11 +1122,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('onRemoveClick will addNotification if there is only 1 user to remove', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1197,11 +1162,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('onRemoveClick will set itemsToDelete', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1247,11 +1207,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('onRemoveClick will set itemsToDelete to the item', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1295,11 +1250,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('removeUser will call removeMultiUsers, getFormPermissionsForUser', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1343,11 +1293,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('removeUser will addNotification with detailed message if an error occurs', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1399,11 +1344,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('removeUser will addNotification if an error occurs', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
@@ -1449,11 +1389,6 @@ describe('TeamManagement.vue', () => {
   });
 
   it('updateFilter sets filterData and hides the columns dialog', async () => {
-    listRolesSpy.mockImplementationOnce(async () => {
-      return {
-        data: ROLES,
-      };
-    });
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
     idpStore.providers = [IDIR, BCEIDBASIC, BCEIDBUSINESS, PUBLIC];
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');

--- a/app/frontend/tests/unit/components/forms/submission/AuditHistory.spec.js
+++ b/app/frontend/tests/unit/components/forms/submission/AuditHistory.spec.js
@@ -50,7 +50,7 @@ describe('AuditHistory.vue', () => {
     await wrapper.vm.loadHistory();
 
     expect(listSubmissionEditsSpy).toHaveBeenCalledTimes(1);
-    expect(listSubmissionEditsSpy).rejects.toEqual({});
+    await expect(listSubmissionEditsSpy).rejects.toEqual({});
     expect(addNotificationSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/frontend/tests/unit/components/forms/submission/ManageSubmissionUsers.spec.js
+++ b/app/frontend/tests/unit/components/forms/submission/ManageSubmissionUsers.spec.js
@@ -131,9 +131,6 @@ describe('ManageSubmissionUsers.vue', () => {
   });
 
   it('onChangeUserSearchInput should get the userSearchResults', async () => {
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
     const pinia = createTestingPinia({ stubActions: false });
     const idpStore = useIdpStore(pinia);
     setActivePinia(pinia);
@@ -150,24 +147,24 @@ describe('ManageSubmissionUsers.vue', () => {
 
     // no input returns nothing
     wrapper.vm.onChangeUserSearchInput();
+    expect(wrapper.vm.userSearchResults).toEqual([]);
 
-    // errors should be caught and console.error should be called
+    // errors should be caught and swallowed, no results
     getUsersSpy.mockImplementationOnce(async () => {
       throw new Error();
     });
     wrapper.vm.onChangeUserSearchInput('search');
-    await flushPromises();
-    expect(consoleErrorSpy).toHaveBeenCalledExactlyOnceWith(
-      'trans.manageSubmissionUsers.getUsersErrMsg'
-    );
-    consoleErrorSpy.mockReset();
-    getUsersSpy.mockReset();
+    expect(wrapper.vm.userSearchResults).toEqual([]);
 
+    await flushPromises();
+
+    getUsersSpy.mockReset();
     getUsersSpy.mockImplementation(async () => {
       return {
         data: ['something'],
       };
     });
+    wrapper.vm.onChangeUserSearchInput('search');
     expect(wrapper.vm.userSearchResults).toEqual([]);
 
     // idir means no teamMembershipConfig, getUsers should be called with just the search
@@ -186,10 +183,7 @@ describe('ManageSubmissionUsers.vue', () => {
       throw new Error();
     });
     wrapper.vm.onChangeUserSearchInput('jon');
-    expect(consoleErrorSpy).toHaveBeenCalledExactlyOnceWith(
-      'trans.manageSubmissionUsers.getUsersErrMsg'
-    );
-    consoleErrorSpy.mockReset();
+    expect(wrapper.vm.userSearchResults).toEqual([]);
     getUsersSpy.mockReset();
 
     // should throw an error if search input is not a valid email specified by teamMebershipConfig
@@ -197,10 +191,7 @@ describe('ManageSubmissionUsers.vue', () => {
       throw new Error();
     });
     wrapper.vm.onChangeUserSearchInput('john@email.');
-    expect(consoleErrorSpy).toHaveBeenCalledExactlyOnceWith(
-      'trans.manageSubmissionUsers.getUsersErrMsg'
-    );
-    consoleErrorSpy.mockReset();
+    expect(wrapper.vm.userSearchResults).toEqual([]);
     getUsersSpy.mockReset();
 
     // should return email in the params if it is a valid email

--- a/app/frontend/tests/unit/utils/permissionUtils.spec.js
+++ b/app/frontend/tests/unit/utils/permissionUtils.spec.js
@@ -198,6 +198,7 @@ describe('preFlightAuth', () => {
 
       throw error;
     });
+    alertNavigateSpy.mockImplementation(() => {});
 
     await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
 
@@ -223,6 +224,7 @@ describe('preFlightAuth', () => {
 
       throw error;
     });
+    alertNavigateSpy.mockImplementation(() => {});
 
     await permissionUtils.preFlightAuth({ formId: 'f' }, mockNext);
 
@@ -278,6 +280,7 @@ describe('preFlightAuth', () => {
 
       throw error;
     });
+    getSubmissionOptionsSpy.mockImplementation(() => {});
 
     await permissionUtils.preFlightAuth({ submissionId: 's' }, mockNext);
 

--- a/app/frontend/tests/unit/views/form/Create.spec.js
+++ b/app/frontend/tests/unit/views/form/Create.spec.js
@@ -49,6 +49,10 @@ describe('Create.vue', () => {
             name: 'FormSettings',
             template: '<div class="form-settings-stub"><slot /></div>',
           },
+          FormProfile: {
+            name: 'FormProfile',
+            template: '<div class="form-profile-stub"><slot /></div>',
+          },
           BasePanel: {
             name: 'BasePanel',
             template: '<div class="base-panel-stub"><slot /></div>',
@@ -119,6 +123,10 @@ describe('Create.vue', () => {
             name: 'FormSettings',
             template: '<div class="form-settings-stub"><slot /></div>',
           },
+          FormProfile: {
+            name: 'FormProfile',
+            template: '<div class="form-profile-stub"><slot /></div>',
+          },
           BasePanel: {
             name: 'BasePanel',
             template: '<div class="base-panel-stub"><slot /></div>',
@@ -178,6 +186,10 @@ describe('Create.vue', () => {
           FormSettings: {
             name: 'FormSettings',
             template: '<div class="form-settings-stub"><slot /></div>',
+          },
+          FormProfile: {
+            name: 'FormProfile',
+            template: '<div class="form-profile-stub"><slot /></div>',
           },
           BasePanel: {
             name: 'BasePanel',
@@ -243,6 +255,10 @@ describe('Create.vue', () => {
           FormSettings: {
             name: 'FormSettings',
             template: '<div class="form-settings-stub"><slot /></div>',
+          },
+          FormProfile: {
+            name: 'FormProfile',
+            template: '<div class="form-profile-stub"><slot /></div>',
           },
           BasePanel: {
             name: 'BasePanel',


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
FORMS 2091 - a lot of vitests were printing to stderr, a lot of pollution in the logs and this sometimes gave fails when run on openshift. Clean up the `ECONNREFUSED` errs and invalid components. Basically initialize the tested components better and mock implement all api calls in the component. I also removed `console.error` code put in place solely for test conditions. Just test the result.

There is still one I couldn't fix `MultiUpload.spec.js`. `[Vue warn]: onMounted is called when there is no active component instance to be associated with`. This is a weird component that I don't think was updated form Options to Composition API. I think the component itself needs updating, then worry about the test.

There is also a `window.scrollTo` error when running on Openshift. I don't see it locally and there is no information about what test class is causing it. ¯\_(ツ)_/¯


<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
 fix (a bug fix)

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
