### PR TITLE
fix: FORMS-1036 Clear reminder flag when form schedule is removed or disabled

### DIFF
--- a/app/frontend/src/components/designer/settings/FormScheduleSettings.vue
+++ b/app/frontend/src/components/designer/settings/FormScheduleSettings.vue
@@ -201,6 +201,36 @@ watch(
     }
   }
 );
+// Watch for schedule type changes and clear reminder when schedule is removed or set to MANUAL
+watch(
+  () => form.value.schedule.scheduleType,
+  (newValue, oldValue) => {
+    // Only act if there was a previous value (not initial load)
+    if (oldValue !== undefined) {
+      // Clear reminder when schedule type is set to null or MANUAL
+      if (
+        (newValue === null || newValue === SCHEDULE_TYPE.value.MANUAL) &&
+        form.value.reminder_enabled
+      ) {
+        form.value.reminder_enabled = false;
+      }
+    }
+  }
+);
+
+// Watch for schedule being disabled via the enabled flag
+watch(
+  () => form.value.schedule.enabled,
+  (newValue, oldValue) => {
+    // Only act if there was a previous value (not initial load)
+    if (oldValue !== undefined) {
+      // Clear reminder when schedule is disabled
+      if (newValue === false && form.value.reminder_enabled) {
+        form.value.reminder_enabled = false;
+      }
+    }
+  }
+);
 
 defineExpose({
   saveTimezone,


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
Reminder enabled flag is not being cleared when schedule removed

Add
Description

Background: a form can have a submission schedule where it automatically opens, closes, or both. One of the features is that email reminders about these dates can be sent out to submitters.

There’s a bug where the form can have “Forms Submissions Schedule“ enabled, and a schedule set up with email reminders enabled. If the “Forms Submissions Schedule” is then disabled, the schedule is cleared but the email reminders remain enabled. This has uncovered a bug (FORMS-1037) in the backend that it is not handling this inconsistent database state.

Fix the backend in 1037 to handle this inconsistent state

Figure out how to prevent this inconsistent state. One way would be to change the frontend, but should the backend also enforce it (400 error) or silently fix it?

Clean up the databases where this inconsistent state happens.


<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
fix (a bug fix)

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments
Solution
Implemented a two-layer fix:

1. **Frontend**: Added watchers to automatically clear the reminder flag when:
   - Schedule type changes to MANUAL or null
   - Schedule is disabled (enabled = false)

2. **Backend**: Added validation to ensure data integrity:
   - Validates reminder settings against schedule configuration
   - Silently corrects any inconsistent state
   - Prevents reminders from being enabled without a valid schedule
<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
