### PR TITLE
CCP-4690:  Fix missing API version array

### DIFF
--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -53,7 +53,7 @@ module.exports = {
   },
   readForm: async (req, res, next) => {
     try {
-      const response = await service.readForm(req.params.formId, req.query, req.currentUser, req.headers);
+      const response = await service.readForm(req.params.formId, req.query, req.apiUser ? null : req.currentUser, req.headers);
       res.status(200).json(response);
     } catch (error) {
       next(error);


### PR DESCRIPTION
# Description

PR #1777 added a permission check on GET /api/v1/forms/{formId} that strips the versions[] array unless the caller has the DESIGN_CREATE permission. The intent was to hide version metadata from non-designer UI users.
Fix: In the controller, passed null for currentUser when req.apiUser is true. The service already treats currentUser === null as the trusted path and returns the full array

## Type of Change


<!-- feat (a new feature) -->
fix (a bug fix)

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

## Checklist
- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

