### PR TITLE
FORMS-2649 - embeddable web component

### DIFF
--- a/app/src/webcomponents/v1/assets/assetRouteUtils.js
+++ b/app/src/webcomponents/v1/assets/assetRouteUtils.js
@@ -1,0 +1,47 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const config = require('config');
+
+// Resolve asset roots from config
+const assetRoots = (() => {
+  const hasRoots = typeof config.has === 'function' && config.has('webcomponents.assets.roots');
+  const raw = hasRoots ? config.get('webcomponents.assets.roots') : [];
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string' && raw.trim().length) {
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+})();
+
+function trySend(res, filePath, contentType) {
+  if (fs.existsSync(filePath)) {
+    if (contentType) res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    fs.createReadStream(filePath).pipe(res);
+    return true;
+  }
+  return false;
+}
+
+function createAssetRoute(relPath, contentType, errorMessage, roots = assetRoots) {
+  return async (_req, res, next) => {
+    try {
+      for (const root of roots) {
+        const p = path.join(root, relPath);
+        if (trySend(res, p, contentType)) return;
+      }
+      res.status(404).json({ detail: errorMessage });
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+module.exports = {
+  assetRoots,
+  trySend,
+  createAssetRoute,
+};

--- a/app/src/webcomponents/v1/assets/routes.js
+++ b/app/src/webcomponents/v1/assets/routes.js
@@ -2,106 +2,25 @@ const routes = require('express').Router();
 const fs = require('node:fs');
 const path = require('node:path');
 const cors = require('cors');
-const config = require('config');
 
 const originAccess = require('../../common/middleware/originAccess');
-
-// Resolve asset roots from config
-const assetRoots = (() => {
-  const hasRoots = typeof config.has === 'function' && config.has('webcomponents.assets.roots');
-  const raw = hasRoots ? config.get('webcomponents.assets.roots') : [];
-  if (Array.isArray(raw)) return raw;
-  if (typeof raw === 'string' && raw.trim().length) {
-    return raw
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-  }
-  return [];
-})();
-
-function trySend(res, filePath, contentType) {
-  if (fs.existsSync(filePath)) {
-    if (contentType) res.setHeader('Content-Type', contentType);
-    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-    fs.createReadStream(filePath).pipe(res);
-    return true;
-  }
-  return false;
-}
+const { assetRoots, createAssetRoute } = require('./assetRouteUtils');
 
 // CHEFS CSS assets for embed components
-// GET /webcomponents/v1/assets/chefs-index.css
-routes.get('/chefs-index.css', cors(), originAccess, async (_req, res, next) => {
-  try {
-    const rel = 'vendor/chefs/chefs-index.css';
-    for (const root of assetRoots) {
-      const p = path.join(root, rel);
-      if (trySend(res, p, 'text/css')) return;
-    }
-    res.status(404).json({ detail: 'CHEFS index CSS not found' });
-  } catch (err) {
-    next(err);
-  }
-});
-
-// GET /webcomponents/v1/assets/chefs-theme.css
-routes.get('/chefs-theme.css', cors(), originAccess, async (_req, res, next) => {
-  try {
-    const rel = 'vendor/chefs/chefs-theme.css';
-    for (const root of assetRoots) {
-      const p = path.join(root, rel);
-      if (trySend(res, p, 'text/css')) return;
-    }
-    res.status(404).json({ detail: 'CHEFS theme CSS not found' });
-  } catch (err) {
-    next(err);
-  }
-});
+routes.get('/chefs-index.css', cors(), originAccess, createAssetRoute('vendor/chefs/chefs-index.css', 'text/css', 'CHEFS index CSS not found'));
+routes.get('/chefs-theme.css', cors(), originAccess, createAssetRoute('vendor/chefs/chefs-theme.css', 'text/css', 'CHEFS theme CSS not found'));
 
 // Form.io assets
-// GET /webcomponents/v1/assets/formio.js
-routes.get('/formio.js', cors(), originAccess, async (_req, res, next) => {
-  try {
-    const rel = 'vendor/formiojs/dist/formio.full.min.js';
-    for (const root of assetRoots) {
-      const p = path.join(root, rel);
-      if (trySend(res, p, 'application/javascript')) return;
-    }
-    res.status(404).json({ detail: 'Form.io asset not found' });
-  } catch (err) {
-    next(err);
-  }
-});
-
-// GET /webcomponents/v1/assets/formio.css
-routes.get('/formio.css', cors(), originAccess, async (_req, res, next) => {
-  try {
-    const rel = 'vendor/formiojs/dist/formio.full.min.css';
-    for (const root of assetRoots) {
-      const p = path.join(root, rel);
-      if (trySend(res, p, 'text/css')) return;
-    }
-    res.status(404).json({ detail: 'Form.io CSS not found' });
-  } catch (err) {
-    next(err);
-  }
-});
+routes.get('/formio.js', cors(), originAccess, createAssetRoute('vendor/formiojs/dist/formio.full.min.js', 'application/javascript', 'Form.io asset not found'));
+routes.get('/formio.css', cors(), originAccess, createAssetRoute('vendor/formiojs/dist/formio.full.min.css', 'text/css', 'Form.io CSS not found'));
 
 // Font Awesome 4.7 assets for Shadow DOM compatibility
-// GET /webcomponents/v1/assets/font-awesome/css/font-awesome.min.css
-routes.get('/font-awesome/css/font-awesome.min.css', cors(), originAccess, async (_req, res, next) => {
-  try {
-    const rel = 'vendor/font-awesome/css/font-awesome.min.css';
-    for (const root of assetRoots) {
-      const p = path.join(root, rel);
-      if (trySend(res, p, 'text/css')) return;
-    }
-    res.status(404).json({ detail: 'Font Awesome CSS not found' });
-  } catch (err) {
-    next(err);
-  }
-});
+routes.get(
+  '/font-awesome/css/font-awesome.min.css',
+  cors(),
+  originAccess,
+  createAssetRoute('vendor/font-awesome/css/font-awesome.min.css', 'text/css', 'Font Awesome CSS not found')
+);
 
 // GET /webcomponents/v1/assets/font-awesome/fonts/:file
 routes.get('/font-awesome/fonts/:file', cors(), originAccess, async (req, res, next) => {

--- a/app/tests/unit/webcomponents/v1/assets/assetRouteUtils.spec.js
+++ b/app/tests/unit/webcomponents/v1/assets/assetRouteUtils.spec.js
@@ -1,0 +1,242 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+jest.mock('node:fs');
+jest.mock('node:path');
+
+// Mock config with a factory function
+const mockConfig = {
+  has: jest.fn(),
+  get: jest.fn(),
+};
+
+jest.mock('config', () => mockConfig);
+
+const MODULE_PATH = '../../../../../src/webcomponents/v1/assets/assetRouteUtils';
+const { trySend, createAssetRoute } = require(MODULE_PATH);
+
+describe('assetRouteUtils', () => {
+  let mockRes;
+  let mockNext;
+
+  beforeEach(() => {
+    mockRes = {
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    mockNext = jest.fn();
+
+    // Mock path.join to return predictable paths
+    path.join.mockImplementation((...args) => args.join('/'));
+
+    jest.clearAllMocks();
+  });
+
+  describe('assetRoots', () => {
+    it('should return empty array when config has no roots', () => {
+      mockConfig.has.mockReturnValue(false);
+
+      // Re-require to get fresh assetRoots
+      jest.resetModules();
+      const { assetRoots: freshAssetRoots } = require(MODULE_PATH);
+
+      expect(freshAssetRoots).toEqual([]);
+    });
+
+    it('should return array when config has array roots', () => {
+      const roots = ['/path1', '/path2'];
+      mockConfig.has.mockReturnValue(true);
+      mockConfig.get.mockReturnValue(roots);
+
+      jest.resetModules();
+      const { assetRoots: freshAssetRoots } = require(MODULE_PATH);
+
+      expect(freshAssetRoots).toEqual(roots);
+    });
+
+    it('should parse comma-separated string roots', () => {
+      const rootsString = '/path1, /path2 , /path3';
+      const expected = ['/path1', '/path2', '/path3'];
+      mockConfig.has.mockReturnValue(true);
+      mockConfig.get.mockReturnValue(rootsString);
+
+      jest.resetModules();
+      const { assetRoots: freshAssetRoots } = require(MODULE_PATH);
+
+      expect(freshAssetRoots).toEqual(expected);
+    });
+
+    it('should filter empty strings from comma-separated roots', () => {
+      const rootsString = '/path1, , /path2,';
+      const expected = ['/path1', '/path2'];
+      mockConfig.has.mockReturnValue(true);
+      mockConfig.get.mockReturnValue(rootsString);
+
+      jest.resetModules();
+      const { assetRoots: freshAssetRoots } = require(MODULE_PATH);
+
+      expect(freshAssetRoots).toEqual(expected);
+    });
+
+    it('should return empty array for empty string', () => {
+      mockConfig.has.mockReturnValue(true);
+      mockConfig.get.mockReturnValue('');
+
+      jest.resetModules();
+      const { assetRoots: freshAssetRoots } = require(MODULE_PATH);
+
+      expect(freshAssetRoots).toEqual([]);
+    });
+  });
+
+  describe('trySend', () => {
+    it('should send file when it exists', () => {
+      const filePath = '/test/file.css';
+      const contentType = 'text/css';
+      const mockStream = { pipe: jest.fn() };
+
+      fs.existsSync.mockReturnValue(true);
+      fs.createReadStream.mockReturnValue(mockStream);
+
+      const result = trySend(mockRes, filePath, contentType);
+
+      expect(result).toBe(true);
+      expect(fs.existsSync).toHaveBeenCalledWith(filePath);
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', contentType);
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=31536000, immutable');
+      expect(fs.createReadStream).toHaveBeenCalledWith(filePath);
+      expect(mockStream.pipe).toHaveBeenCalledWith(mockRes);
+    });
+
+    it('should not set content type when not provided', () => {
+      const filePath = '/test/file.css';
+      const mockStream = { pipe: jest.fn() };
+
+      fs.existsSync.mockReturnValue(true);
+      fs.createReadStream.mockReturnValue(mockStream);
+
+      trySend(mockRes, filePath);
+
+      expect(mockRes.setHeader).not.toHaveBeenCalledWith('Content-Type', expect.any(String));
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=31536000, immutable');
+    });
+
+    it('should return false when file does not exist', () => {
+      const filePath = '/test/nonexistent.css';
+
+      fs.existsSync.mockReturnValue(false);
+
+      const result = trySend(mockRes, filePath, 'text/css');
+
+      expect(result).toBe(false);
+      expect(fs.existsSync).toHaveBeenCalledWith(filePath);
+      expect(mockRes.setHeader).not.toHaveBeenCalled();
+      expect(fs.createReadStream).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createAssetRoute', () => {
+    it('should return a function', () => {
+      const route = createAssetRoute('test.css', 'text/css', 'Not found');
+      expect(typeof route).toBe('function');
+    });
+
+    it('should send file when found in first root', async () => {
+      const relPath = 'vendor/test.css';
+      const contentType = 'text/css';
+      const errorMessage = 'Not found';
+      const mockStream = { pipe: jest.fn() };
+      const testRoots = ['/root1', '/root2'];
+
+      // Mock file exists and stream
+      fs.existsSync.mockImplementation((path) => path === '/root1/vendor/test.css');
+      fs.createReadStream.mockReturnValue(mockStream);
+
+      const route = createAssetRoute(relPath, contentType, errorMessage, testRoots);
+      await route({}, mockRes, mockNext);
+
+      // Test the behavior - file was sent successfully
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', contentType);
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=31536000, immutable');
+      expect(mockStream.pipe).toHaveBeenCalledWith(mockRes);
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should try multiple roots until file is found', async () => {
+      const relPath = 'vendor/test.css';
+      const contentType = 'text/css';
+      const errorMessage = 'Not found';
+      const mockStream = { pipe: jest.fn() };
+      const testRoots = ['/root1', '/root2', '/root3'];
+
+      // Mock file exists in second root
+      fs.existsSync.mockImplementation((path) => path === '/root2/vendor/test.css');
+      fs.createReadStream.mockReturnValue(mockStream);
+
+      const route = createAssetRoute(relPath, contentType, errorMessage, testRoots);
+      await route({}, mockRes, mockNext);
+
+      // Test the behavior - file was found in second root
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', contentType);
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=31536000, immutable');
+      expect(mockStream.pipe).toHaveBeenCalledWith(mockRes);
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when file not found in any root', async () => {
+      const relPath = 'vendor/nonexistent.css';
+      const contentType = 'text/css';
+      const errorMessage = 'File not found';
+      const testRoots = ['/root1', '/root2'];
+
+      // Mock file does not exist
+      fs.existsSync.mockReturnValue(false);
+
+      const route = createAssetRoute(relPath, contentType, errorMessage, testRoots);
+      await route({}, mockRes, mockNext);
+
+      // Test the behavior - 404 response
+      expect(mockRes.status).toHaveBeenCalledWith(404);
+      expect(mockRes.json).toHaveBeenCalledWith({ detail: errorMessage });
+      expect(mockRes.setHeader).not.toHaveBeenCalled();
+    });
+
+    it('should call next with error when exception occurs', async () => {
+      const relPath = 'vendor/test.css';
+      const contentType = 'text/css';
+      const errorMessage = 'Not found';
+      const testError = new Error('Test error');
+      const testRoots = ['/root1'];
+
+      // Mock fs.existsSync to throw error
+      fs.existsSync.mockImplementation(() => {
+        throw testError;
+      });
+
+      const route = createAssetRoute(relPath, contentType, errorMessage, testRoots);
+      await route({}, mockRes, mockNext);
+
+      // Test the behavior - error passed to next
+      expect(mockNext).toHaveBeenCalledWith(testError);
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should not set content type when not provided', async () => {
+      const relPath = 'vendor/test.css';
+      const errorMessage = 'Not found';
+      const mockStream = { pipe: jest.fn() };
+      const testRoots = ['/root1'];
+
+      fs.existsSync.mockReturnValue(true);
+      fs.createReadStream.mockReturnValue(mockStream);
+
+      const route = createAssetRoute(relPath, null, errorMessage, testRoots);
+      await route({}, mockRes, mockNext);
+
+      // Test the behavior - no content type set
+      expect(mockRes.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=31536000, immutable');
+      expect(mockRes.setHeader).not.toHaveBeenCalledWith('Content-Type', expect.any(String));
+    });
+  });
+});

--- a/components/src/components/Common/ShadowDOMAddressComponent.ts
+++ b/components/src/components/Common/ShadowDOMAddressComponent.ts
@@ -172,7 +172,7 @@ export abstract class ShadowDOMAddressComponent extends ParentComponent {
           container.className = 'autocomplete-suggestions';
           container.style.cssText =
             'position: absolute; z-index: 1000; top: 0; left: 0;';
-          container.setAttribute('data-shadow-dom-autocomplete', 'true');
+          container.dataset.shadowDomAutocomplete = 'true';
           permanentContainer.appendChild(container);
         }
 
@@ -269,7 +269,7 @@ export abstract class ShadowDOMAddressComponent extends ParentComponent {
       // If this autocompleter wasn't in our pre-creation snapshot, it's new
       if (
         !existingAutocompleters.has(el) &&
-        !el.hasAttribute('data-shadow-dom-autocomplete')
+        !(el as HTMLElement).dataset.shadowDomAutocomplete
       ) {
         el.remove();
       }


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
This covers a lot of JIRA Tickets under FORMS-2649 epic.
FORMS-2655 - token and user objects
FORMS-2659 - CHEFS Form Viewer embeddable Web Component
FORMS-2660 - Embed in JS/HTML example
FORMS-2662 - Backend for CHEFS Form Viewer support.
FORMS-2738 - Provide mechanism for Embedding to not require the API Key from browser

Almost all of this is completely isolated from CHEFS Core, except changes to the Dockerfile to build/minify the web component and ensure that we have all the support resources (formio.css/js, font-awesome) available for CHEFS to host for embedding applications.

Token and User objects are for the embedding application to set (these can contain any attributes the form designer wants/needs for programming within their form).

There is a demo HTML provided to help illustrate how one might embed the component and interact with it.

We need a backend to serve the needed resources (formio, custom components, font-awesome etc) and manage CORS/CSP issues. Resources could be offloaded to a real CDN (Content Delivery Network), but to expedite we will self host all that is needed to embed the component. The backend also has endpoints for reading the schema and handing submit; all webcomponent API is isolated under `/webcomponents/v1/`. Reading of the schema uses the existing api (`/api/v1/submissions/<subId>`).

The main focus of the PR is the webcomponent (a Javascript embeddable web component): [chefs-form-viewer.js](./app/src/frontend/public/embed/chefs-form-viewer.js)

I've added extensive documentation in the component and in a [README](./app/src/frontend/public/embed/README.md) - we can test how useful or not it is when we build out a completely external application that embeds the component.

**IMPORTANT**

We have not yet determined or handled what it means to have a protected form (that requires a CHEFS user) when the form (and login/auth) exists outside of CHEFS control. For now, only test with a Publically accessible form. Also, do not use components that require CHEFS infrastructure (most of the BC Gov Components - file upload, etc) as these use relative paths to the CHEFS server, and when the webcomponent is running elsewhere, those relative paths won't work. Same with External API.  Keep your forms simple for now.

Create a FORM, set to Public, add components, set required fields etc.  Create an API Key. 
In the demo html, provide the Form ID and API Key, click Load and the form should appear, populate as usual and Submit.  A successful submit should populate the submission id and set the readonly webcomponent setting and display the submission as readonly.  There is a Submit (programmatic) button to illustrate that the embedding application can take control. I did not add all the event handlers and things like prompting before Submit or Saving drafts but that is all possible. We wil save that for the full demo implementation.

*UPDATE* - we can now (and should) use an `auth-token` to load the web component. A backend server gets the `auth-token` and makes it available to their frontend to pass in to launch chefs-form-viewer.

[chefs-form-viewer-auth-demo](https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-1755/embed/chefs-form-viewer-auth-demo.html)

[chefs-form-viewer-generator](https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-1755/embed/chefs-form-viewer-generator.html)

[chefs-form-viewer-demo](https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-1755/embed/chefs-form-viewer-demo.html)

You will notice that the styling of the form does not look the same. That is another set of tickets to put together the requisite styles and style isolation (CHEFS has application styles (from Vuetify) that bleed into the Form styles... :( so there will be considerable effort required to truly separte form designer and form viewer styles from CHEFS application, making the styling universal - if the embedder wants that).

*UPDATE* styling has been addressed, it is nearly identical.

**MORE IMPORTANT**
It appears that not all "regular" components are rendering properly... may have to implement the CSS sooner rather than later. Stick to text fields for now :(

**UPDATE One**
CSS/Styling has been solved. However, still some components (Select list) still don't work in the shadow DOM. WOrk will continue on that

**UPDATE One**
The formio components I was having trouble with (masked text like phone number, and dropdown/select that uses Choices.js) have been fixed. This does not include our custom components that have internal relative paths to our backend (like file upload, address, map).

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

feat (a new feature)
<!-- fix (a bug fix) -->

build (change in build system or dependencies)
<!-- ci (change in continuous integration / deployment) -->
docs (change to documentation)
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
 test (add missing tests or correct existing tests)


This is **NOT** a breaking change because the webcomponent and the backend are completely isolated from the current API code.


## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
