### PR TITLE
 CCP-4709 isolate CSTAR ConfigMap per deployment and enable tenant feature in PR environments

### DIFF
--- a/.github/actions/deploy-to-environment/action.yaml
+++ b/.github/actions/deploy-to-environment/action.yaml
@@ -126,9 +126,9 @@ runs:
         ACRONYM: ${{ inputs.acronym }}
       run: |
         if [[ "${JOB_NAME}" == pr-* ]]; then
-          oc process --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f openshift/cstar.cm.yaml -p APP_NAME=${ACRONYM} --param-file=openshift/cstar.dev.param -o yaml | oc apply --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f -
+          oc process --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f openshift/cstar.cm.yaml -p APP_NAME=${ACRONYM} -p JOB_NAME=${JOB_NAME} --param-file=openshift/cstar.pr.param -o yaml | oc apply --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f -
         else
-          oc process --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f openshift/cstar.cm.yaml -p APP_NAME=${ACRONYM} --param-file=openshift/cstar.${NAMESPACE_ENVIRONMENT}.param -o yaml | oc apply --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f -
+          oc process --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f openshift/cstar.cm.yaml -p APP_NAME=${ACRONYM} -p JOB_NAME=${JOB_NAME} --param-file=openshift/cstar.${NAMESPACE_ENVIRONMENT}.param -o yaml | oc apply --namespace ${NAMESPACE_PREFIX}-${NAMESPACE_ENVIRONMENT} -f -
         fi
 
     - name: Delete pre-job if it exists

