### PR TITLE
FORMS-2537: move submission notification outside transaction

### DIFF
--- a/app/src/forms/submission/updateService.js
+++ b/app/src/forms/submission/updateService.js
@@ -1,0 +1,107 @@
+const { FileStorage, FormSubmission, FormSubmissionStatus, SubmissionMetadata } = require('../common/models');
+const emailService = require('../email/emailService');
+const eventService = require('../event/eventService');
+const fileService = require('../file/service');
+const log = require('../../components/log')(module.filename);
+
+const { Statuses } = require('../common/constants');
+const { eventStreamService, SUBMISSION_EVENT_TYPES } = require('../../components/eventStreamService');
+
+const service = {
+  _isRestoring: (data) => {
+    return data['deleted'] !== undefined && typeof data.deleted == 'boolean';
+  },
+
+  _restoreSubmission: async (id, data, user, trx) => {
+    await FormSubmission.query(trx).patchAndFetchById(id, { deleted: data.deleted, updatedBy: user.usernameIdp });
+  },
+
+  _getStatuses: async (id) => {
+    return FormSubmissionStatus.query().modify('filterSubmissionId', id).modify('orderDescending');
+  },
+
+  _shouldBlockDraftUpdate: (data, statuses) => {
+    return data.draft && statuses && statuses.length > 0 && (statuses[0].code === Statuses.SUBMITTED || statuses[0].code === Statuses.COMPLETED);
+  },
+
+  _handleStatusChange: async (submissionService, id, data, statuses, user, trx) => {
+    if (!data.draft && (!statuses || !statuses.length || statuses[0].code === Statuses.REVISING)) {
+      await submissionService.changeStatusState(id, { code: Statuses.SUBMITTED }, user, trx);
+      return true;
+    }
+    return false;
+  },
+
+  _patchSubmission: async (id, data, user, trx) => {
+    await FormSubmission.query(trx).patchAndFetchById(id, {
+      draft: data.draft,
+      submission: data.submission,
+      updatedBy: user.usernameIdp,
+    });
+  },
+
+  _handleFileUploads: async (submissionService, data, id, user, trx) => {
+    const fileIds = submissionService._findFileIds(data);
+    for (const fileId of fileIds) {
+      const fileStorage = await fileService.read(fileId);
+      if (!fileStorage.formSubmissionId) {
+        await FileStorage.query(trx).patchAndFetchById(fileId, { formSubmissionId: id, updatedBy: user.usernameIdp });
+        fileService.moveSubmissionFile(id, fileStorage, user.usernameIdp).catch((error) => {
+          log.error('Error moving file', error);
+        });
+      }
+    }
+  },
+
+  _sendNotifications: async (updated, data, referrer, submissionReceived, formSubmissionId) => {
+    await eventStreamService.onSubmit(SUBMISSION_EVENT_TYPES.UPDATED, updated.submission, data.draft);
+    if (submissionReceived) {
+      const submissionMetaData = await SubmissionMetadata.query().where('submissionId', formSubmissionId).first();
+      await emailService.submissionReceived(submissionMetaData.formId, formSubmissionId, data, referrer).catch(() => {});
+      await eventService.formSubmissionEventReceived(submissionMetaData.formId, submissionMetaData.formVersionId, formSubmissionId, data).catch(() => {});
+    }
+  },
+
+  update: async (submissionService, formSubmissionId, data, currentUser, referrer, etrx = undefined) => {
+    let trx;
+    let result;
+    let submissionReceived = false;
+    try {
+      trx = etrx || (await FormSubmissionStatus.startTransaction());
+      log.info(`Starting update for submissionId=${formSubmissionId} by user=${currentUser.usernameIdp}`);
+
+      if (service._isRestoring(data)) {
+        log.info(`Restoring submissionId=${formSubmissionId}`);
+        await service._restoreSubmission(formSubmissionId, data, currentUser, trx);
+      } else {
+        const statuses = await service._getStatuses(formSubmissionId);
+        if (service._shouldBlockDraftUpdate(data, statuses)) {
+          log.info(`Draft update blocked for submissionId=${formSubmissionId} due to status=${statuses[0]?.code}`);
+          return false;
+        }
+        submissionReceived = await service._handleStatusChange(submissionService, formSubmissionId, data, statuses, currentUser, trx);
+        log.info(`Patched submissionId=${formSubmissionId} with new data`);
+        await service._patchSubmission(formSubmissionId, data, currentUser, trx);
+        await service._handleFileUploads(submissionService, data, formSubmissionId, currentUser, trx);
+      }
+
+      if (!etrx) {
+        await trx.commit();
+        log.info(`Transaction committed for submissionId=${formSubmissionId}`);
+      }
+      result = await submissionService.read(formSubmissionId);
+    } catch (err) {
+      if (!etrx && trx) {
+        await trx.rollback();
+        log.error(`Transaction rolled back for submissionId=${formSubmissionId} due to error: ${err.message}`);
+      }
+      throw err;
+    }
+    if (result) {
+      log.info(`Update completed for submissionId=${formSubmissionId}`);
+      await service._sendNotifications(result, data, referrer, submissionReceived, formSubmissionId);
+    }
+    return result;
+  },
+};
+module.exports = service;

