### PR TITLE
My form list update with correct list

### DIFF
--- a/app/src/components/tenantService.js
+++ b/app/src/components/tenantService.js
@@ -2,6 +2,7 @@ const config = require('config');
 const axios = require('axios');
 const jwtService = require('./jwtService');
 const idpService = require('./idpService');
+const log = require('./log')(module.filename);
 const SERVICE = 'TenantService';
 const endpoint = config.get('cstar.endpoint');
 const listUserTenantsPath = config.get('cstar.listUserTenantsPath');
@@ -144,8 +145,14 @@ class TenantService {
     const formGroups = await FormGroup.query().where({ formId }).select('groupId');
     const associatedGroupIds = formGroups.map((fg) => fg.groupId);
 
-    // Source of truth
-    const allTenantGroups = await this.getGroupsForCurrentTenant(req);
+    // Source of truth — degrade gracefully if CSTAR is unavailable so a
+    // transient outage doesn't produce an error alert that persists across navigation.
+    let allTenantGroups = [];
+    try {
+      allTenantGroups = await this.getGroupsForCurrentTenant(req);
+    } catch (err) {
+      log.error(`${SERVICE}: failed to fetch tenant groups for ${req.currentUser.tenantId}, degrading to empty group list`, err);
+    }
 
     // Associated and present
     const associatedGroups = allTenantGroups

--- a/app/src/forms/auth/service.js
+++ b/app/src/forms/auth/service.js
@@ -142,10 +142,34 @@ const service = {
     } else {
       // if user has an id, then we fetch whatever forms match the query params
       items = await UserFormAccess.query().modify('filterUserId', userInfo.id).modify('filterFormId', params.formId).modify('filterActive', params.active);
-      // Group-only tenanted forms (no idps) are only visible/resolvable while
-      // the user is actively in that tenant's context. Outside of that
-      // context they must not appear, even if the user happens to belong to
-      // a matching group, so we leave their roles unresolved (empty) here.
+
+      // For single-form permission checks (params.formId set, e.g. hasFormPermissions
+      // middleware on /form/submit, /user/draft, /user/view), resolve group-based roles
+      // using the form's own tenantId from form_tenant — not from the request header,
+      // since those routes never send x-tenant-id by design. This lets legitimate group
+      // members access the form regardless of which tenant is currently selected in the UI.
+      //
+      // For list-all calls (no formId, e.g. "My Forms"), skip resolution: group-only
+      // forms must only appear when that tenant is actively selected (branch above).
+      if (params.formId && headers) {
+        const userGroupsByTenant = new Map();
+        const allRoles = await Role.query().withGraphFetched('permissions');
+        for (const item of items) {
+          if (item && item.tenantId && Array.isArray(item.idps) && item.idps.length === 0) {
+            if (!userGroupsByTenant.has(item.tenantId)) {
+              let userGroups = [];
+              try {
+                userGroups = await tenantService.getUserTenantGroupsAndRoles({ currentUser: userInfo, headers }, item.tenantId);
+              } catch (err) {
+                log.error(`Failed to fetch tenant groups/roles for form ${item.formId} (tenant ${item.tenantId})`, err);
+              }
+              userGroupsByTenant.set(item.tenantId, userGroups);
+            }
+            await service.populateItemWithTenantRoles(item, userGroupsByTenant.get(item.tenantId), allRoles);
+          }
+        }
+      }
+
       return service.filterForms(userInfo, items, params.accessLevels);
     }
   },