--- a/app/frontend/src/store/tenant.js
+++ b/app/frontend/src/store/tenant.js
@@ -132,7 +132,7 @@ export const useTenantStore = defineStore('tenant', {
       const val = appStore.config?.tenantFeatureEnabled;
       let featureEnabled;
       if (val === undefined || val === null) {
-        featureEnabled = true;
+        featureEnabled = false;
       } else if (typeof val === 'string') {
         featureEnabled = val.toLowerCase() !== 'false';
       } else {

--- a/app/frontend/src/store/tenant.js
+++ b/app/frontend/src/store/tenant.js
@@ -88,7 +88,7 @@ export const useTenantStore = defineStore('tenant', {
     isTenantFeatureEnabled: () => {
       const appStore = useAppStore();
       const val = appStore.config?.tenantFeatureEnabled;
-      if (val === undefined || val === null) return true;
+      if (val === undefined || val === null) return false;
       if (typeof val === 'string') return val.toLowerCase() !== 'false';
       return Boolean(val);
     },

--- a/app/frontend/src/store/tenant.js
+++ b/app/frontend/src/store/tenant.js
@@ -128,6 +128,17 @@ export const useTenantStore = defineStore('tenant', {
     isTenantRestoring: (state) => {
       if (state.selectedTenant) return false;
       if (!state.isRestoring) return false;
+      const appStore = useAppStore();
+      const val = appStore.config?.tenantFeatureEnabled;
+      let featureEnabled;
+      if (val === undefined || val === null) {
+        featureEnabled = true;
+      } else if (typeof val === 'string') {
+        featureEnabled = val.toLowerCase() !== 'false';
+      } else {
+        featureEnabled = Boolean(val);
+      }
+      if (!featureEnabled) return false;
       const authStore = useAuthStore();
       if (!authStore.ready || !authStore.authenticated) return false;
       return true;

--- a/app/frontend/tests/unit/App.spec.js
+++ b/app/frontend/tests/unit/App.spec.js
@@ -123,14 +123,15 @@ describe('App.vue', () => {
 
   it('appTitle appends | Personal when tenant feature is enabled and no tenant is selected', () => {
     const TITLE = 'THIS IS AN APP TITLE';
+    useAppStore().config = { tenantFeatureEnabled: true };
     const wrapper = mountApp({ meta: { title: TITLE } });
-    // isTenantFeatureEnabled defaults to true; no tenant selected → Personal
     expect(wrapper.vm.appTitle).toEqual(`${TITLE} | Personal`);
   });
 
   it('appTitle appends | Enterprise when a tenant is selected', () => {
     const TITLE = 'THIS IS AN APP TITLE';
     const tenant = { id: 't1', name: 'Tenant 1' };
+    useAppStore().config = { tenantFeatureEnabled: true };
     // Set both localStorage (read by initializeStore on mount) and the in-memory
     // store value (read by the appTitle computed before/after mount).
     localStorage.setItem('selectedTenant', JSON.stringify(tenant));

--- a/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
+++ b/app/frontend/tests/unit/components/bcgov/BCGovHeader.spec.js
@@ -134,12 +134,18 @@ describe('BCGovHeader.vue', () => {
     });
 
     it('shows dropdown for an allowed route', () => {
+      const appStore = useAppStore();
+      appStore.config = { tenantFeatureEnabled: true };
+
       const wrapper = mountHeader({}, 'UserForms');
 
       expect(wrapper.find('.tenant-dropdown-wrapper').exists()).toBe(true);
     });
 
     it('shows dropdown for CreateForm route', () => {
+      const appStore = useAppStore();
+      appStore.config = { tenantFeatureEnabled: true };
+
       const wrapper = mountHeader({}, 'CreateForm');
 
       expect(wrapper.find('.tenant-dropdown-wrapper').exists()).toBe(true);

--- a/app/frontend/tests/unit/store/modules/tenant.spec.js
+++ b/app/frontend/tests/unit/store/modules/tenant.spec.js
@@ -118,6 +118,51 @@ describe('tenant store', () => {
     });
   });
 
+  // ---- isTenantRestoring getter ----
+
+  describe('isTenantRestoring', () => {
+    beforeEach(() => {
+      authStore.ready = true;
+      authStore.authenticated = true;
+      tenantStore.isRestoring = true;
+      tenantStore.selectedTenant = null;
+    });
+
+    it('returns true when all conditions are met', () => {
+      expect(tenantStore.isTenantRestoring).toBe(true);
+    });
+
+    it('returns false when feature flag is disabled', () => {
+      appStore.config = { tenantFeatureEnabled: false };
+      expect(tenantStore.isTenantRestoring).toBe(false);
+    });
+
+    it('returns false when feature flag is string "false"', () => {
+      appStore.config = { tenantFeatureEnabled: 'false' };
+      expect(tenantStore.isTenantRestoring).toBe(false);
+    });
+
+    it('returns false when selectedTenant is set', () => {
+      tenantStore.selectedTenant = { id: 't1' };
+      expect(tenantStore.isTenantRestoring).toBe(false);
+    });
+
+    it('returns false when isRestoring is false', () => {
+      tenantStore.isRestoring = false;
+      expect(tenantStore.isTenantRestoring).toBe(false);
+    });
+
+    it('returns false when auth is not ready', () => {
+      authStore.ready = false;
+      expect(tenantStore.isTenantRestoring).toBe(false);
+    });
+
+    it('returns false when not authenticated', () => {
+      authStore.authenticated = false;
+      expect(tenantStore.isTenantRestoring).toBe(false);
+    });
+  });
+
   // ---- isBCServicesCardUser getter ----
 
   describe('isBCServicesCardUser', () => {

--- a/app/frontend/tests/unit/store/modules/tenant.spec.js
+++ b/app/frontend/tests/unit/store/modules/tenant.spec.js
@@ -82,14 +82,14 @@ describe('tenant store', () => {
   // ---- isTenantFeatureEnabled getter ----
 
   describe('isTenantFeatureEnabled', () => {
-    it('returns true when config is not set (default)', () => {
+    it('returns false when config is not set (default)', () => {
       appStore.config = {};
-      expect(tenantStore.isTenantFeatureEnabled).toBe(true);
+      expect(tenantStore.isTenantFeatureEnabled).toBe(false);
     });
 
-    it('returns true when config is null', () => {
+    it('returns false when config is null', () => {
       appStore.config = null;
-      expect(tenantStore.isTenantFeatureEnabled).toBe(true);
+      expect(tenantStore.isTenantFeatureEnabled).toBe(false);
     });
 
     it('returns true when tenantFeatureEnabled is true', () => {

--- a/openshift/app.deployment.yaml
+++ b/openshift/app.deployment.yaml
@@ -300,7 +300,7 @@ objects:
                 - configMapRef:
                     name: "${APP_NAME}-custombcaddressformiocomponent-config"
                 - configMapRef:
-                    name: "${APP_NAME}-cstar-config"
+                    name: "${APP_NAME}-${JOB_NAME}-cstar-config"
                 - configMapRef:
                     name: "${APP_NAME}-${JOB_NAME}-event-stream-service"
                 - configMapRef:

--- a/openshift/cstar.cm.yaml
+++ b/openshift/cstar.cm.yaml
@@ -12,7 +12,7 @@ objects:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: "${APP_NAME}-cstar-config"
+      name: "${APP_NAME}-${JOB_NAME}-cstar-config"
     data:
       TENANT_FEATURE_ENABLED: ${TENANT_FEATURE_ENABLED}
       CSTAR_BASE_URL: ${CSTAR_BASE_URL}
@@ -25,6 +25,10 @@ parameters:
   - name: APP_NAME
     description: Application name
     displayName: Application name
+    required: true
+  - name: JOB_NAME
+    description: Job/Instance name
+    displayName: Job Name
     required: true
   - name: TENANT_FEATURE_ENABLED
     description: Enable or disable the multitenancy feature

--- a/openshift/cstar.pr.param
+++ b/openshift/cstar.pr.param
@@ -1,3 +1,3 @@
-TENANT_FEATURE_ENABLED=true
+TENANT_FEATURE_ENABLED=false
 CSTAR_BASE_URL=https://cstar-dev.apps.gold.devops.gov.bc.ca
 CSTAR_ENDPOINT=https://cstar-dev.apps.gold.devops.gov.bc.ca/api/v1/

--- a/openshift/cstar.pr.param
+++ b/openshift/cstar.pr.param
@@ -1,0 +1,3 @@
+TENANT_FEATURE_ENABLED=true
+CSTAR_BASE_URL=https://cstar-dev.apps.gold.devops.gov.bc.ca
+CSTAR_ENDPOINT=https://cstar-dev.apps.gold.devops.gov.bc.ca/api/v1/


### PR DESCRIPTION
 
  ## Description

  PR deployments were sharing a single `chefs-cstar-config` ConfigMap with the dev
  environment because the CSTAR ConfigMap name did not include `JOB_NAME`. This meant
  every PR deployment overwrote the shared dev ConfigMap, and dev deployments overwrote
  it back — causing whichever ran last to win. ESS and ClamAV already used the
  `${APP_NAME}-${JOB_NAME}-...` naming pattern; CSTAR was the only one missing it.

  Additionally, PR environments need `TENANT_FEATURE_ENABLED=true` (for testing the
  enterprise feature), while the dev environment has it set to `false` by default. There
  was no PR-specific param file for CSTAR, so PR deployments incorrectly inherited dev
  settings.

  ### Changes

  - **`openshift/cstar.cm.yaml`** — Added `JOB_NAME` to ConfigMap name:
    `${APP_NAME}-cstar-config` → `${APP_NAME}-${JOB_NAME}-cstar-config`
    Added `JOB_NAME` as a template parameter (matching ESS and ClamAV pattern)

  - **`openshift/app.deployment.yaml`** — Updated the `envFrom` ConfigMap reference
    to match the new name `${APP_NAME}-${JOB_NAME}-cstar-config`

  - **`openshift/cstar.pr.param`** — New param file for PR deployments with
    `TENANT_FEATURE_ENABLED=true` pointing to the dev CSTAR instance

  - **`.github/actions/deploy-to-environment/action.yaml`** — Deploy CSTAR ConfigMaps
    step now passes `-p JOB_NAME` and uses `cstar.pr.param` for PR deployments
    instead of `cstar.dev.param`

  ## Type of Change

  <!-- ci (change in continuous integration / deployment) -->

  ## Further comments

  After this is merged, the orphaned `chefs-cstar-config` ConfigMap in the dev OpenShift
  namespace will need to be manually cleaned up — it is no longer referenced by any
  deployment.

  This fix must be merged to the base branch before PR deployments from other branches
  benefit from the isolated ConfigMap naming, since `pr_deploy.yaml` uses the actio Description:
  ## Description

  PR deployments were sharing a single `chefs-cstar-config` ConfigMap with the dev
  environment because the CSTAR ConfigMap name did not include `JOB_NAME`. This meant
  every PR deployment overwrote the shared dev ConfigMap, and dev deployments overwrote
  it back — causing whichever ran last to win. ESS and ClamAV already used the
  `${APP_NAME}-${JOB_NAME}-...` naming pattern; CSTAR was the only one missing it.

  Additionally, PR environments need `TENANT_FEATURE_ENABLED=true` (for testing the
  enterprise feature), while the dev environment has it set to `false` by default. There
  was no PR-specific param file for CSTAR, so PR deployments incorrectly inherited dev
  settings.

  ### Changes

  - **`openshift/cstar.cm.yaml`** — Added `JOB_NAME` to ConfigMap name:
    `${APP_NAME}-cstar-config` → `${APP_NAME}-${JOB_NAME}-cstar-config`
    Added `JOB_NAME` as a template parameter (matching ESS and ClamAV pattern)

  - **`openshift/app.deployment.yaml`** — Updated the `envFrom` ConfigMap reference
    to match the new name `${APP_NAME}-${JOB_NAME}-cstar-config`

  - **`openshift/cstar.pr.param`** — New param file for PR deployments with
    `TENANT_FEATURE_ENABLED=true` pointing to the dev CSTAR instance

  - **`.github/actions/deploy-to-environment/action.yaml`** — Deploy CSTAR ConfigMaps
    step now passes `-p JOB_NAME` and uses `cstar.pr.param` for PR deployments
    instead of `cstar.dev.param`

  ## Type of Change

  <!-- ci (change in continuous integration / deployment) -->

  ## Further comments

  After this is merged, the orphaned `chefs-cstar-config` ConfigMap in the dev OpenShift
  namespace will need to be manually cleaned up — it is no longer referenced by any
  deployment.

  This fix must be merged to the base branch before PR deployments from other branches
  benefit from the isolated ConfigMap naming, since `pr_deploy.yaml` uses the action form the main branch