--- a/app/tests/unit/forms/submission/updateService.spec.js
+++ b/app/tests/unit/forms/submission/updateService.spec.js
@@ -1,0 +1,354 @@
+const updateService = require('../../../../src/forms/submission/updateService');
+const { Statuses } = require('../../../../src/forms/common/constants');
+
+jest.mock('../../../../src/forms/common/models', () => ({
+  FileStorage: { query: jest.fn() },
+  FormSubmission: { query: jest.fn() },
+  FormSubmissionStatus: { query: jest.fn(), startTransaction: jest.fn() },
+  SubmissionMetadata: { query: jest.fn() },
+}));
+jest.mock('../../../../src/forms/file/service', () => ({
+  read: jest.fn(),
+  moveSubmissionFile: jest.fn(),
+}));
+jest.mock('../../../../src/forms/email/emailService', () => ({
+  submissionReceived: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../../../../src/forms/event/eventService', () => ({
+  formSubmissionEventReceived: jest.fn().mockResolvedValue(),
+}));
+jest.mock('../../../../src/components/eventStreamService', () => ({
+  eventStreamService: { onSubmit: jest.fn() },
+  SUBMISSION_EVENT_TYPES: { UPDATED: 'UPDATED' },
+}));
+jest.mock('../../../../src/components/log', () => () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+}));
+
+describe('updateService', () => {
+  const { FormSubmission, FormSubmissionStatus, SubmissionMetadata } = require('../../../../src/forms/common/models');
+  const emailService = require('../../../../src/forms/email/emailService');
+  const eventService = require('../../../../src/forms/event/eventService');
+  const { eventStreamService } = require('../../../../src/components/eventStreamService');
+
+  let submissionService;
+  let trx;
+
+  beforeEach(() => {
+    submissionService = {
+      changeStatusState: jest.fn(),
+      read: jest.fn(),
+      _findFileIds: jest.fn(),
+    };
+    trx = {};
+    jest.clearAllMocks();
+  });
+
+  describe('_isRestoring', () => {
+    it('returns true if deleted is boolean', () => {
+      expect(updateService._isRestoring({ deleted: true })).toBe(true);
+      expect(updateService._isRestoring({ deleted: false })).toBe(true);
+    });
+    it('returns false if deleted is not boolean', () => {
+      expect(updateService._isRestoring({ deleted: 'yes' })).toBe(false);
+      expect(updateService._isRestoring({})).toBe(false);
+    });
+  });
+
+  describe('_shouldBlockDraftUpdate', () => {
+    it('returns true if draft and status is SUBMITTED', () => {
+      const data = { draft: true };
+      const statuses = [{ code: Statuses.SUBMITTED }];
+      expect(updateService._shouldBlockDraftUpdate(data, statuses)).toBe(true);
+    });
+    it('returns false if not draft', () => {
+      const data = { draft: false };
+      const statuses = [{ code: Statuses.SUBMITTED }];
+      expect(updateService._shouldBlockDraftUpdate(data, statuses)).toBe(false);
+    });
+  });
+
+  describe('_restoreSubmission', () => {
+    it('patches the submission with deleted and updatedBy', async () => {
+      const patchAndFetchById = jest.fn().mockResolvedValue({});
+      FormSubmission.query.mockReturnValue({ patchAndFetchById });
+      const id = 123;
+      const data = { deleted: true };
+      const user = { usernameIdp: 'tester' };
+      const trx = {};
+      await updateService._restoreSubmission(id, data, user, trx);
+      expect(FormSubmission.query).toHaveBeenCalledWith(trx);
+      expect(patchAndFetchById).toHaveBeenCalledWith(id, { deleted: true, updatedBy: 'tester' });
+    });
+  });
+
+  describe('_getStatuses', () => {
+    it('returns statuses with correct modifiers', async () => {
+      const modify = jest.fn().mockReturnThis();
+      FormSubmissionStatus.query.mockReturnValue({ modify });
+      const id = 456;
+      await updateService._getStatuses(id);
+      expect(FormSubmissionStatus.query).toHaveBeenCalled();
+      expect(modify).toHaveBeenCalledWith('filterSubmissionId', id);
+      expect(modify).toHaveBeenCalledWith('orderDescending');
+    });
+  });
+
+  describe('_handleStatusChange', () => {
+    it('calls changeStatusState and returns true if not draft and no statuses', async () => {
+      const submissionService = { changeStatusState: jest.fn().mockResolvedValue() };
+      const id = 789;
+      const data = { draft: false };
+      const statuses = [];
+      const user = { usernameIdp: 'tester' };
+      const trx = {};
+      const result = await updateService._handleStatusChange(submissionService, id, data, statuses, user, trx);
+      expect(submissionService.changeStatusState).toHaveBeenCalledWith(id, { code: Statuses.SUBMITTED }, user, trx);
+      expect(result).toBe(true);
+    });
+
+    it('returns false if draft is true', async () => {
+      const submissionService = { changeStatusState: jest.fn() };
+      const result = await updateService._handleStatusChange(submissionService, 1, { draft: true }, [], {}, {});
+      expect(submissionService.changeStatusState).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('returns false if statuses[0].code is not REVISING', async () => {
+      const submissionService = { changeStatusState: jest.fn() };
+      const statuses = [{ code: Statuses.SUBMITTED }];
+      const result = await updateService._handleStatusChange(submissionService, 1, { draft: false }, statuses, {}, {});
+      expect(submissionService.changeStatusState).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('_sendNotifications', () => {
+    it('calls eventStreamService.onSubmit and does not send emails/events if submissionReceived is false', async () => {
+      emailService.submissionReceived = jest.fn().mockResolvedValue();
+      eventService.formSubmissionEventReceived = jest.fn().mockResolvedValue();
+      const updated = { submission: { foo: 'bar' } };
+      const data = { draft: false };
+      const referrer = 'ref';
+      const submissionReceived = false;
+      const formSubmissionId = 1;
+      await updateService._sendNotifications(updated, data, referrer, submissionReceived, formSubmissionId);
+      expect(eventStreamService.onSubmit).toHaveBeenCalledWith('UPDATED', updated.submission, false);
+      expect(emailService.submissionReceived).not.toHaveBeenCalled();
+      expect(eventService.formSubmissionEventReceived).not.toHaveBeenCalled();
+    });
+
+    it('calls eventStreamService.onSubmit and sends emails/events if submissionReceived is true', async () => {
+      emailService.submissionReceived = jest.fn().mockResolvedValue();
+      eventService.formSubmissionEventReceived = jest.fn().mockResolvedValue();
+      const updated = { submission: { foo: 'bar' } };
+      const data = { draft: false };
+      const referrer = 'ref';
+      const submissionReceived = true;
+      const formSubmissionId = 2;
+      const submissionMetaData = { formId: 'f1', formVersionId: 'v1' };
+      SubmissionMetadata.query.mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        first: jest.fn().mockResolvedValue(submissionMetaData),
+      });
+      await updateService._sendNotifications(updated, data, referrer, submissionReceived, formSubmissionId);
+      expect(eventStreamService.onSubmit).toHaveBeenCalledWith('UPDATED', updated.submission, false);
+      expect(emailService.submissionReceived).toHaveBeenCalledWith('f1', formSubmissionId, data, referrer);
+      expect(eventService.formSubmissionEventReceived).toHaveBeenCalledWith('f1', 'v1', formSubmissionId, data);
+    });
+  });
+
+  describe('_patchSubmission', () => {
+    it('patches the submission with draft, submission, and updatedBy', async () => {
+      const patchAndFetchById = jest.fn().mockResolvedValue({});
+      FormSubmission.query.mockReturnValue({ patchAndFetchById });
+      const id = 321;
+      const data = { draft: true, submission: { foo: 'bar' } };
+      const user = { usernameIdp: 'patcher' };
+      const trx = {};
+      await updateService._patchSubmission(id, data, user, trx);
+      expect(FormSubmission.query).toHaveBeenCalledWith(trx);
+      expect(patchAndFetchById).toHaveBeenCalledWith(id, {
+        draft: true,
+        submission: { foo: 'bar' },
+        updatedBy: 'patcher',
+      });
+    });
+  });
+
+  describe('_handleFileUploads', () => {
+    const fileService = require('../../../../src/forms/file/service');
+    const { FileStorage } = require('../../../../src/forms/common/models');
+
+    it('patches and moves files that are not already linked', async () => {
+      const fileIds = ['f1', 'f2'];
+      const data = {};
+      const id = 555;
+      const user = { usernameIdp: 'uploader' };
+      const trx = {};
+
+      // Mock submissionService._findFileIds to return fileIds
+      const submissionService = {
+        _findFileIds: jest.fn().mockReturnValue(fileIds),
+      };
+
+      // Mock fileService.read to return fileStorage objects
+      fileService.read.mockImplementation((fileId) => Promise.resolve({ id: fileId, formSubmissionId: null }));
+
+      // Mock FileStorage.query().patchAndFetchById
+      const patchAndFetchById = jest.fn().mockResolvedValue({});
+      FileStorage.query.mockReturnValue({ patchAndFetchById });
+
+      // Mock fileService.moveSubmissionFile
+      fileService.moveSubmissionFile.mockResolvedValue();
+
+      await updateService._handleFileUploads(submissionService, data, id, user, trx);
+
+      expect(submissionService._findFileIds).toHaveBeenCalledWith(data);
+      expect(fileService.read).toHaveBeenCalledTimes(fileIds.length);
+      expect(patchAndFetchById).toHaveBeenCalledTimes(fileIds.length);
+      expect(fileService.moveSubmissionFile).toHaveBeenCalledTimes(fileIds.length);
+      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f1', formSubmissionId: null }, 'uploader');
+      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f2', formSubmissionId: null }, 'uploader');
+    });
+
+    it('does not patch or move files already linked to a submission', async () => {
+      const fileIds = ['f3'];
+      const data = {};
+      const id = 556;
+      const user = { usernameIdp: 'uploader' };
+      const trx = {};
+
+      const submissionService = {
+        _findFileIds: jest.fn().mockReturnValue(fileIds),
+      };
+
+      fileService.read.mockResolvedValue({ id: 'f3', formSubmissionId: 556 });
+      const patchAndFetchById = jest.fn();
+      FileStorage.query.mockReturnValue({ patchAndFetchById });
+      fileService.moveSubmissionFile.mockResolvedValue();
+
+      await updateService._handleFileUploads(submissionService, data, id, user, trx);
+
+      expect(patchAndFetchById).not.toHaveBeenCalled();
+      expect(fileService.moveSubmissionFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('restores submission if _isRestoring is true', async () => {
+      const data = { deleted: true };
+      updateService._isRestoring = jest.fn().mockReturnValue(true);
+      updateService._restoreSubmission = jest.fn();
+      submissionService.read = jest.fn().mockResolvedValue({});
+
+      await updateService.update(submissionService, 1, data, { usernameIdp: 'user' }, null, trx);
+
+      expect(updateService._restoreSubmission).toHaveBeenCalled();
+    });
+
+    it('returns false if _shouldBlockDraftUpdate is true', async () => {
+      updateService._isRestoring = jest.fn().mockReturnValue(false);
+      updateService._getStatuses = jest.fn().mockResolvedValue([{ code: Statuses.SUBMITTED }]);
+      updateService._shouldBlockDraftUpdate = jest.fn().mockReturnValue(true);
+
+      const result = await updateService.update(submissionService, 1, { draft: true }, { usernameIdp: 'user' }, null, trx);
+
+      expect(result).toBe(false);
+    });
+
+    it('calls status change, patch, file uploads, notifications', async () => {
+      updateService._isRestoring = jest.fn().mockReturnValue(false);
+      updateService._getStatuses = jest.fn().mockResolvedValue([]);
+      updateService._shouldBlockDraftUpdate = jest.fn().mockReturnValue(false);
+      updateService._handleStatusChange = jest.fn().mockResolvedValue(true);
+      updateService._patchSubmission = jest.fn();
+      updateService._handleFileUploads = jest.fn();
+      submissionService.read = jest.fn().mockResolvedValue({ submission: {}, id: 1 });
+      updateService._sendNotifications = jest.fn();
+
+      await updateService.update(submissionService, 1, {}, { usernameIdp: 'user' }, null, trx);
+
+      expect(updateService._handleStatusChange).toHaveBeenCalled();
+      expect(updateService._patchSubmission).toHaveBeenCalled();
+      expect(updateService._handleFileUploads).toHaveBeenCalled();
+      expect(updateService._sendNotifications).toHaveBeenCalled();
+    });
+
+    it('does not commit or rollback external transaction on successful update', async () => {
+      const fakeTrx = { commit: jest.fn(), rollback: jest.fn() };
+
+      // Set up all helpers to succeed
+      updateService._isRestoring = jest.fn().mockReturnValue(true);
+      updateService._restoreSubmission = jest.fn().mockResolvedValue();
+      const expectedResult = { id: 1 };
+      const submissionService = { read: jest.fn().mockResolvedValue(expectedResult) };
+
+      const result = await updateService.update(submissionService, 1, { deleted: true }, { usernameIdp: 'user' }, null, fakeTrx);
+
+      expect(fakeTrx.commit).not.toHaveBeenCalled();
+      expect(fakeTrx.rollback).not.toHaveBeenCalled();
+      expect(result).toBe(expectedResult);
+    });
+
+    it('does not rollback external transaction on failed update', async () => {
+      updateService._isRestoring = jest.fn().mockReturnValue(true);
+      updateService._restoreSubmission = jest.fn().mockRejectedValue(new Error('fail'));
+      const fakeTrx = { rollback: jest.fn() };
+
+      await expect(updateService.update(submissionService, 1, { deleted: true }, { usernameIdp: 'user' }, null, fakeTrx)).rejects.toThrow('fail');
+      // Should NOT call rollback on external transaction
+      expect(fakeTrx.rollback).not.toHaveBeenCalled();
+    });
+
+    it('internal transaction commits if update succeeds', async () => {
+      // Mock the transaction object with commit
+      const mockRollback = jest.fn();
+      const mockCommit = jest.fn();
+      const mockTrx = { rollback: mockRollback, commit: mockCommit };
+
+      // Mock FormSubmissionStatus.startTransaction to return our mockTrx
+      const startTransactionSpy = jest.spyOn(require('../../../../src/forms/common/models').FormSubmissionStatus, 'startTransaction').mockResolvedValue(mockTrx);
+
+      // Set up all helpers to succeed
+      updateService._isRestoring = jest.fn().mockReturnValue(true);
+      updateService._restoreSubmission = jest.fn().mockResolvedValue();
+      // Simulate a successful read
+      const expectedResult = { id: 1 };
+      const submissionService = { read: jest.fn().mockResolvedValue(expectedResult) };
+
+      const result = await updateService.update(submissionService, 1, { deleted: true }, { usernameIdp: 'user' }, null);
+
+      expect(startTransactionSpy).toHaveBeenCalled();
+      expect(mockCommit).toHaveBeenCalled();
+      expect(result).toBe(expectedResult);
+
+      // Clean up
+      startTransactionSpy.mockRestore();
+    });
+
+    it('internal transaction rolled back on error', async () => {
+      // Mock the transaction object with rollback
+      const mockRollback = jest.fn();
+      const mockCommit = jest.fn();
+      const mockTrx = { rollback: mockRollback, commit: mockCommit };
+
+      // Mock FormSubmissionStatus.startTransaction to return our mockTrx
+      const startTransactionSpy = jest.spyOn(require('../../../../src/forms/common/models').FormSubmissionStatus, 'startTransaction').mockResolvedValue(mockTrx);
+
+      // Force an error in the update flow
+      updateService._isRestoring = jest.fn().mockReturnValue(true);
+      updateService._restoreSubmission = jest.fn().mockRejectedValue(new Error('fail'));
+
+      await expect(updateService.update(submissionService, 1, { deleted: true }, { usernameIdp: 'user' }, null)).rejects.toThrow('fail');
+
+      // Ensure internal transaction was started and rollback was called
+      expect(startTransactionSpy).toHaveBeenCalled();
+      expect(mockRollback).toHaveBeenCalled();
+
+      // Clean up
+      startTransactionSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
We had a case where a user submitted their draft, the browser appeared to spin and never return. The staff got a Submission Received email notification with a link to that submission. However, that transaction failed (error not returned to browser? that is unclear), leaving the submission in draft state. Which meant that when staff clicked the link to view the submission they got an error that the submission could not be loaded. The submission was also not in their table of submissions to review (as it was still in draft).

It appears that the transaction was rolled back, but we had the notification logic inside the transaction; can't rollback the email notification.

So this PR is to refactor the update logic (it is gnarly) and move notifications outside the transaction. If the update is successful, then we want to send out notifcations (event stream, event webhooks, emails).

The logic for the update method was intense, I refactored it to its own file for clarity and testing.

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
fix (a bug fix)

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
test (add missing tests or correct existing tests)

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
