### PR TITLE
feat: Add API access check to submission notes route

### DIFF
--- a/app/src/docs/v1.api-spec.yaml
+++ b/app/src/docs/v1.api-spec.yaml
@@ -1968,6 +1968,10 @@ paths:
     get:
       summary: Get the list of notes for a submission
       operationId: readSubmissioNotes
+      security:
+        - BasicAuth: []
+        - BearerAuth: []
+          OpenID: []
       tags:
         - Status
       parameters:

--- a/app/src/forms/submission/routes.js
+++ b/app/src/forms/submission/routes.js
@@ -36,7 +36,7 @@ routes.get('/:formSubmissionId/options', async (req, res, next) => {
   await controller.readOptions(req, res, next);
 });
 
-routes.get('/:formSubmissionId/notes', hasSubmissionPermissions([P.SUBMISSION_REVIEW]), async (req, res, next) => {
+routes.get('/:formSubmissionId/notes', apiAccess, hasSubmissionPermissions([P.SUBMISSION_REVIEW]), async (req, res, next) => {
   await controller.getNotes(req, res, next);
 });
 

--- a/app/tests/unit/forms/submission/routes.spec.js
+++ b/app/tests/unit/forms/submission/routes.spec.js
@@ -220,7 +220,7 @@ describe(`${basePath}/:formSubmissionId/notes`, () => {
 
     await appRequest.get(path);
 
-    expect(apiAccess).toBeCalledTimes(0);
+    expect(apiAccess).toBeCalledTimes(1);
     expect(controller.getNotes).toBeCalledTimes(1);
     expect(hasSubmissionPermissionsMock).toBeCalledTimes(1);
     expect(userAccess.currentUser).toBeCalledTimes(1);


### PR DESCRIPTION

<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
The GET /:formSubmissionId/notes route now requires apiAccess middleware in addition to submission review permissions. Updated the OpenAPI spec to reflect new security requirements and adjusted unit tests to expect the apiAccess check.

Reference:
https://citz-do.atlassian.net/browse/FORMS-2667

https://chefs-fider.apps.silver.devops.gov.bc.ca/posts/228/enable-basic-auth-support-for-notes-api-submissions-formsubmissionid-notes
<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

feat (a new feature)
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
docs (change to documentation)
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