--- a/app/src/forms/auth/service.js
+++ b/app/src/forms/auth/service.js
@@ -126,7 +126,12 @@ const service = {
         .modify('filterActive', params.active)
         .modify('filterTenantId', userInfo.tenantId);
 
-      const userGroups = await tenantService.getUserTenantGroupsAndRoles({ currentUser: userInfo, headers }, userInfo.tenantId);
+      let userGroups = [];
+      try {
+        userGroups = await tenantService.getUserTenantGroupsAndRoles({ currentUser: userInfo, headers }, userInfo.tenantId);
+      } catch (err) {
+        log.error(`Failed to fetch tenant groups/roles for tenant ${userInfo.tenantId}`, err);
+      }
       const allRoles = await Role.query().withGraphFetched('permissions');
 
       for (const item of items) {
@@ -137,22 +142,10 @@ const service = {
     } else {
       // if user has an id, then we fetch whatever forms match the query params
       items = await UserFormAccess.query().modify('filterUserId', userInfo.id).modify('filterFormId', params.formId).modify('filterActive', params.active);
-      const userGroupsByTenant = new Map();
-      const allRoles = await Role.query().withGraphFetched('permissions');
-      for (const item of items) {
-        if (item && item.tenantId && Array.isArray(item.idps) && item.idps.length === 0) {
-          // Group-only tenanted forms need tenant context to look up roles; skip if no headers
-          if (!headers) continue;
-
-          if (!userGroupsByTenant.has(item.tenantId)) {
-            const userGroups = await tenantService.getUserTenantGroupsAndRoles({ currentUser: userInfo, headers }, item.tenantId);
-            userGroupsByTenant.set(item.tenantId, userGroups);
-          }
-
-          await service.populateItemWithTenantRoles(item, userGroupsByTenant.get(item.tenantId), allRoles);
-        }
-      }
-
+      // Group-only tenanted forms (no idps) are only visible/resolvable while
+      // the user is actively in that tenant's context. Outside of that
+      // context they must not appear, even if the user happens to belong to
+      // a matching group, so we leave their roles unresolved (empty) here.
       return service.filterForms(userInfo, items, params.accessLevels);
     }
   },

--- a/app/src/forms/rbac/service.js
+++ b/app/src/forms/rbac/service.js
@@ -5,6 +5,7 @@ const { Roles } = require('../common/constants');
 const { queryUtils } = require('../common/utils');
 const authService = require('../auth/service');
 const idpService = require('../../components/idpService');
+const log = require('../../components/log')(module.filename);
 
 const service = {
   list: async () => {
@@ -93,7 +94,8 @@ const service = {
       );
       const filteredForms = authService.filterForms(currentUser, forms, accessLevels);
       return filteredForms;
-    } catch {
+    } catch (err) {
+      log.error('Failed to get current user forms', err);
       return [];
     }
   },

--- a/app/tests/unit/components/tenantService.spec.js
+++ b/app/tests/unit/components/tenantService.spec.js
@@ -479,7 +479,7 @@ describe('TenantService', () => {
       await expect(tenantService.getFormGroups(req, formId)).rejects.toThrow('DB error');
     });
 
-    it('should throw error when getGroupsForCurrentTenant fails', async () => {
+    it('should degrade gracefully when getGroupsForCurrentTenant fails (CSTAR unavailable)', async () => {
       FormTenant.query.mockReturnValue({
         where: jest.fn().mockReturnValue({
           first: jest.fn().mockResolvedValue({ formId, tenantId: tenantId }),
@@ -488,13 +488,24 @@ describe('TenantService', () => {
 
       FormGroup.query.mockReturnValue({
         where: jest.fn().mockReturnValue({
-          select: jest.fn().mockResolvedValue([]),
+          select: jest.fn().mockResolvedValue([{ groupId: 'group-1' }]),
         }),
       });
 
       mockAxios.onGet(apiUrl).networkError();
 
-      await expect(tenantService.getFormGroups(req, formId)).rejects.toThrow();
+      const result = await tenantService.getFormGroups(req, formId);
+      expect(result.associatedGroups).toEqual([]);
+      expect(result.availableGroups).toEqual([]);
+      expect(result.missingGroups).toEqual([
+        {
+          id: 'group-1',
+          name: 'Group no longer available',
+          description: 'This group may have been deleted from the tenant',
+          isAssociated: true,
+          isDeleted: true,
+        },
+      ]);
     });
   });
 

--- a/app/tests/unit/forms/auth/authService.spec.js
+++ b/app/tests/unit/forms/auth/authService.spec.js
@@ -198,7 +198,7 @@ describe('getUserForms', () => {
     expect(tenantSpy).not.toHaveBeenCalled();
   });
 
-  it('personal path: tenanted group-only form does not resolve tenant roles even when headers are present', async () => {
+  it('personal path: group-only form without formId param does not resolve tenant roles (list-all / My Forms case)', async () => {
     const userInfo = { id: 'user-1' };
     const headers = { authorization: 'Bearer token' };
     const items = [{ formId: 'group-form', tenantId: 'tenant-1', idps: [], roles: [], permissions: [] }];
@@ -209,12 +209,36 @@ describe('getUserForms', () => {
     const tenantSpy = jest.spyOn(tenantService, 'getUserTenantGroupsAndRoles');
     jest.spyOn(service, 'filterForms').mockReturnValue([]);
 
-    // Outside of an actively selected tenant, group-only forms must stay unresolved
-    // (and therefore excluded) regardless of whether headers happen to be present.
+    // No formId in params → list-all path (My Forms). Group-only forms must stay
+    // unresolved so they are excluded outside of an actively selected tenant context.
     const result = await service.getUserForms(userInfo, {}, headers);
 
     expect(tenantSpy).not.toHaveBeenCalled();
     expect(result).toEqual([]);
+  });
+
+  it('personal path: group-only form WITH formId param resolves tenant roles via form own tenantId (single-form permission check)', async () => {
+    const userInfo = { id: 'user-1' };
+    const headers = { authorization: 'Bearer token' };
+    const items = [{ formId: 'group-form', tenantId: 'tenant-1', idps: [], roles: [], permissions: [] }];
+
+    jest.spyOn(queryUtils, 'defaultActiveOnly').mockReturnValue({ formId: 'group-form', active: true });
+    const queryObj = makeQueryObj(items);
+    jest.spyOn(UserFormAccess, 'query').mockReturnValue(queryObj);
+    jest.spyOn(Role, 'query').mockReturnValue({
+      withGraphFetched: jest.fn().mockResolvedValue([{ code: 'submission_reviewer', permissions: [{ code: 'submission_read' }] }]),
+    });
+    jest.spyOn(FormGroup, 'query').mockReturnValue({ modify: jest.fn().mockResolvedValue([{ groupId: 'group-1' }]) });
+    jest.spyOn(tenantService, 'getUserTenantGroupsAndRoles').mockResolvedValue([{ id: 'group-1', roles: ['submission_reviewer'] }]);
+    jest.spyOn(service, 'filterForms').mockReturnValue(['group-form']);
+
+    // formId in params → single-form permission check (e.g. hasFormPermissions on
+    // /form/submit or /user/draft which never send x-tenant-id). Roles must be
+    // resolved using the form's own tenantId so legitimate group members get access.
+    const result = await service.getUserForms(userInfo, { formId: 'group-form' }, headers);
+
+    expect(tenantService.getUserTenantGroupsAndRoles).toHaveBeenCalledWith({ currentUser: userInfo, headers }, 'tenant-1');
+    expect(result).toEqual(['group-form']);
   });
 
   it('returns filtered tenant forms and enriches with tenant roles/permissions when headers are provided', async () => {

--- a/app/tests/unit/forms/auth/authService.spec.js
+++ b/app/tests/unit/forms/auth/authService.spec.js
@@ -198,7 +198,7 @@ describe('getUserForms', () => {
     expect(tenantSpy).not.toHaveBeenCalled();
   });
 
-  it('personal path: tenanted group-only form populates tenant roles when headers are present', async () => {
+  it('personal path: tenanted group-only form does not resolve tenant roles even when headers are present', async () => {
     const userInfo = { id: 'user-1' };
     const headers = { authorization: 'Bearer token' };
     const items = [{ formId: 'group-form', tenantId: 'tenant-1', idps: [], roles: [], permissions: [] }];
@@ -206,17 +206,15 @@ describe('getUserForms', () => {
     jest.spyOn(queryUtils, 'defaultActiveOnly').mockReturnValue({ active: true });
     const queryObj = makeQueryObj(items);
     jest.spyOn(UserFormAccess, 'query').mockReturnValue(queryObj);
-    jest.spyOn(Role, 'query').mockReturnValue({
-      withGraphFetched: jest.fn().mockResolvedValue([{ code: 'submission_reviewer', permissions: [{ code: 'submission_read' }] }]),
-    });
-    jest.spyOn(FormGroup, 'query').mockReturnValue({ modify: jest.fn().mockResolvedValue([{ groupId: 'group-1' }]) });
-    jest.spyOn(tenantService, 'getUserTenantGroupsAndRoles').mockResolvedValue([{ id: 'group-1', roles: ['submission_reviewer'] }]);
-    jest.spyOn(service, 'filterForms').mockReturnValue(['group-form']);
+    const tenantSpy = jest.spyOn(tenantService, 'getUserTenantGroupsAndRoles');
+    jest.spyOn(service, 'filterForms').mockReturnValue([]);
 
+    // Outside of an actively selected tenant, group-only forms must stay unresolved
+    // (and therefore excluded) regardless of whether headers happen to be present.
     const result = await service.getUserForms(userInfo, {}, headers);
 
-    expect(tenantService.getUserTenantGroupsAndRoles).toHaveBeenCalledWith({ currentUser: userInfo, headers }, 'tenant-1');
-    expect(result).toEqual(['group-form']);
+    expect(tenantSpy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
   });
 
   it('returns filtered tenant forms and enriches with tenant roles/permissions when headers are provided', async () => {


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
 Fixes two related bugs in tenant-aware form access resolution (`authService.getUserForms`):

  1. **Group-only tenant forms leaking into "My Forms"** — a form created inside a tenant
     and restricted to specific groups (no IDPs configured) was showing up in a user's
     default "My Forms" list even when they had no tenant selected, as long as they
     happened to belong to a matching group. It should only be visible/usable while that
     tenant is actively selected (this already worked correctly for forms with an IDP,
     e.g. `idir`).

  2. **External CSTAR service failures wiping the whole form list** — `getUserForms`
     called `tenantService.getUserTenantGroupsAndRoles` (an external HTTP call) with no
     error handling. Any failure there propagated up through `getCurrentUserForms` and
     hit a blanket `catch { return []; }`, silently returning an empty form list for the
     user — including forms they should have always had access to (IDP/public). This
     was observed in dev right after the tenant feature was enabled: some users saw no
     forms at all in "My Forms," including pre-existing and newly created ones.

  ## Root cause
  - In `getUserForms`'s default (no-tenant-selected) branch, every form-access row
    across *all* of the user's tenants was being resolved against that form's own
    `tenantId` (via `form_tenant`) regardless of which tenant the user currently had
    selected — so group-only forms always resolved roles and passed the `filterForms`
    check, no matter the active tenant context.
  - The CSTAR group/role lookup had no try/catch, so a transient external-service error
    during that lookup took down the entire forms list instead of degrading gracefully.

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
