### PR TITLE
Session timeout redirection to Save tenant Context when loggin back

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -14,6 +14,17 @@ const ready = ref(false);
 const route = useRoute();
 const tenantStore = useTenantStore();
 
+function hasPendingRestoreToken() {
+  try {
+    return !!(
+      sessionStorage.getItem('tenantSessionRestore') ||
+      localStorage.getItem('tenantLoginRestore')
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
 const appTitle = computed(() => {
   const base =
     route && route.meta && route.meta.title
@@ -21,6 +32,14 @@ const appTitle = computed(() => {
       : import.meta.env.VITE_TITLE || 'Common Hosted Forms';
 
   if (!tenantStore.isTenantFeatureEnabled) return base;
+  // Suppress the suffix only when an actual tenant restore is in flight.
+  // Personal-CHEFS-only users get "Personal" immediately, no flicker.
+  const restoring =
+    tenantStore.isRestoring ||
+    (!tenantStore.selectedTenant &&
+      tenantStore.loading &&
+      hasPendingRestoreToken());
+  if (restoring) return base;
 
   const suffix = tenantStore.selectedTenant ? 'Enterprise' : 'Personal';
   return `${base} | ${suffix}`;

--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -14,16 +14,14 @@ const ready = ref(false);
 const route = useRoute();
 const tenantStore = useTenantStore();
 
-function hasPendingRestoreToken() {
-  try {
-    return !!(
-      sessionStorage.getItem('tenantSessionRestore') ||
-      localStorage.getItem('tenantLoginRestore')
-    );
-  } catch (e) {
-    return false;
-  }
-}
+const isTenantRestoring = computed(() => tenantStore.isTenantRestoring);
+
+// Show the centered loader on tenant-scoped routes only — public/submitter
+// routes don't carry tenant context (interceptors.js excludes them) and
+// shouldn't be blocked by a restore happening in another tab.
+const showTenantRestoreLoader = computed(
+  () => isTenantRestoring.value && !route?.meta?.formSubmitMode
+);
 
 const appTitle = computed(() => {
   const base =
@@ -32,14 +30,7 @@ const appTitle = computed(() => {
       : import.meta.env.VITE_TITLE || 'Common Hosted Forms';
 
   if (!tenantStore.isTenantFeatureEnabled) return base;
-  // Suppress the suffix only when an actual tenant restore is in flight.
-  // Personal-CHEFS-only users get "Personal" immediately, no flicker.
-  const restoring =
-    tenantStore.isRestoring ||
-    (!tenantStore.selectedTenant &&
-      tenantStore.loading &&
-      hasPendingRestoreToken());
-  if (restoring) return base;
+  if (isTenantRestoring.value) return base;
 
   const suffix = tenantStore.selectedTenant ? 'Enterprise' : 'Personal';
   return `${base} | ${suffix}`;
@@ -87,7 +78,29 @@ onMounted(async () => {
       <BCGovNavBar :form-submit-mode="isFormSubmitMode" />
       <BCGovEnterpriseBanner :form-submit-mode="isFormSubmitMode" />
       <GlobalStatusOverlay :parent-ready="ready" />
-      <RouterView v-slot="{ Component }">
+      <div
+        v-if="showTenantRestoreLoader"
+        class="tenant-restore-loader main"
+        role="status"
+        aria-live="polite"
+        aria-label="Restoring your enterprise context"
+      >
+        <div class="tenant-restore-card">
+          <v-progress-circular
+            indeterminate
+            color="primary"
+            size="48"
+            width="4"
+          />
+          <div class="tenant-restore-title">
+            Restoring your enterprise context&hellip;
+          </div>
+          <div class="tenant-restore-subtitle">
+            One moment while we reconnect you to your tenant.
+          </div>
+        </div>
+      </div>
+      <RouterView v-else v-slot="{ Component }">
         <transition name="component-fade" mode="out-in">
           <component :is="Component" :class="isWidePage" />
         </transition>
@@ -122,5 +135,44 @@ onMounted(async () => {
 }
 :deep(.v-btn--icon) {
   border-radius: 0px;
+}
+
+.tenant-restore-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 2rem 1rem;
+  animation: tenant-restore-fade 200ms ease-out;
+}
+
+.tenant-restore-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+  max-width: 28rem;
+}
+
+.tenant-restore-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #003366;
+  margin-top: 0.5rem;
+}
+
+.tenant-restore-subtitle {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+@keyframes tenant-restore-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 </style>

--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -78,11 +78,9 @@ onMounted(async () => {
       <BCGovNavBar :form-submit-mode="isFormSubmitMode" />
       <BCGovEnterpriseBanner :form-submit-mode="isFormSubmitMode" />
       <GlobalStatusOverlay :parent-ready="ready" />
-      <div
+      <output
         v-if="showTenantRestoreLoader"
         class="tenant-restore-loader main"
-        role="status"
-        aria-live="polite"
         aria-label="Restoring your enterprise context"
       >
         <div class="tenant-restore-card">
@@ -99,7 +97,7 @@ onMounted(async () => {
             One moment while we reconnect you to your tenant.
           </div>
         </div>
-      </div>
+      </output>
       <RouterView v-else v-slot="{ Component }">
         <transition name="component-fade" mode="out-in">
           <component :is="Component" :class="isWidePage" />

--- a/app/frontend/src/components/bcgov/BCGovEnterpriseBanner.vue
+++ b/app/frontend/src/components/bcgov/BCGovEnterpriseBanner.vue
@@ -21,28 +21,7 @@ const tenantName = computed(
   () => selectedTenant.value?.name || selectedTenant.value?.displayName || ''
 );
 
-// Show the loader only when there is actually something to restore.
-// Personal-CHEFS-only users (no tenant ever selected) get the Personal
-// banner immediately — no loader flash. The conditions:
-//   - explicit restore in flight (set by hydrator/fetchTenants), OR
-//   - tenants are being fetched, no tenant resolved yet, AND a restore
-//     token is sitting in storage (sessionStorage from session timeout
-//     or localStorage from voluntary logout).
-function hasPendingRestoreToken() {
-  try {
-    return !!(
-      sessionStorage.getItem('tenantSessionRestore') ||
-      localStorage.getItem('tenantLoginRestore')
-    );
-  } catch (e) {
-    return false;
-  }
-}
-const showRestoring = computed(
-  () =>
-    tenantStore.isRestoring ||
-    (!selectedTenant.value && tenantStore.loading && hasPendingRestoreToken())
-);
+const { isTenantRestoring: showRestoring } = storeToRefs(tenantStore);
 </script>
 
 <template>

--- a/app/frontend/src/components/bcgov/BCGovEnterpriseBanner.vue
+++ b/app/frontend/src/components/bcgov/BCGovEnterpriseBanner.vue
@@ -20,6 +20,29 @@ const isEnterprise = computed(() => !!selectedTenant.value);
 const tenantName = computed(
   () => selectedTenant.value?.name || selectedTenant.value?.displayName || ''
 );
+
+// Show the loader only when there is actually something to restore.
+// Personal-CHEFS-only users (no tenant ever selected) get the Personal
+// banner immediately — no loader flash. The conditions:
+//   - explicit restore in flight (set by hydrator/fetchTenants), OR
+//   - tenants are being fetched, no tenant resolved yet, AND a restore
+//     token is sitting in storage (sessionStorage from session timeout
+//     or localStorage from voluntary logout).
+function hasPendingRestoreToken() {
+  try {
+    return !!(
+      sessionStorage.getItem('tenantSessionRestore') ||
+      localStorage.getItem('tenantLoginRestore')
+    );
+  } catch (e) {
+    return false;
+  }
+}
+const showRestoring = computed(
+  () =>
+    tenantStore.isRestoring ||
+    (!selectedTenant.value && tenantStore.loading && hasPendingRestoreToken())
+);
 </script>
 
 <template>
@@ -28,16 +51,28 @@ const tenantName = computed(
       authenticated && tenantStore.isTenantFeatureEnabled && !formSubmitMode
     "
     class="context-banner d-print-none"
-    :class="isEnterprise ? 'enterprise-banner' : 'personal-banner'"
+    :class="
+      showRestoring
+        ? 'restoring-banner'
+        : isEnterprise
+        ? 'enterprise-banner'
+        : 'personal-banner'
+    "
     role="status"
     :aria-label="
-      isEnterprise
+      showRestoring
+        ? 'Restoring tenant context'
+        : isEnterprise
         ? `Enterprise CHEFS - Tenant: ${tenantName}`
         : 'Personal CHEFS'
     "
   >
     <div class="banner-content px-md-16 px-4">
-      <template v-if="isEnterprise">
+      <template v-if="showRestoring">
+        <v-progress-circular indeterminate size="16" width="2" class="mr-2" />
+        <span class="banner-prefix">Restoring your tenant context&hellip;</span>
+      </template>
+      <template v-else-if="isEnterprise">
         <span class="banner-prefix"
           >Enterprise CHEFS &ndash; Tenant:&nbsp;</span
         >
@@ -67,6 +102,14 @@ const tenantName = computed(
 
     .banner-content {
       color: #ffffff;
+    }
+  }
+
+  &.restoring-banner {
+    background-color: #e0e0e0;
+
+    .banner-content {
+      color: #333333;
     }
   }
 

--- a/app/frontend/src/components/designer/FormsTable.vue
+++ b/app/frontend/src/components/designer/FormsTable.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { useAuthStore } from '~/store/auth';
@@ -64,46 +64,7 @@ const filteredFormList = computed(() =>
   )
 );
 
-function hasPendingRestoreToken() {
-  try {
-    return !!(
-      sessionStorage.getItem('tenantSessionRestore') ||
-      localStorage.getItem('tenantLoginRestore')
-    );
-  } catch (e) {
-    return false;
-  }
-}
-
 onMounted(async () => {
-  // Wait for tenant state to settle before fetching forms — but ONLY if
-  // there's actually a tenant restore in progress. For Personal-CHEFS-only
-  // users (no token in storage) we fetch immediately. The wait conditions:
-  //   - explicit restore in flight, OR
-  //   - tenants are loading, no tenant resolved yet, AND a restore token
-  //     is sitting in storage (so a tenant is about to be restored).
-  const needsWait = () =>
-    tenantStore.isRestoring ||
-    (!tenantStore.selectedTenant &&
-      tenantStore.loading &&
-      hasPendingRestoreToken());
-  if (needsWait()) {
-    await new Promise((resolve) => {
-      const stop = watch(
-        () => [
-          tenantStore.isRestoring,
-          tenantStore.loading,
-          tenantStore.selectedTenant,
-        ],
-        () => {
-          if (!needsWait()) {
-            stop();
-            resolve();
-          }
-        }
-      );
-    });
-  }
   await formStore.getFormsForCurrentUser();
   loading.value = false;
 });

--- a/app/frontend/src/components/designer/FormsTable.vue
+++ b/app/frontend/src/components/designer/FormsTable.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { useAuthStore } from '~/store/auth';
@@ -64,7 +64,46 @@ const filteredFormList = computed(() =>
   )
 );
 
+function hasPendingRestoreToken() {
+  try {
+    return !!(
+      sessionStorage.getItem('tenantSessionRestore') ||
+      localStorage.getItem('tenantLoginRestore')
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
 onMounted(async () => {
+  // Wait for tenant state to settle before fetching forms — but ONLY if
+  // there's actually a tenant restore in progress. For Personal-CHEFS-only
+  // users (no token in storage) we fetch immediately. The wait conditions:
+  //   - explicit restore in flight, OR
+  //   - tenants are loading, no tenant resolved yet, AND a restore token
+  //     is sitting in storage (so a tenant is about to be restored).
+  const needsWait = () =>
+    tenantStore.isRestoring ||
+    (!tenantStore.selectedTenant &&
+      tenantStore.loading &&
+      hasPendingRestoreToken());
+  if (needsWait()) {
+    await new Promise((resolve) => {
+      const stop = watch(
+        () => [
+          tenantStore.isRestoring,
+          tenantStore.loading,
+          tenantStore.selectedTenant,
+        ],
+        () => {
+          if (!needsWait()) {
+            stop();
+            resolve();
+          }
+        }
+      );
+    });
+  }
   await formStore.getFormsForCurrentUser();
   loading.value = false;
 });

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -16,6 +16,7 @@ import vuetify from '~/plugins/vuetify';
 import getRouter from '~/router';
 import { useAuthStore } from '~/store/auth';
 import { useAppStore } from '~/store/app';
+import { useTenantStore } from '~/store/tenant';
 import { assertOptions, getConfig, sanitizeConfig } from '~/utils/keycloak';
 import { rbacService } from './services';
 import { useIdpStore } from '~/store/identityProviders';
@@ -280,6 +281,26 @@ function loadKeycloak(config) {
       };
       keycloak.onAuthRefreshSuccess = () => {
         authStore.updateKeycloak(keycloak, true);
+      };
+      keycloak.onAuthRefreshError = () => {
+        // Refresh failed. This could mean the SSO session is gone, OR it could
+        // be a transient network blip / race on reload. Distinguish the two by
+        // checking whether the access token itself is expired:
+        //   - access token dead → session is truly gone, save restore context
+        //     and flip auth state so BaseSecure shows the login prompt
+        //   - access token still valid → refresh will retry, don't disrupt the
+        //     user; the interval keeps running and will either recover or
+        //     eventually come back through this path once the token does expire
+        const tokenDead =
+          !keycloak.authenticated ||
+          (typeof keycloak.isTokenExpired === 'function' &&
+            keycloak.isTokenExpired());
+        if (!tokenDead) return;
+
+        const tenantStore = useTenantStore();
+        tenantStore.saveSessionRestore();
+        authStore.redirectUri = location.toString();
+        authStore.updateKeycloak(keycloak, false);
       };
       keycloak.onAuthLogout = () => {
         authStore.updateKeycloak(keycloak, false);

--- a/app/frontend/src/router.js
+++ b/app/frontend/src/router.js
@@ -1,4 +1,5 @@
 import NProgress from 'nprogress';
+import { watch } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 
 import { useAuthStore } from '~/store/auth';
@@ -476,6 +477,32 @@ export default function getRouter(basePath = '/') {
     }
   }
 
+  // Wait for an in-flight tenant restore to settle before resolving navigation
+  // to a tenant-scoped route. Only applies when:
+  //   - the tenant feature is enabled
+  //   - the route is NOT a public/submitter route (interceptors.js doesn't send
+  //     x-tenant-id for those, so they don't need to wait)
+  // Without this, components like ManageLayout/SubmissionsTable/FormDesigner
+  // that fetch on mount would race the restore and request data with the wrong
+  // (or missing) tenant context.
+  async function waitForTenantContext(to, tenantStore) {
+    if (!tenantStore.isTenantFeatureEnabled) return;
+    if (to.meta?.formSubmitMode) return;
+    if (!tenantStore.isTenantRestoring) return;
+
+    await new Promise((resolve) => {
+      const stop = watch(
+        () => tenantStore.isTenantRestoring,
+        (restoring) => {
+          if (!restoring) {
+            stop();
+            resolve();
+          }
+        }
+      );
+    });
+  }
+
   function handleAuthRedirect(to, authStore) {
     const requiresAuth = to.matched.some((route) => route.meta.requiresAuth);
     if (!requiresAuth || !authStore.ready || authStore.authenticated) return;
@@ -496,7 +523,7 @@ export default function getRouter(basePath = '/') {
     authStore.login(idpHint);
   }
 
-  router.beforeEach((to, _from, next) => {
+  router.beforeEach(async (to, _from, next) => {
     NProgress.start();
 
     const authStore = useAuthStore();
@@ -504,8 +531,10 @@ export default function getRouter(basePath = '/') {
     handleFirstTransition(to, authStore);
     handleAuthRedirect(to, authStore);
 
-    // For Enterprise CHEFS (tenanted): check form_admin role for FormCreate route
     const tenantStore = useTenantStore();
+    await waitForTenantContext(to, tenantStore);
+
+    // For Enterprise CHEFS (tenanted): check form_admin role for FormCreate route
     if (
       to.name === 'FormCreate' &&
       authStore.authenticated &&

--- a/app/frontend/src/store/auth.js
+++ b/app/frontend/src/store/auth.js
@@ -121,9 +121,8 @@ export const useAuthStore = defineStore('auth', {
           });
       } else {
         this.currentUser = defaultUser;
-        // Reset tenant store on logout
         const tenantStore = useTenantStore();
-        tenantStore.resetTenant();
+        tenantStore.clearTenantState();
       }
     },
     async login(idpHint) {

--- a/app/frontend/src/store/tenant.js
+++ b/app/frontend/src/store/tenant.js
@@ -5,14 +5,50 @@ import { useAuthStore } from '~/store/auth';
 import { useNotificationStore } from '~/store/notification';
 import getRouter from '~/router';
 
+// Hydrate selectedTenant and isRestoring synchronously from storage at store
+// creation time. Pinia's state() runs before any component renders, so doing
+// this here prevents the banner/title from flashing "Personal CHEFS" on the
+// first paint of a post-login page load.
+function hydrateSelectedTenant() {
+  try {
+    const stored = localStorage.getItem('selectedTenant');
+    if (stored && stored !== 'null' && stored !== 'undefined') {
+      return JSON.parse(stored);
+    }
+  } catch (e) {
+    // ignore parse errors
+  }
+  return null;
+}
+
+function hydrateIsRestoring(selectedTenant) {
+  // Already have a selectedTenant from localStorage → nothing to restore;
+  // render with the known tenant immediately.
+  if (selectedTenant) return false;
+  try {
+    if (sessionStorage.getItem('tenantSessionRestore')) return true;
+    if (localStorage.getItem('tenantLoginRestore')) return true;
+  } catch (e) {
+    // ignore
+  }
+  return false;
+}
+
 export const useTenantStore = defineStore('tenant', {
-  state: () => ({
-    tenants: [], // List of available tenants
-    selectedTenant: null, // Currently selected tenant (persisted to localStorage)
-    loading: false, // Loading state for API calls
-    error: null, // Error message if any
-    serviceDegraded: false, // True when X-Tenant-Service-Status: degraded header received
-  }),
+  state: () => {
+    const selectedTenant = hydrateSelectedTenant();
+    return {
+      tenants: [], // List of available tenants
+      selectedTenant, // Currently selected tenant (persisted to localStorage)
+      loading: false, // Loading state for API calls
+      error: null, // Error message if any
+      serviceDegraded: false, // True when X-Tenant-Service-Status: degraded header received
+      // True while a post-login tenant restore is in flight. Components that
+      // depend on selectedTenant (banner, title, forms list) should wait on
+      // this to avoid flashing Personal CHEFS before the tenant lands.
+      isRestoring: hydrateIsRestoring(selectedTenant),
+    };
+  },
 
   getters: {
     /**
@@ -126,6 +162,9 @@ export const useTenantStore = defineStore('tenant', {
 
       this.loading = true;
       this.error = null;
+      // Only flag "restoring" when there's actually a restore token waiting —
+      // avoids hiding UI on every tenant refetch (e.g. manual tenant switch).
+      this.isRestoring = !!(this.getSessionRestore() || this.getLoginRestore());
 
       try {
         const response = await rbacService.getCurrentUserTenants();
@@ -151,6 +190,43 @@ export const useTenantStore = defineStore('tenant', {
           this.persistSelectedTenant();
         }
 
+        // Restore previously active tenant after re-login.
+        // Priority 1 — session timeout (sessionStorage, tab-scoped):
+        //   Written by selectTenant() / onAuthRefreshError, consumed once.
+        // Priority 2 — voluntary logout (localStorage, browser-scoped):
+        //   Written by selectTenant(), cleared when user picks Personal CHEFS,
+        //   intentionally kept through resetTenant() so it survives logout.
+        // In both cases the API response is the permission authority — we only
+        // restore if the tenant is present in the current user's tenant list.
+        const currentUserId = this.currentUserIdForRestore();
+
+        const sessionRestore = this.getSessionRestore();
+        if (sessionRestore) {
+          if (sessionRestore.userId === currentUserId) {
+            const match = this.getTenantById(sessionRestore.tenantId);
+            if (match) {
+              this.selectedTenant = match;
+              this.persistSelectedTenant();
+            }
+          }
+          this.clearSessionRestore(); // always consume — one-time token
+        } else {
+          const loginRestore = this.getLoginRestore();
+          if (loginRestore) {
+            if (loginRestore.userId === currentUserId) {
+              const match = this.getTenantById(loginRestore.tenantId);
+              if (match) {
+                this.selectedTenant = match;
+                this.persistSelectedTenant();
+              }
+              // Not consumed — kept as "last used tenant" for future logins.
+              // selectTenant() will overwrite it on next explicit selection.
+            } else {
+              this.clearLoginRestore(); // different user on same browser — drop stale data
+            }
+          }
+        }
+
         // Don't auto-select first tenant - keep user in Classic CHEFS mode on login
       } catch (error) {
         this.error = error.message || 'Failed to fetch tenants';
@@ -160,6 +236,7 @@ export const useTenantStore = defineStore('tenant', {
         });
       } finally {
         this.loading = false;
+        this.isRestoring = false;
       }
     },
 
@@ -170,18 +247,38 @@ export const useTenantStore = defineStore('tenant', {
     selectTenant(tenant) {
       this.selectedTenant = tenant;
       this.persistSelectedTenant();
+      this.saveSessionRestore(); // tab-scoped: session timeout recovery
+      this.saveLoginRestore(); // browser-scoped: voluntary logout recovery
     },
 
     /**
-     * Clear selected tenant
+     * Clear selected tenant (user explicitly chose Personal CHEFS).
+     * Also clears the login restore token so that after a voluntary logout
+     * the user returns to Personal CHEFS, not the previously active tenant.
      */
     clearSelectedTenant() {
       this.selectedTenant = null;
       this.persistSelectedTenant();
+      this.clearLoginRestore();
     },
 
     /**
-     * Reset tenant store to initial state
+     * Reset Pinia state and localStorage but preserve sessionStorage restore data.
+     * Use this on session expiry so the tenant can be recovered after re-login
+     * within the same tab.
+     */
+    clearTenantState() {
+      this.tenants = [];
+      this.selectedTenant = null;
+      this.loading = false;
+      this.error = null;
+      this.serviceDegraded = false;
+      this.persistSelectedTenant();
+    },
+
+    /**
+     * Reset tenant store to initial state and clear all persisted data including
+     * sessionStorage restore. Use this on voluntary logout only.
      */
     resetTenant() {
       this.tenants = [];
@@ -190,6 +287,98 @@ export const useTenantStore = defineStore('tenant', {
       this.error = null;
       this.serviceDegraded = false;
       this.persistSelectedTenant();
+      this.clearSessionRestore();
+    },
+
+    /**
+     * Resolve a stable identifier for the current user. Tries the Keycloak
+     * subject first, then falls back to the parsed token's `sub` claim, then
+     * to the RBAC `idpUserId` — some code paths (e.g. right after refresh)
+     * may have one populated but not the others.
+     */
+    currentUserIdForRestore() {
+      const authStore = useAuthStore();
+      return (
+        authStore.keycloak?.subject ||
+        authStore.keycloak?.tokenParsed?.sub ||
+        authStore.currentUser?.idpUserId ||
+        null
+      );
+    },
+
+    /**
+     * Persist {userId, tenantId} to sessionStorage so the tenant can be
+     * restored after a session timeout within the same browser tab.
+     * sessionStorage is tab-scoped and survives Keycloak redirect-back,
+     * so each tab restores its own context independently.
+     */
+    saveSessionRestore() {
+      const userId = this.currentUserIdForRestore();
+      const tenantId = this.selectedTenant?.id;
+      if (!userId || !tenantId) return;
+      try {
+        sessionStorage.setItem(
+          'tenantSessionRestore',
+          JSON.stringify({ userId, tenantId })
+        );
+      } catch (e) {
+        // ignore storage errors (e.g. private browsing quota)
+      }
+    },
+
+    getSessionRestore() {
+      try {
+        const raw = sessionStorage.getItem('tenantSessionRestore');
+        return raw ? JSON.parse(raw) : null;
+      } catch (e) {
+        return null;
+      }
+    },
+
+    clearSessionRestore() {
+      try {
+        sessionStorage.removeItem('tenantSessionRestore');
+      } catch (e) {
+        // ignore
+      }
+    },
+
+    /**
+     * Persist {userId, tenantId} to localStorage so the tenant can be
+     * restored after a voluntary logout + re-login on the same browser.
+     * Unlike the sessionStorage token, this is never consumed — it represents
+     * "last explicitly selected tenant for this user on this browser" and is
+     * overwritten by each selectTenant() call, cleared by clearSelectedTenant().
+     */
+    saveLoginRestore() {
+      const userId = this.currentUserIdForRestore();
+      const tenantId = this.selectedTenant?.id;
+      if (!userId || !tenantId) return;
+      try {
+        localStorage.setItem(
+          'tenantLoginRestore',
+          JSON.stringify({ userId, tenantId })
+        );
+      } catch (e) {
+        // ignore storage errors
+      }
+    },
+
+    getLoginRestore() {
+      try {
+        const raw = localStorage.getItem('tenantLoginRestore');
+        return raw ? JSON.parse(raw) : null;
+      } catch (e) {
+        return null;
+      }
+    },
+
+    clearLoginRestore() {
+      try {
+        localStorage.removeItem('tenantLoginRestore');
+      } catch (e) {
+        // ignore
+      }
     },
   },
 });

--- a/app/frontend/src/store/tenant.js
+++ b/app/frontend/src/store/tenant.js
@@ -5,32 +5,60 @@ import { useAuthStore } from '~/store/auth';
 import { useNotificationStore } from '~/store/notification';
 import getRouter from '~/router';
 
+// Safe Web Storage wrappers. Reads/writes/removes can throw when storage is
+// disabled (private browsing, browser security setting) or full (quota
+// exceeded). Restore tokens and the cached selectedTenant are best-effort UX
+// state — on any failure we fall back to "no value", which downgrades to a
+// fresh-login experience without breaking the app.
+function safeStorageGet(storage, key) {
+  try {
+    return storage.getItem(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+function safeStorageSet(storage, key, value) {
+  try {
+    storage.setItem(key, value);
+  } catch (e) {
+    /* swallow: see safeStorageGet — storage may be disabled or full */
+  }
+}
+
+function safeStorageRemove(storage, key) {
+  try {
+    storage.removeItem(key);
+  } catch (e) {
+    /* swallow: see safeStorageGet — storage may be disabled */
+  }
+}
+
+function safeJsonParse(raw) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+}
+
 // Hydrate selectedTenant and isRestoring synchronously from storage at store
 // creation time. Pinia's state() runs before any component renders, so doing
 // this here prevents the banner/title from flashing "Personal CHEFS" on the
 // first paint of a post-login page load.
 function hydrateSelectedTenant() {
-  try {
-    const stored = localStorage.getItem('selectedTenant');
-    if (stored && stored !== 'null' && stored !== 'undefined') {
-      return JSON.parse(stored);
-    }
-  } catch (e) {
-    // ignore parse errors
-  }
-  return null;
+  const stored = safeStorageGet(localStorage, 'selectedTenant');
+  if (!stored || stored === 'null' || stored === 'undefined') return null;
+  return safeJsonParse(stored);
 }
 
 function hydrateIsRestoring(selectedTenant) {
   // Already have a selectedTenant from localStorage → nothing to restore;
   // render with the known tenant immediately.
   if (selectedTenant) return false;
-  try {
-    if (sessionStorage.getItem('tenantSessionRestore')) return true;
-    if (localStorage.getItem('tenantLoginRestore')) return true;
-  } catch (e) {
-    // ignore
-  }
+  if (safeStorageGet(sessionStorage, 'tenantSessionRestore')) return true;
+  if (safeStorageGet(localStorage, 'tenantLoginRestore')) return true;
   return false;
 }
 
@@ -137,36 +165,48 @@ export const useTenantStore = defineStore('tenant', {
 
   actions: {
     /**
-     * Initialize store - load selected tenant from localStorage
+     * Re-validate the hydrated selectedTenant against the current app/auth
+     * context. Hydration runs synchronously at store creation (before
+     * appStore/authStore are populated) so it can't enforce the feature flag
+     * or BCSC checks. This action runs from App.vue onMounted, after stores
+     * are ready, and clears any tenant that shouldn't be carried forward:
+     *   - feature flag disabled
+     *   - user authenticated via BC Services Card
+     *   - stored value is missing, "null"/"undefined" string, or unparseable
+     * Corrupted entries are also removed from localStorage.
      */
     initializeStore() {
-      if (!this.isTenantFeatureEnabled || this.isBCServicesCardUser) return;
-      try {
-        const stored = localStorage.getItem('selectedTenant');
-        if (stored && stored !== 'null' && stored !== 'undefined') {
-          this.selectedTenant = JSON.parse(stored);
-        }
-      } catch (error) {
-        console.warn('Failed to parse stored tenant, clearing:', error); // eslint-disable-line no-console
-        localStorage.removeItem('selectedTenant');
+      if (!this.isTenantFeatureEnabled || this.isBCServicesCardUser) {
+        this.selectedTenant = null;
+        return;
       }
+      const raw = safeStorageGet(localStorage, 'selectedTenant');
+      if (!raw || raw === 'null' || raw === 'undefined') {
+        this.selectedTenant = null;
+        return;
+      }
+      const parsed = safeJsonParse(raw);
+      if (parsed === null) {
+        // Corrupted entry — clear it so the user gets a clean slate next load.
+        safeStorageRemove(localStorage, 'selectedTenant');
+        this.selectedTenant = null;
+        return;
+      }
+      this.selectedTenant = parsed;
     },
 
     /**
      * Save selected tenant to localStorage
      */
     persistSelectedTenant() {
-      try {
-        if (this.selectedTenant) {
-          localStorage.setItem(
-            'selectedTenant',
-            JSON.stringify(this.selectedTenant)
-          );
-        } else {
-          localStorage.removeItem('selectedTenant');
-        }
-      } catch (error) {
-        console.warn('Failed to persist tenant to localStorage:', error); // eslint-disable-line no-console
+      if (this.selectedTenant) {
+        safeStorageSet(
+          localStorage,
+          'selectedTenant',
+          JSON.stringify(this.selectedTenant)
+        );
+      } else {
+        safeStorageRemove(localStorage, 'selectedTenant');
       }
     },
 
@@ -344,31 +384,21 @@ export const useTenantStore = defineStore('tenant', {
       const userId = this.currentUserIdForRestore();
       const tenantId = this.selectedTenant?.id;
       if (!userId || !tenantId) return;
-      try {
-        sessionStorage.setItem(
-          'tenantSessionRestore',
-          JSON.stringify({ userId, tenantId })
-        );
-      } catch (e) {
-        // ignore storage errors (e.g. private browsing quota)
-      }
+      safeStorageSet(
+        sessionStorage,
+        'tenantSessionRestore',
+        JSON.stringify({ userId, tenantId })
+      );
     },
 
     getSessionRestore() {
-      try {
-        const raw = sessionStorage.getItem('tenantSessionRestore');
-        return raw ? JSON.parse(raw) : null;
-      } catch (e) {
-        return null;
-      }
+      return safeJsonParse(
+        safeStorageGet(sessionStorage, 'tenantSessionRestore')
+      );
     },
 
     clearSessionRestore() {
-      try {
-        sessionStorage.removeItem('tenantSessionRestore');
-      } catch (e) {
-        // ignore
-      }
+      safeStorageRemove(sessionStorage, 'tenantSessionRestore');
     },
 
     /**
@@ -382,31 +412,19 @@ export const useTenantStore = defineStore('tenant', {
       const userId = this.currentUserIdForRestore();
       const tenantId = this.selectedTenant?.id;
       if (!userId || !tenantId) return;
-      try {
-        localStorage.setItem(
-          'tenantLoginRestore',
-          JSON.stringify({ userId, tenantId })
-        );
-      } catch (e) {
-        // ignore storage errors
-      }
+      safeStorageSet(
+        localStorage,
+        'tenantLoginRestore',
+        JSON.stringify({ userId, tenantId })
+      );
     },
 
     getLoginRestore() {
-      try {
-        const raw = localStorage.getItem('tenantLoginRestore');
-        return raw ? JSON.parse(raw) : null;
-      } catch (e) {
-        return null;
-      }
+      return safeJsonParse(safeStorageGet(localStorage, 'tenantLoginRestore'));
     },
 
     clearLoginRestore() {
-      try {
-        localStorage.removeItem('tenantLoginRestore');
-      } catch (e) {
-        // ignore
-      }
+      safeStorageRemove(localStorage, 'tenantLoginRestore');
     },
   },
 });

--- a/app/frontend/src/store/tenant.js
+++ b/app/frontend/src/store/tenant.js
@@ -79,6 +79,32 @@ export const useTenantStore = defineStore('tenant', {
     currentTenant: (state) => state.selectedTenant,
 
     /**
+     * True while a post-login tenant restore is in flight. Single source of
+     * truth used by:
+     *   - router guard (waitForTenantContext)
+     *   - App.vue (centered loader, title suffix suppression)
+     *   - BCGovEnterpriseBanner (restoring banner state)
+     *
+     * Three conditions must hold:
+     *   1. No selectedTenant yet — once one is loaded, restore is moot.
+     *   2. isRestoring flag is true (hydrated from storage tokens at boot,
+     *      maintained by fetchTenants while it runs).
+     *   3. User is authenticated and auth is ready — otherwise fetchTenants
+     *      won't be triggered (handleFirstTransition gates on auth), so
+     *      blocking the UI on a restore that will never run causes a
+     *      deadlock. Returning enterprise users with selectedTenant cached
+     *      skip the loader entirely; unauthenticated users see the normal
+     *      login prompt instead of a stuck spinner.
+     */
+    isTenantRestoring: (state) => {
+      if (state.selectedTenant) return false;
+      if (!state.isRestoring) return false;
+      const authStore = useAuthStore();
+      if (!authStore.ready || !authStore.authenticated) return false;
+      return true;
+    },
+
+    /**
      * Get tenant by ID
      */
     getTenantById: (state) => (tenantId) => {
@@ -273,6 +299,7 @@ export const useTenantStore = defineStore('tenant', {
       this.loading = false;
       this.error = null;
       this.serviceDegraded = false;
+      this.isRestoring = false;
       this.persistSelectedTenant();
     },
 
@@ -286,6 +313,7 @@ export const useTenantStore = defineStore('tenant', {
       this.loading = false;
       this.error = null;
       this.serviceDegraded = false;
+      this.isRestoring = false;
       this.persistSelectedTenant();
       this.clearSessionRestore();
     },

--- a/app/frontend/tests/unit/App.spec.js
+++ b/app/frontend/tests/unit/App.spec.js
@@ -130,8 +130,12 @@ describe('App.vue', () => {
 
   it('appTitle appends | Enterprise when a tenant is selected', () => {
     const TITLE = 'THIS IS AN APP TITLE';
+    const tenant = { id: 't1', name: 'Tenant 1' };
+    // Set both localStorage (read by initializeStore on mount) and the in-memory
+    // store value (read by the appTitle computed before/after mount).
+    localStorage.setItem('selectedTenant', JSON.stringify(tenant));
     const tenantStore = useTenantStore();
-    tenantStore.selectedTenant = { id: 't1', name: 'Tenant 1' };
+    tenantStore.selectedTenant = tenant;
     const wrapper = mountApp({ meta: { title: TITLE } });
     expect(wrapper.vm.appTitle).toEqual(`${TITLE} | Enterprise`);
   });


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
Previously, when an Enterprise CHEFS user's session timed out (or they logged out and back in), they were dropped back to Personal CHEFS mode and had to re-select their     
  tenant from the dropdown. Their place in the app — including any tenant-scoped page they were on — was lost.

  This change automatically restores the user's tenant context after re-authentication, in two scenarios:

Session timeout (same browser tab) — When the SSO session expires while the user is working, the system remembers which tenant they were in. After they log back in,      
they're returned to the same tenant automatically.

Voluntary logout & re-login (same browser, same user) — The last tenant the user explicitly selected is remembered for next time. On the next login from the same browser,
that tenant is auto-selected.
- Exception: if the user explicitly switches to Personal CHEFS before logging out, no tenant is restored — they get Personal next time, as expected.

  Visual feedback added

  While the tenant context is being restored after re-login, the user now sees:

A clear centered loader in the page area: a spinner with the message "Restoring your enterprise context… One moment while we reconnect you to your tenant."

A grey "Restoring your tenant context…" banner across the top.

The browser tab title omits the Personal/Enterprise suffix until restore finishes (no more flicker).

  These appear only when an actual restore is in progress — Personal-CHEFS users and normal navigation are not affected.

  Where the protection applies

  The restore wait now happens once at the router level, before any tenant-scoped page is allowed to render. This guarantees that pages like Forms, Manage Form, Submissions,  
  Form Designer, Teams, Email Management, Admin, etc. all wait for the correct tenant before fetching data — preventing the bug where a page would briefly load with the wrong
  (or missing) tenant context.

  Public form-submission routes (Submit, Success, View submission, Edit draft, Duplicate submission) are excluded — they don't use tenant context, so they're never blocked.   
<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
