### PR TITLE
test: CCP-3581 Tooltip message validation (#1851)

### DIFF
--- a/tests/functional/cypress/cypress/fixtures/formId.json
+++ b/tests/functional/cypress/cypress/fixtures/formId.json
@@ -1,3 +1,3 @@
 {
-  "formId": "707023d4-9d7f-4fce-ac4d-95b58942ac6a"
+  "formId": "9668e1b2-bd7c-4034-a1e6-bd1b247cdc1a"
 }

--- a/tests/functional/cypress/e2e/form-apikey-cdogs.cy.js
+++ b/tests/functional/cypress/e2e/form-apikey-cdogs.cy.js
@@ -27,11 +27,11 @@ describe('Form Designer', () => {
     cy.checkA11yPage();
   });
   it('Getting page ready', () => {
-    cy.viewport(1000, 1100);
+    cy.viewport(1000, 1800);
     cy.get('button').contains('BC Government').click();   
   });
   it('checks Data Retention Settings', () => {
-    cy.viewport(1000, 1100);
+    cy.viewport(1000, 1800);
     cy.waitForLoad();
     cy.get('div.formio-builder-form').then($el => {
       const coords = $el[0].getBoundingClientRect();
@@ -68,13 +68,41 @@ describe('Form Designer', () => {
     });
      // Form saving
     cy.wait(1000); 
+    cy.get('.mdi-dots-vertical').click();
+    cy.get('[data-cy="previewRouterLink"] > .v-btn').trigger('mouseover', { force: true });
+    cy.get('.v-overlay__content').contains('Save a version of the form to preview').should('exist');
+    cy.get('[data-cy="publishRouterLink"] > .v-btn').trigger('mouseover', { force: true });
+    cy.get('.v-overlay__content').contains('Publish form').should('exist');
     cy.get('[data-cy=saveButton]').click();
     cy.wait(2000);
     cy.get('.mdi-dots-vertical').click();
+    cy.get('[data-cy="publishRouterLink"] > .v-btn').trigger('mouseover', { force: true });
+    cy.get('.v-overlay__content').contains('Please save a new version to publish').should('exist');
     cy.get('[data-cy="settingsRouterLink"] > .v-btn > .v-btn__content').click();
     cy.get('span').contains('Please publish or delete your latest draft version before starting a new version.').should('exist');
     cy.get('.mdi-plus').should('not.be.enabled');
     cy.get('button[title="Delete Version"]').should('be.visible');
+    cy.get('button[title="Edit Version"]').click();
+    cy.wait(1000);
+    //Add new component to version 1
+    cy.get('div.formio-builder-form').then($el => {
+    const coords = $el[0].getBoundingClientRect();
+    cy.get('span.btn').contains('Text/Images')
+      
+      .trigger('mousedown', { which: 1}, { force: true })
+      .trigger('mousemove', coords.x, -50, { force: true })
+      .trigger('mouseup', { force: true });
+      cy.waitForLoad();
+    cy.get('.btn-success').click();
+    });
+    cy.wait(1000);
+    cy.get('.mdi-dots-vertical').click();
+    //Tooiltip message for preview button for new version
+    cy.get('[data-cy="previewRouterLink"] > .v-btn').trigger('mouseover', { force: true });
+    cy.get('.v-overlay__content').contains('Save to preview updated form version').should('exist');
+    //Delete old version
+    cy.get('[data-cy="settingsRouterLink"] > .v-btn > .v-btn__content').click();
+    cy.wait(1000);
     cy.get('button[title="Delete Version"]').click();
     cy.get('span').contains('Are you sure you wish to delete this Version?').should('be.visible');
     cy.get('button').contains('Delete').should('be.visible').click();

--- a/tests/functional/cypress/e2e/form-design-advancedfield.cy.js
+++ b/tests/functional/cypress/e2e/form-design-advancedfield.cy.js
@@ -202,6 +202,14 @@ describe('Form Designer', () => {
         cy.get('span').contains('Publish Version 1');
         cy.contains('Continue').should('be.visible');
         cy.contains('Continue').trigger('click');
+
+        //Share link verification
+        cy.get('[data-cy=shareFormButton]').should('be.visible').click();
+        cy.get('.v-card-actions > .v-btn > .v-btn__content > span').click();
+        cy.location('search').then(search => {
+          //let pathName = fullUrl.pathname
+        let arr = search.split('=');
+        let arrayValues = arr[1].split('&');
         cy.visit(`/${depEnv}/form/submit?f=${arrayValues[0]}`);
         cy.waitForLoad();
         // for print option verification
@@ -278,4 +286,4 @@ describe('Form Designer', () => {
         });
 
     });
-  
+});

--- a/tests/functional/cypress/e2e/form-design-export-import-design.cy.js
+++ b/tests/functional/cypress/e2e/form-design-export-import-design.cy.js
@@ -75,6 +75,10 @@ describe('Form Designer', () => {
     cy.get('.mdi-dots-vertical').click();
     //Preview button disabled before form saving
     cy.get('[data-cy="previewRouterLink"] > .v-btn').should('have.attr', 'disabled');
+    cy.get('[data-cy="previewRouterLink"] > .v-btn').trigger('mouseover', { force: true });
+    cy.get('.v-overlay__content').contains('Save a version of the form to preview').should('exist');
+    cy.get('[data-cy="publishRouterLink"] > .v-btn').trigger('mouseover', { force: true });
+    cy.get('.v-overlay__content').contains('Insufficient permissions to publish form').should('exist');
     cy.get('[data-cy="undoButton"] > .v-btn').should('not.have.attr', 'disabled');
     cy.get('[data-cy="redoButton"] > .v-btn').should('have.attr', 'disabled');
     cy.get('.mdi-undo').click();
@@ -92,6 +96,7 @@ describe('Form Designer', () => {
      cy.get('.mdi-dots-vertical').click();
     //Preview button enabled
     cy.get('[data-cy="previewRouterLink"] > .v-btn').should('not.have.attr', 'disabled');
+    cy.get('.v-overlay__content').contains('Click to Preview Form').should('exist');
     // Filter the newly created form
     cy.location('search').then(search => {
     let arr = search.split('=');

--- a/tests/functional/cypress/e2e/form-draft-submission-management.cy.js
+++ b/tests/functional/cypress/e2e/form-draft-submission-management.cy.js
@@ -26,30 +26,24 @@ describe('Form Designer', () => {
     formsettings();
     cy.checkA11yPage();
   });  
-// Publish a simple form 
-it('Verify draft submission', () => {
-    cy.viewport(1000, 1100);
-    cy.waitForLoad();
+it('Getting page', () => {
     
+    cy.viewport(1000, 1100);
+    cy.get('div.builder-components.drag-container.formio-builder-form', { timeout: 30000 }).should('be.visible');
     cy.get('button').contains('Basic Fields').click();
+  });
+  // Publish a simple form 
+  it('Verify draft submission', () => {
+    cy.viewport(1000, 1100);
+    cy.wait(2000);
     cy.get('div.formio-builder-form').then($el => {
       const coords = $el[0].getBoundingClientRect();
       cy.get('span.btn').contains('Text Field')
       
       .trigger('mousedown', { which: 1}, { force: true })
-      .trigger('mousemove', coords.x, -1, { force: true })
+      .trigger('mousemove', coords.x, -150, { force: true })
       .trigger('mouseup', { force: true });
       cy.get('.btn-success').click();
-    });
-    //Multiline Text
-    cy.get('div.formio-builder-form').then($el => {
-        const coords = $el[0].getBoundingClientRect();
-        cy.get('span.btn').contains('Multi-line Text')
-        
-        .trigger('mousedown', { which: 1}, { force: true })
-        .trigger('mousemove', coords.x, +1, { force: true })
-        .trigger('mouseup', { force: true });
-        cy.get('.btn-success').click();
     });
     
   // Form saving

--- a/tests/functional/cypress/e2e/form-edit-submission-data.cy.js
+++ b/tests/functional/cypress/e2e/form-edit-submission-data.cy.js
@@ -23,29 +23,26 @@ describe("Form Designer", () => {
     formsettings();
     cy.checkA11yPage();
   });
-  it("Add some fields for submission", () => {
-    cy.viewport(1000, 1800);
-    cy.waitForLoad();
-    cy.get("button").contains("Basic Fields").click();
-    cy.get("div.formio-builder-form").then(($el) => {
+  it('Getting page', () => {
+    
+    cy.viewport(1000, 1100);
+    cy.get('div.builder-components.drag-container.formio-builder-form', { timeout: 30000 }).should('be.visible');
+    cy.get('button').contains('Basic Fields').click();
+  });
+  // Publish a simple form 
+  it('Verify draft submission', () => {
+    cy.viewport(1000, 1100);
+    cy.wait(2000);
+    cy.get('div.formio-builder-form').then($el => {
       const coords = $el[0].getBoundingClientRect();
       cy.get('span.btn').contains('Text Field')
       
       .trigger('mousedown', { which: 1}, { force: true })
-      .trigger('mousemove', coords.x, -1, { force: true })
+      .trigger('mousemove', coords.x, -150, { force: true })
       .trigger('mouseup', { force: true });
       cy.get('.btn-success').click();
     });
-    //Multiline Text
-    cy.get('div.formio-builder-form').then($el => {
-        const coords = $el[0].getBoundingClientRect();
-        cy.get('span.btn').contains('Multi-line Text')
-        
-        .trigger('mousedown', { which: 1}, { force: true })
-        .trigger('mousemove', coords.x, +1, { force: true })
-        .trigger('mouseup', { force: true });
-        cy.get('.btn-success').click();
-    });
+    
     // Form saving
   });
   it("Form Submission and Updation", () => {

--- a/tests/functional/cypress/e2e/form-submission-revise-status.cy.js
+++ b/tests/functional/cypress/e2e/form-submission-revise-status.cy.js
@@ -74,16 +74,8 @@ it('Verify draft submission', () => {
     cy.contains('Continue').should('be.visible');
     cy.contains('Continue').trigger('click');
     //Share link verification
-    let shareFormButton = cy.get('[data-cy=shareFormButton]');
-    expect(shareFormButton).to.not.be.null;
-    shareFormButton.trigger('click').then(()=>{
-      //let shareFormLinkButton = cy.get('[data-cy=shareFormLinkButtonss]');
-      let shareFormLinkButton=cy.get('.mx-2');
-      expect(shareFormLinkButton).to.not.be.null;
-      shareFormLinkButton.trigger('click');
-      cy.get('.mx-2 > .v-btn').click();
-    })
-      //Draft submission and verification
+    cy.get('[data-cy=shareFormButton]').should('be.visible').click();
+    //Draft submission and verification
     cy.visit(`/${depEnv}/form/submit?f=${arrayValues[0]}`);
     cy.waitForLoad();
     cy.get('button').contains('Submit').should('be.visible');


### PR DESCRIPTION
* Updated tests

* Added validation for tooltip behaviour for both preview and publish button

* Modified to run tests on both echefs PR and chefs

<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
