### PR TITLE
Set the form default access to login

### DIFF
--- a/app/frontend/src/store/form.js
+++ b/app/frontend/src/store/form.js
@@ -84,7 +84,7 @@ const genInitialForm = () => ({
   reminder_enabled: false,
   schedule: genInitialSchedule(),
   subscribe: genInitialSubscribe(),
-  userType: IdentityMode.TEAM,
+  userType: IdentityMode.LOGIN,
   versions: [],
   enableCopyExistingSubmission: false,
   enableTeamMemberDraftShare: false,

--- a/app/frontend/tests/unit/components/forms/manage/TeamManagement.spec.js
+++ b/app/frontend/tests/unit/components/forms/manage/TeamManagement.spec.js
@@ -282,7 +282,6 @@ describe('TeamManagement.vue', () => {
   const idpStore = useIdpStore(pinia);
   const notificationStore = useNotificationStore(pinia);
   const appStore = useAppStore(pinia);
-  const fetchFormSpy = vi.spyOn(formStore, 'fetchForm');
   const listRolesSpy = vi.spyOn(roleService, 'list');
 
   beforeEach(() => {
@@ -291,7 +290,6 @@ describe('TeamManagement.vue', () => {
     idpStore.$reset();
     appStore.$reset();
     notificationStore.$reset();
-    fetchFormSpy.mockReset();
     listRolesSpy.mockReset();
 
     listRolesSpy.mockImplementation(async () => {
@@ -309,12 +307,7 @@ describe('TeamManagement.vue', () => {
     const getFormUsersSpy = vi.spyOn(rbacService, 'getFormUsers');
     const setUserFormsSpy = vi.spyOn(rbacService, 'setUserForms');
     const removeMultiUsersSpy = vi.spyOn(rbacService, 'removeMultiUsers');
-    fetchFormSpy.mockImplementationOnce(async () => {
-      return {
-        name: 'This is a form name',
-        userType: 'team',
-      };
-    });
+
     getFormPermissionsForUserSpy.mockImplementationOnce(async () => {
       return [FormPermissions.TEAM_UPDATE];
     });
@@ -341,6 +334,7 @@ describe('TeamManagement.vue', () => {
 
     expect(wrapper.text()).toContain('trans.teamManagement.teamManagement');
     expect(wrapper.text()).toContain(formStore.form.name);
+    expect(wrapper.text()).toContain('This is a form title');
   });
 
   it('DeleteMessage returns delSelectedMembersWarning if there is at least 2 items to delete otherwise it returns delSelectedMemberWarning', async () => {
@@ -1012,6 +1006,7 @@ describe('TeamManagement.vue', () => {
     });
 
     formStore.permissions = [FormPermissions.TEAM_UPDATE];
+    formStore.form = { userType: 'team' };
     const wrapper = shallowMount(TeamManagement, {
       props: {
         formId: formId,


### PR DESCRIPTION
This is the most common type of form, so makes sense to make this the default. They still must choose the providers.

<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
