### PR TITLE
fix: file access for api, transaction race conditions

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,12 @@
   },
 
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      // The feature's "latest" buildx detection resolves to a tag whose
+      // linux-arm64 artifact is not published, causing a 404 during install.
+      // moby-buildx is already installed via apt, so skip the extra download.
+      "installDockerBuildx": false
+    },
     "ghcr.io/devcontainers/features/git:1": {}
   },
 

--- a/app/src/forms/file/routes.js
+++ b/app/src/forms/file/routes.js
@@ -1,6 +1,6 @@
 const routes = require('express').Router();
 
-const apiAccess = require('../public/middleware/apiAccess');
+const basicApiAccess = require('../auth/middleware/apiAccess');
 const { currentUser } = require('../auth/middleware/userAccess');
 const P = require('../common/constants').Permissions;
 const validateParameter = require('../common/middleware/validateParameter');
@@ -23,15 +23,30 @@ routes.delete('/', hasFileDelete, async (req, res, next) => {
   await controller.deleteFiles(req, res, next);
 });
 
-routes.get('/:fileId', apiAccess.checkApiKey, currentFileRecord, hasFilePermissions([P.SUBMISSION_READ]), async (req, res, next) => {
+// Auth chain for the /:fileId routes (runs top to bottom):
+//   1. currentUser (added by routes.use above) - if a Bearer token is sent it must
+//      be valid (else 401); no token just means the request continues as a public user.
+//   2. basicApiAccess - only acts on "Authorization: Basic <formId:apiKey>". Valid
+//      Basic creds set req.apiUser (API access to protected forms, honours the form's
+//      filesApiAccess flag); bad creds are rejected (401). Anything that isn't Basic
+//      (public, Bearer) is left alone and falls through.
+//   3. currentFileRecord - loads the file row, or 403s if it can't be found.
+//   4. hasFilePermissions - the real gate:
+//        - req.apiUser  -> allowed.
+//        - draft file (no submissionId yet) -> allowed, so a public submitter can
+//          read/delete their own upload before the form is submitted.
+//        - submitted file + public user -> 403.
+//        - submitted file + logged-in user -> checked against submission permissions
+//          (public forms still allow SUBMISSION_READ).
+routes.get('/:fileId', basicApiAccess, currentFileRecord, hasFilePermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.read(req, res, next);
 });
 
-routes.get('/:fileId/clone', apiAccess.checkApiKey, currentFileRecord, hasFilePermissions([P.SUBMISSION_READ]), async (req, res, next) => {
+routes.get('/:fileId/clone', basicApiAccess, currentFileRecord, hasFilePermissions([P.SUBMISSION_READ]), async (req, res, next) => {
   await controller.clone(req, res, next);
 });
 
-routes.delete('/:fileId', apiAccess.checkApiKey, currentFileRecord, hasFilePermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
+routes.delete('/:fileId', basicApiAccess, currentFileRecord, hasFilePermissions([P.SUBMISSION_UPDATE]), async (req, res, next) => {
   await controller.delete(req, res, next);
 });
 

--- a/app/src/forms/file/service.js
+++ b/app/src/forms/file/service.js
@@ -136,20 +136,48 @@ const service = {
   },
 
   /**
+   * Best-effort deletion of the stored object for a file, without touching the
+   * database record. Used to remove the original object after a submission file
+   * has been copied to permanent storage, and to purge orphaned objects once the
+   * DB rows are gone. Storage failures are logged and swallowed so they can't
+   * undo work that has already been committed.
+   *
+   * @param {FileStorage} fileStorage the file storage object to remove.
+   * @returns {boolean} true if the object was removed.
+   */
+  deleteStorageObject: async (fileStorage) => {
+    try {
+      return await storageService.delete(fileStorage);
+    } catch (err) {
+      log.error(`Failed to delete stored object for file ${fileStorage?.id}`, err);
+      return false;
+    }
+  },
+
+  /**
    * Move a submission file from the "upload" storage location to the
    * "submission" location. This is used when a submission is either saved as
    * draft or submitted, and makes the uploaded files permanent.
    *
+   * When an existing transaction is supplied the database update runs inside it
+   * and the caller owns both the commit and the cleanup of the original object
+   * (which must happen only after the commit). This avoids opening a second
+   * transaction that would deadlock against the caller's row lock. Without a
+   * transaction this manages its own and cleans up the original itself.
+   *
    * @param {uuidv4} submissionId the id of the submission that holds the file.
    * @param {FileStorage} fileStorage the file storage object for the file.
    * @param {string} updatedBy the user who is saving the submission.
+   * @param {object} [etrx] an optional existing transaction to run within.
+   * @returns {FileStorage} the original file storage object (pre-move), so the
+   *   caller can clean up the source object after committing.
    */
-  moveSubmissionFile: async (submissionId, fileStorage, updatedBy) => {
+  moveSubmissionFile: async (submissionId, fileStorage, updatedBy, etrx = undefined) => {
     let trx;
     try {
-      trx = await FileStorage.startTransaction();
+      trx = etrx || (await FileStorage.startTransaction());
 
-      // Move the file from its current directory to the "submissions" subdirectory.
+      // Copy the file from its current directory to the "submissions" subdirectory.
       const path = await storageService.move(fileStorage, 'submissions', submissionId);
       if (!path) {
         throw new Error('Error moving files for submission');
@@ -162,16 +190,15 @@ const service = {
         updatedBy: updatedBy,
       });
 
-      await trx.commit();
-
-      // Only after successful commit, remove the original object from storage.
-      try {
-        await storageService.delete(fileStorage);
-      } catch (delErr) {
-        log.error(`Failed to delete original file after move for file ${fileStorage.id}`, delErr);
+      // Only manage commit/cleanup when we own the transaction.
+      if (!etrx) {
+        await trx.commit();
+        await service.deleteStorageObject(fileStorage);
       }
+
+      return fileStorage;
     } catch (err) {
-      if (trx) await trx.rollback();
+      if (!etrx && trx) await trx.rollback();
       throw err;
     }
   },

--- a/app/src/forms/file/service.js
+++ b/app/src/forms/file/service.js
@@ -143,7 +143,7 @@ const service = {
    * undo work that has already been committed.
    *
    * @param {FileStorage} fileStorage the file storage object to remove.
-   * @returns {boolean} true if the object was removed.
+   * @returns {Promise<boolean>} true if the object was removed.
    */
   deleteStorageObject: async (fileStorage) => {
     try {
@@ -168,9 +168,9 @@ const service = {
    * @param {uuidv4} submissionId the id of the submission that holds the file.
    * @param {FileStorage} fileStorage the file storage object for the file.
    * @param {string} updatedBy the user who is saving the submission.
-   * @param {object} [etrx] an optional existing transaction to run within.
-   * @returns {FileStorage} the original file storage object (pre-move), so the
-   *   caller can clean up the source object after committing.
+   * @param {*} [etrx] an optional existing transaction to run within.
+   * @returns {Promise<FileStorage>} the original file storage object (pre-move),
+   *   so the caller can clean up the source object after committing.
    */
   moveSubmissionFile: async (submissionId, fileStorage, updatedBy, etrx = undefined) => {
     let trx;

--- a/app/src/forms/public/middleware/apiAccess.js
+++ b/app/src/forms/public/middleware/apiAccess.js
@@ -1,8 +1,29 @@
+const crypto = require('node:crypto');
 const Problem = require('api-problem');
 
 /**
+ * Constant-time comparison of two strings. Returns false on any length
+ * mismatch (and never throws) so it is safe to feed user-supplied input.
+ *
+ * @param {string} a the first value to compare.
+ * @param {string} b the second value to compare.
+ * @returns {boolean} true only if both values are identical.
+ */
+const _safeCompare = (a, b) => {
+  const bufA = Buffer.from(String(a));
+  const bufB = Buffer.from(String(b));
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(bufA, bufB);
+};
+
+/**
  * Checks that the API Key in the request headers matches the API Key in the
- * process environment variables.
+ * process environment variables. This guards system-only endpoints (the
+ * reminder and records-management deletion cron routes), so it deliberately
+ * only honours the `apikey` header - an `Authorization` header (Bearer/Basic)
+ * must NOT be treated as a way past this check.
  *
  * @param {*} req the Express object representing the HTTP request.
  * @param {*} _res the Express object representing the HTTP response - unused.
@@ -11,18 +32,22 @@ const Problem = require('api-problem');
 const checkApiKey = async (req, _res, next) => {
   try {
     const requestApikey = req.headers.apikey;
-    const requestToken = req.headers.authorization;
-    if (requestToken) {
-      return next();
-    }
     if (requestApikey === undefined || requestApikey === '') {
       throw new Problem(401, {
         detail: 'No API key provided',
       });
     }
 
+    // Fail closed: if the server has no API key configured then nothing can
+    // satisfy this check, so never fall through to next().
     const systemApikey = process.env.APITOKEN;
-    if (requestApikey !== systemApikey) {
+    if (!systemApikey) {
+      throw new Problem(401, {
+        detail: 'Invalid API key',
+      });
+    }
+
+    if (!_safeCompare(requestApikey, systemApikey)) {
       throw new Problem(401, {
         detail: 'Invalid API key',
       });

--- a/app/src/forms/submission/service.js
+++ b/app/src/forms/submission/service.js
@@ -184,12 +184,13 @@ const service = {
    */
   deleteSubmissionAndRelatedData: async (submissionId) => {
     let trx;
+    let fileRecords = [];
     try {
       trx = await FileStorage.startTransaction();
 
-      // Delete the file from the storage service first
-      const fileRecords = await FileStorage.query(trx).where('formSubmissionId', submissionId);
-      fileService.deleteFiles(fileRecords.map((file) => file.id));
+      // Capture the file rows up front so we can remove the stored objects once
+      // everything has been deleted from the database and committed.
+      fileRecords = await FileStorage.query(trx).where('formSubmissionId', submissionId);
 
       // Delete in the correct order based on foreign key dependencies
 
@@ -209,6 +210,14 @@ const service = {
       const result = await FormSubmission.query(trx).where('id', submissionId).delete();
 
       await trx.commit();
+
+      // Now that the DB rows are committed, purge the stored objects. This is
+      // best-effort and runs outside the transaction: a storage failure just
+      // leaves an orphan to be cleaned up later rather than failing the delete.
+      for (const file of fileRecords) {
+        await fileService.deleteStorageObject(file);
+      }
+
       return { success: result > 0 };
     } catch (error) {
       if (trx) await trx.rollback();

--- a/app/src/forms/submission/updateService.js
+++ b/app/src/forms/submission/updateService.js
@@ -1,4 +1,4 @@
-const { FileStorage, FormSubmission, FormSubmissionStatus, SubmissionMetadata } = require('../common/models');
+const { FormSubmission, FormSubmissionStatus, SubmissionMetadata } = require('../common/models');
 const emailService = require('../email/emailService');
 const eventService = require('../event/eventService');
 const fileService = require('../file/service');
@@ -43,20 +43,23 @@ const service = {
 
   _handleFileUploads: async (submissionService, data, id, user, trx) => {
     const fileIds = submissionService._findFileIds(data);
+    const movedFiles = [];
     for (const fileId of fileIds) {
       const fileStorage = await fileService.read(fileId);
       if (!fileStorage.formSubmissionId) {
-        await FileStorage.query(trx).patchAndFetchById(fileId, { formSubmissionId: id, updatedBy: user.usernameIdp });
-
-        // move file and update storage/path atomically to ensure we don't swallow errors
+        // Run the file's row update inside the submission transaction so it does
+        // not deadlock against the lock this transaction holds. The original
+        // object is removed by the caller once the transaction has committed.
         try {
-          await fileService.moveSubmissionFile(id, fileStorage, user.usernameIdp);
+          const moved = await fileService.moveSubmissionFile(id, fileStorage, user.usernameIdp, trx);
+          movedFiles.push(moved || fileStorage);
         } catch (error) {
           log.error('Error moving file', { error, fileId, submissionId: id, userId: user.usernameIdp, originalName: fileStorage.originalName });
           throw error;
         }
       }
     }
+    return movedFiles;
   },
 
   _sendNotifications: async (updated, data, referrer, submissionReceived, formSubmissionId) => {
@@ -82,6 +85,7 @@ const service = {
     let trx;
     let result;
     let submissionReceived = false;
+    let movedFiles = [];
     try {
       trx = etrx || (await FormSubmissionStatus.startTransaction());
       log.info(`Starting update for submissionId=${formSubmissionId} by user=${currentUser.usernameIdp}`);
@@ -105,11 +109,18 @@ const service = {
         submissionReceived = await service._handleStatusChange(submissionService, formSubmissionId, data, statuses, currentUser, trx);
         log.info(`Patched submissionId=${formSubmissionId} with new data`);
         await service._patchSubmission(formSubmissionId, data, currentUser, trx);
-        await service._handleFileUploads(submissionService, data, formSubmissionId, currentUser, trx);
+        movedFiles = (await service._handleFileUploads(submissionService, data, formSubmissionId, currentUser, trx)) || [];
       }
 
       if (!etrx) {
         await trx.commit();
+
+        // Files were copied to permanent storage inside the transaction; now that
+        // it is committed, remove the original (pre-move) objects. Best-effort: a
+        // storage failure just leaves an orphan and must not fail the submission.
+        for (const fileStorage of movedFiles) {
+          await fileService.deleteStorageObject(fileStorage);
+        }
         log.info(`Transaction committed for submissionId=${formSubmissionId}`);
       }
       result = await submissionService.read(formSubmissionId);

--- a/app/tests/unit/forms/file/routes.spec.js
+++ b/app/tests/unit/forms/file/routes.spec.js
@@ -3,7 +3,7 @@ const uuid = require('uuid');
 
 const { expressHelper } = require('../../../common/helper');
 
-const apiAccess = require('../../../../src/forms/public/middleware/apiAccess');
+const basicApiAccess = require('../../../../src/forms/auth/middleware/apiAccess');
 const userAccess = require('../../../../src/forms/auth/middleware/userAccess');
 const validateParameter = require('../../../../src/forms/common/middleware/validateParameter');
 const controller = require('../../../../src/forms/file/controller');
@@ -15,10 +15,9 @@ const upload = require('../../../../src/forms/file/middleware/upload');
 // correctly, not the functionality of the middleware.
 //
 
-jest.mock('../../../../src/forms/public/middleware/apiAccess');
-apiAccess.checkApiKey = jest.fn((_req, _res, next) => {
-  next();
-});
+// The /:fileId routes are guarded by the Basic-auth middleware (default export),
+// which sets req.apiUser for valid form API keys and falls through otherwise.
+jest.mock('../../../../src/forms/auth/middleware/apiAccess', () => jest.fn((_req, _res, next) => next()));
 
 filePermissions.currentFileRecord = jest.fn((_req, _res, next) => {
   next();
@@ -71,7 +70,7 @@ describe(`${basePath}`, () => {
 
     await appRequest.post(path);
 
-    expect(apiAccess.checkApiKey).toBeCalledTimes(0);
+    expect(basicApiAccess).toBeCalledTimes(0);
     expect(controller.create).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(0);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(1);
@@ -88,7 +87,7 @@ describe(`${basePath}`, () => {
 
     await appRequest.delete(path);
 
-    expect(apiAccess.checkApiKey).toBeCalledTimes(0);
+    expect(basicApiAccess).toBeCalledTimes(0);
     expect(controller.deleteFiles).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(0);
     expect(filePermissions.hasFileDelete).toBeCalledTimes(1);
@@ -110,7 +109,7 @@ describe(`${basePath}/:id`, () => {
 
     await appRequest.delete(path);
 
-    expect(apiAccess.checkApiKey).toBeCalledTimes(1);
+    expect(basicApiAccess).toBeCalledTimes(1);
     expect(controller.delete).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(1);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(0);
@@ -127,7 +126,7 @@ describe(`${basePath}/:id`, () => {
 
     await appRequest.get(path);
 
-    expect(apiAccess.checkApiKey).toBeCalledTimes(1);
+    expect(basicApiAccess).toBeCalledTimes(1);
     expect(controller.read).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(1);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(0);
@@ -149,7 +148,7 @@ describe(`${basePath}/:id/clone`, () => {
 
     await appRequest.get(path);
 
-    expect(apiAccess.checkApiKey).toBeCalledTimes(1);
+    expect(basicApiAccess).toBeCalledTimes(1);
     expect(controller.clone).toBeCalledTimes(1);
     expect(filePermissions.currentFileRecord).toBeCalledTimes(1);
     expect(filePermissions.hasFileCreate).toBeCalledTimes(0);

--- a/app/tests/unit/forms/file/service.spec.js
+++ b/app/tests/unit/forms/file/service.spec.js
@@ -236,7 +236,7 @@ describe('create', () => {
         patchAndFetchById: jest.fn().mockResolvedValue({}),
       });
 
-      await expect(service.moveSubmissionFile('subId', { id: 'fileId' }, 'user')).resolves.toBeUndefined();
+      await expect(service.moveSubmissionFile('subId', { id: 'fileId' }, 'user')).resolves.toEqual({ id: 'fileId' });
       expect(storageService.move).toHaveBeenCalled();
       expect(FileStorage.query().patchAndFetchById).toHaveBeenCalled();
     });
@@ -382,6 +382,61 @@ describe('create', () => {
       expect(mockTrx.commit).toHaveBeenCalled();
       // Delete was attempted
       expect(storageService.delete).toHaveBeenCalled();
+    });
+  });
+
+  describe('moveSubmissionFile with an external transaction', () => {
+    it('reuses the supplied transaction and does not commit, rollback, or delete the source', async () => {
+      const etrx = { commit: jest.fn(), rollback: jest.fn() };
+      const fileStorage = { id: 'fileId', path: 'uploads/fileId', storage: 'uploads' };
+      const patchAndFetchById = jest.fn().mockResolvedValue({});
+
+      const startTransactionSpy = jest.spyOn(FileStorage, 'startTransaction');
+      storageService.move = jest.fn().mockResolvedValue('/new/path');
+      storageService.delete = jest.fn().mockResolvedValue(true);
+      FileStorage.query = jest.fn().mockReturnValue({ patchAndFetchById });
+
+      const result = await service.moveSubmissionFile('subId', fileStorage, 'user', etrx);
+
+      // The DB update runs inside the supplied transaction.
+      expect(FileStorage.query).toHaveBeenCalledWith(etrx);
+      expect(patchAndFetchById).toHaveBeenCalledWith('fileId', expect.objectContaining({ formSubmissionId: 'subId', path: '/new/path' }));
+      // No second transaction is opened, and the caller owns commit + cleanup.
+      expect(startTransactionSpy).not.toHaveBeenCalled();
+      expect(etrx.commit).not.toHaveBeenCalled();
+      expect(etrx.rollback).not.toHaveBeenCalled();
+      expect(storageService.delete).not.toHaveBeenCalled();
+      // The original file is returned so the caller can clean it up post-commit.
+      expect(result).toBe(fileStorage);
+    });
+
+    it('does not roll back the supplied transaction when the move fails', async () => {
+      const etrx = { commit: jest.fn(), rollback: jest.fn() };
+      storageService.move = jest.fn().mockResolvedValue(null);
+
+      await expect(service.moveSubmissionFile('subId', { id: 'fileId' }, 'user', etrx)).rejects.toThrow('Error moving files for submission');
+      expect(etrx.rollback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteStorageObject', () => {
+    it('returns the storageService.delete result on success', async () => {
+      const fileStorage = { id: 'fileId' };
+      storageService.delete = jest.fn().mockResolvedValue(true);
+
+      const result = await service.deleteStorageObject(fileStorage);
+
+      expect(result).toBe(true);
+      expect(storageService.delete).toHaveBeenCalledWith(fileStorage);
+    });
+
+    it('swallows storage errors and returns false', async () => {
+      const fileStorage = { id: 'fileId' };
+      storageService.delete = jest.fn().mockRejectedValue(new Error('S3 down'));
+
+      const result = await service.deleteStorageObject(fileStorage);
+
+      expect(result).toBe(false);
     });
   });
 

--- a/app/tests/unit/forms/public/middleware/apiAccess.spec.js
+++ b/app/tests/unit/forms/public/middleware/apiAccess.spec.js
@@ -46,6 +46,50 @@ describe('checkApiKey', () => {
       expect(next).toBeCalledTimes(1);
       expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
     });
+
+    // Regression guard: an Authorization header must NOT bypass the apikey check.
+    // Previously a stray "if (req.headers.authorization) return next()" let any
+    // Bearer/Basic header through these system-only routes.
+    test('a Bearer Authorization header is present but no apikey', async () => {
+      const req = getMockReq({
+        headers: { authorization: 'Bearer some-token' },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess.checkApiKey(req, res, next);
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
+    });
+
+    test('a Basic Authorization header is present but no apikey', async () => {
+      const req = getMockReq({
+        headers: { authorization: 'Basic Zm9vOmJhcg==' },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess.checkApiKey(req, res, next);
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
+    });
+
+    test('a valid apikey is sent alongside an Authorization header but APITOKEN is not configured', async () => {
+      const savedToken = process.env.APITOKEN;
+      delete process.env.APITOKEN;
+
+      const req = getMockReq({
+        headers: { apikey: 'anything', authorization: 'Bearer some-token' },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess.checkApiKey(req, res, next);
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith(expect.objectContaining(expectedStatus));
+
+      process.env.APITOKEN = savedToken;
+    });
   });
 
   describe('allows', () => {
@@ -53,6 +97,21 @@ describe('checkApiKey', () => {
       const req = getMockReq({
         headers: {
           apikey: process.env.APITOKEN,
+        },
+      });
+      const { res, next } = getMockRes();
+
+      await apiAccess.checkApiKey(req, res, next);
+
+      expect(next).toBeCalledTimes(1);
+      expect(next).toBeCalledWith();
+    });
+
+    test('matching apikey even when an Authorization header is also present', async () => {
+      const req = getMockReq({
+        headers: {
+          apikey: process.env.APITOKEN,
+          authorization: 'Bearer some-token',
         },
       });
       const { res, next } = getMockRes();

--- a/app/tests/unit/forms/public/routes.auth.spec.js
+++ b/app/tests/unit/forms/public/routes.auth.spec.js
@@ -1,0 +1,64 @@
+const request = require('supertest');
+const uuid = require('uuid');
+
+const { expressHelper } = require('../../../common/helper');
+
+//
+// Unlike routes.spec.js (which mocks the middleware to test wiring), this suite
+// exercises the REAL checkApiKey middleware to lock down the auth behaviour of
+// the system-only /reminder route. Only the controller is stubbed.
+//
+const controller = require('../../../../src/forms/public/controller');
+controller.sendReminderToSubmitter = jest.fn((_req, res) => {
+  res.sendStatus(200);
+});
+
+const router = require('../../../../src/forms/public/routes');
+const basePath = '/public';
+const appRequest = request(expressHelper(basePath, router));
+
+const path = `${basePath}/reminder`;
+
+let savedToken;
+beforeAll(() => {
+  savedToken = process.env.APITOKEN;
+  process.env.APITOKEN = uuid.v4();
+});
+
+afterAll(() => {
+  process.env.APITOKEN = savedToken;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe(`GET ${path} auth`, () => {
+  it('401s when no credentials are sent', async () => {
+    const response = await appRequest.get(path);
+
+    expect(response.status).toBe(401);
+    expect(controller.sendReminderToSubmitter).not.toBeCalled();
+  });
+
+  it('401s when only an Authorization header is sent (no apikey bypass)', async () => {
+    const response = await appRequest.get(path).set({ authorization: 'Bearer some-token' });
+
+    expect(response.status).toBe(401);
+    expect(controller.sendReminderToSubmitter).not.toBeCalled();
+  });
+
+  it('401s when the apikey does not match', async () => {
+    const response = await appRequest.get(path).set({ apikey: uuid.v4() });
+
+    expect(response.status).toBe(401);
+    expect(controller.sendReminderToSubmitter).not.toBeCalled();
+  });
+
+  it('200s when a matching apikey is sent', async () => {
+    const response = await appRequest.get(path).set({ apikey: process.env.APITOKEN });
+
+    expect(response.status).toBe(200);
+    expect(controller.sendReminderToSubmitter).toBeCalledTimes(1);
+  });
+});

--- a/app/tests/unit/forms/recordsManagement/routes.spec.js
+++ b/app/tests/unit/forms/recordsManagement/routes.spec.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+const uuid = require('uuid');
+
+const { expressHelper } = require('../../../common/helper');
+
+//
+// Lock down the auth on the system-only deletion endpoint. This route is called
+// by an OpenShift cron with the `apikey` header, and must NOT be reachable by
+// sending an arbitrary Authorization header. checkApiKey runs for real here; the
+// controller is stubbed so we don't touch the service/database layer.
+//
+jest.mock('../../../../src/forms/recordsManagement/controller');
+const controller = require('../../../../src/forms/recordsManagement/controller');
+controller.processDeletions = jest.fn((_req, res) => {
+  res.sendStatus(200);
+});
+
+const router = require('../../../../src/forms/recordsManagement/routes');
+const basePath = '/recordsManagement';
+const appRequest = request(expressHelper(basePath, router));
+
+const path = `${basePath}/internal/deletions/process`;
+
+let savedToken;
+beforeAll(() => {
+  savedToken = process.env.APITOKEN;
+  process.env.APITOKEN = uuid.v4();
+});
+
+afterAll(() => {
+  process.env.APITOKEN = savedToken;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe(`POST ${path} auth`, () => {
+  it('401s when no credentials are sent', async () => {
+    const response = await appRequest.post(path).send({});
+
+    expect(response.status).toBe(401);
+    expect(controller.processDeletions).not.toBeCalled();
+  });
+
+  it('401s when only an Authorization header is sent (no apikey bypass)', async () => {
+    const response = await appRequest.post(path).set({ authorization: 'Bearer some-token' }).send({});
+
+    expect(response.status).toBe(401);
+    expect(controller.processDeletions).not.toBeCalled();
+  });
+
+  it('401s when the apikey does not match', async () => {
+    const response = await appRequest.post(path).set({ apikey: uuid.v4() }).send({});
+
+    expect(response.status).toBe(401);
+    expect(controller.processDeletions).not.toBeCalled();
+  });
+
+  it('reaches the controller when a matching apikey is sent', async () => {
+    const response = await appRequest.post(path).set({ apikey: process.env.APITOKEN }).send({});
+
+    expect(response.status).toBe(200);
+    expect(controller.processDeletions).toBeCalledTimes(1);
+  });
+});

--- a/app/tests/unit/forms/submission/service.deleteSubmission.spec.js
+++ b/app/tests/unit/forms/submission/service.deleteSubmission.spec.js
@@ -1,0 +1,78 @@
+jest.mock('../../../../src/forms/common/models', () => ({
+  Form: { query: jest.fn() },
+  FormGroup: { query: jest.fn() },
+  FormVersion: { query: jest.fn() },
+  FormSubmission: { query: jest.fn() },
+  FormSubmissionStatus: { query: jest.fn() },
+  FormSubmissionUser: { query: jest.fn() },
+  FileStorage: { query: jest.fn(), startTransaction: jest.fn() },
+  Note: { query: jest.fn() },
+  SubmissionAudit: { query: jest.fn() },
+  SubmissionMetadata: { query: jest.fn() },
+}));
+jest.mock('../../../../src/forms/file/service', () => ({
+  deleteStorageObject: jest.fn(),
+  deleteFiles: jest.fn(),
+}));
+
+const service = require('../../../../src/forms/submission/service');
+const { FileStorage, Note, FormSubmission, FormSubmissionStatus, FormSubmissionUser } = require('../../../../src/forms/common/models');
+const fileService = require('../../../../src/forms/file/service');
+
+const submissionId = 'submission-1';
+const fileRows = [{ id: 'file-1' }, { id: 'file-2' }];
+
+// Helper returning a query stub whose .where(...).delete() resolves.
+const deletableQuery = (deleteResult) => ({
+  where: jest.fn().mockReturnValue({ delete: jest.fn().mockResolvedValue(deleteResult) }),
+});
+
+describe('deleteSubmissionAndRelatedData', () => {
+  let trx;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    trx = { commit: jest.fn().mockResolvedValue(), rollback: jest.fn().mockResolvedValue() };
+    FileStorage.startTransaction.mockResolvedValue(trx);
+
+    // First FileStorage.query() reads the file rows, second deletes them.
+    FileStorage.query.mockReturnValueOnce({ where: jest.fn().mockResolvedValue(fileRows) }).mockReturnValueOnce(deletableQuery(fileRows.length));
+    Note.query.mockReturnValue(deletableQuery());
+    FormSubmissionStatus.query.mockReturnValue(deletableQuery());
+    FormSubmissionUser.query.mockReturnValue(deletableQuery());
+    FormSubmission.query.mockReturnValue(deletableQuery(1));
+  });
+
+  it('commits the deletion and purges stored objects after commit', async () => {
+    const result = await service.deleteSubmissionAndRelatedData(submissionId);
+
+    expect(result).toEqual({ success: true });
+    expect(trx.commit).toHaveBeenCalled();
+    expect(trx.rollback).not.toHaveBeenCalled();
+
+    // Each captured file's stored object is removed, and the old fire-and-forget
+    // path (deleteFiles, with its own conflicting transaction) is not used.
+    expect(fileService.deleteStorageObject).toHaveBeenCalledTimes(fileRows.length);
+    expect(fileService.deleteStorageObject).toHaveBeenCalledWith({ id: 'file-1' });
+    expect(fileService.deleteStorageObject).toHaveBeenCalledWith({ id: 'file-2' });
+    expect(fileService.deleteFiles).not.toHaveBeenCalled();
+  });
+
+  it('removes stored objects only after the transaction has committed', async () => {
+    await service.deleteSubmissionAndRelatedData(submissionId);
+
+    const commitOrder = trx.commit.mock.invocationCallOrder[0];
+    const firstDeleteOrder = fileService.deleteStorageObject.mock.invocationCallOrder[0];
+    expect(commitOrder).toBeLessThan(firstDeleteOrder);
+  });
+
+  it('rolls back and does not touch storage when a delete fails', async () => {
+    Note.query.mockReturnValue({ where: jest.fn().mockReturnValue({ delete: jest.fn().mockRejectedValue(new Error('db error')) }) });
+
+    await expect(service.deleteSubmissionAndRelatedData(submissionId)).rejects.toThrow('db error');
+
+    expect(trx.rollback).toHaveBeenCalled();
+    expect(trx.commit).not.toHaveBeenCalled();
+    expect(fileService.deleteStorageObject).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/unit/forms/submission/updateService.spec.js
+++ b/app/tests/unit/forms/submission/updateService.spec.js
@@ -10,6 +10,7 @@ jest.mock('../../../../src/forms/common/models', () => ({
 jest.mock('../../../../src/forms/file/service', () => ({
   read: jest.fn(),
   moveSubmissionFile: jest.fn(),
+  deleteStorageObject: jest.fn(),
 }));
 jest.mock('../../../../src/forms/email/emailService', () => ({
   submissionReceived: jest.fn().mockResolvedValue(),
@@ -184,14 +185,13 @@ describe('updateService', () => {
 
   describe('_handleFileUploads', () => {
     const fileService = require('../../../../src/forms/file/service');
-    const { FileStorage } = require('../../../../src/forms/common/models');
 
-    it('patches and moves files that are not already linked', async () => {
+    it('moves files that are not already linked, reusing the submission transaction', async () => {
       const fileIds = ['f1', 'f2'];
       const data = {};
       const id = 555;
       const user = { usernameIdp: 'uploader' };
-      const trx = {};
+      const trx = { id: 'submission-trx' };
 
       // Mock submissionService._findFileIds to return fileIds
       const submissionService = {
@@ -201,24 +201,26 @@ describe('updateService', () => {
       // Mock fileService.read to return fileStorage objects
       fileService.read.mockImplementation((fileId) => Promise.resolve({ id: fileId, formSubmissionId: null }));
 
-      // Mock FileStorage.query().patchAndFetchById
-      const patchAndFetchById = jest.fn().mockResolvedValue({});
-      FileStorage.query.mockReturnValue({ patchAndFetchById });
+      // moveSubmissionFile returns the original file storage object
+      fileService.moveSubmissionFile.mockImplementation((_id, fileStorage) => Promise.resolve(fileStorage));
 
-      // Mock fileService.moveSubmissionFile
-      fileService.moveSubmissionFile.mockResolvedValue();
-
-      await updateService._handleFileUploads(submissionService, data, id, user, trx);
+      const moved = await updateService._handleFileUploads(submissionService, data, id, user, trx);
 
       expect(submissionService._findFileIds).toHaveBeenCalledWith(data);
       expect(fileService.read).toHaveBeenCalledTimes(fileIds.length);
-      expect(patchAndFetchById).toHaveBeenCalledTimes(fileIds.length);
       expect(fileService.moveSubmissionFile).toHaveBeenCalledTimes(fileIds.length);
-      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f1', formSubmissionId: null }, 'uploader');
-      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f2', formSubmissionId: null }, 'uploader');
+      // The submission transaction must be passed through so a second transaction
+      // is never opened against the row this transaction already locked.
+      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f1', formSubmissionId: null }, 'uploader', trx);
+      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f2', formSubmissionId: null }, 'uploader', trx);
+      // It returns the moved files so the caller can clean up the originals.
+      expect(moved).toEqual([
+        { id: 'f1', formSubmissionId: null },
+        { id: 'f2', formSubmissionId: null },
+      ]);
     });
 
-    it('does not patch or move files already linked to a submission', async () => {
+    it('does not move files already linked to a submission', async () => {
       const fileIds = ['f3'];
       const data = {};
       const id = 556;
@@ -230,14 +232,12 @@ describe('updateService', () => {
       };
 
       fileService.read.mockResolvedValue({ id: 'f3', formSubmissionId: 556 });
-      const patchAndFetchById = jest.fn();
-      FileStorage.query.mockReturnValue({ patchAndFetchById });
       fileService.moveSubmissionFile.mockResolvedValue();
 
-      await updateService._handleFileUploads(submissionService, data, id, user, trx);
+      const moved = await updateService._handleFileUploads(submissionService, data, id, user, trx);
 
-      expect(patchAndFetchById).not.toHaveBeenCalled();
       expect(fileService.moveSubmissionFile).not.toHaveBeenCalled();
+      expect(moved).toEqual([]);
     });
 
     it('should throw error from moveSubmissionFile instead of silently catching', async () => {
@@ -253,16 +253,13 @@ describe('updateService', () => {
 
       fileService.read.mockResolvedValue({ id: 'f1', formSubmissionId: null });
 
-      const patchAndFetchById = jest.fn().mockResolvedValue({});
-      FileStorage.query.mockReturnValue({ patchAndFetchById });
-
       // Mock moveSubmissionFile to throw
       fileService.moveSubmissionFile.mockRejectedValue(new Error('File move failed'));
 
       // Should throw, not silently catch
       await expect(updateService._handleFileUploads(submissionService, data, id, user, trx)).rejects.toThrow('File move failed');
 
-      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f1', formSubmissionId: null }, 'uploader');
+      expect(fileService.moveSubmissionFile).toHaveBeenCalledWith(id, { id: 'f1', formSubmissionId: null }, 'uploader', trx);
     });
   });
 
@@ -408,6 +405,53 @@ describe('updateService', () => {
 
       // Clean up
       startTransactionSpy.mockRestore();
+    });
+
+    it('deletes the original storage objects after the internal transaction commits', async () => {
+      const fileService = require('../../../../src/forms/file/service');
+      const mockTrx = { rollback: jest.fn(), commit: jest.fn() };
+      const startTransactionSpy = jest.spyOn(require('../../../../src/forms/common/models').FormSubmissionStatus, 'startTransaction').mockResolvedValue(mockTrx);
+
+      const movedFiles = [{ id: 'f1' }, { id: 'f2' }];
+      updateService._isRestoring = jest.fn().mockReturnValue(false);
+      updateService._getStatuses = jest.fn().mockResolvedValue([]);
+      updateService._shouldBlockDraftUpdate = jest.fn().mockReturnValue(false);
+      updateService._handleStatusChange = jest.fn().mockResolvedValue(false);
+      updateService._patchSubmission = jest.fn();
+      updateService._handleFileUploads = jest.fn().mockResolvedValue(movedFiles);
+      updateService._sendNotifications = jest.fn();
+      const submissionService = { read: jest.fn().mockResolvedValue({ id: 1 }) };
+
+      // No external transaction -> update owns the commit and the cleanup.
+      await updateService.update(submissionService, 1, { draft: true }, { usernameIdp: 'user' }, null);
+
+      expect(mockTrx.commit).toHaveBeenCalled();
+      expect(fileService.deleteStorageObject).toHaveBeenCalledTimes(2);
+      expect(fileService.deleteStorageObject).toHaveBeenCalledWith({ id: 'f1' });
+      expect(fileService.deleteStorageObject).toHaveBeenCalledWith({ id: 'f2' });
+
+      startTransactionSpy.mockRestore();
+    });
+
+    it('does not delete original storage objects when using an external transaction', async () => {
+      const fileService = require('../../../../src/forms/file/service');
+
+      const movedFiles = [{ id: 'f1' }];
+      updateService._isRestoring = jest.fn().mockReturnValue(false);
+      updateService._getStatuses = jest.fn().mockResolvedValue([]);
+      updateService._shouldBlockDraftUpdate = jest.fn().mockReturnValue(false);
+      updateService._handleStatusChange = jest.fn().mockResolvedValue(false);
+      updateService._patchSubmission = jest.fn();
+      updateService._handleFileUploads = jest.fn().mockResolvedValue(movedFiles);
+      updateService._sendNotifications = jest.fn();
+      const submissionService = { read: jest.fn().mockResolvedValue({ id: 1 }) };
+      const fakeTrx = { commit: jest.fn(), rollback: jest.fn() };
+
+      // External transaction -> the owner commits and is responsible for cleanup.
+      await updateService.update(submissionService, 1, { draft: true }, { usernameIdp: 'user' }, null, fakeTrx);
+
+      expect(fakeTrx.commit).not.toHaveBeenCalled();
+      expect(fileService.deleteStorageObject).not.toHaveBeenCalled();
     });
 
     it('internal transaction rolled back on error', async () => {

--- a/tests/functional/cypress/e2e/form-submission-public-no-status-assign.cy.js
+++ b/tests/functional/cypress/e2e/form-submission-public-no-status-assign.cy.js
@@ -94,13 +94,21 @@ describe('Form Designer', () => {
     cy.get('label').contains('Text Field').should('be.visible');
     cy.location('pathname').should('eq', `/${depEnv}/form/success`);
     cy.contains('h1', 'Your form has been submitted successfully');
-    //Re-login as IDIR before viewing submissions (manage page requires authentication)
+    //Re-login before viewing submissions (manage page requires authentication).
+    //The Keycloak logout above does not clear the upstream IdP (SSO) session, so the
+    //login may complete silently. Only fill the IDIR credential form if it is shown.
     cy.visit(`/${depEnv}`);
     cy.get('#loginButton').click();
-    cy.get('[data-test="idir"]').click();
-    cy.get('#user').type(username);
-    cy.get('#password').type(password);
-    cy.get('.btn').click();
+    cy.wait(3000);
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-test="idir"]').length) {
+        cy.get('[data-test="idir"]').click();
+        cy.get('#user').type(username);
+        cy.get('#password').type(password);
+        cy.get('.btn').click();
+      }
+    });
+    cy.get('#logoutButton', { timeout: 60000 }).should('exist');
     //view submission
     cy.visit(`/${depEnv}/form/manage?f=${formId}`);
     cy.get('.mdi-list-box-outline').click();

--- a/tests/functional/cypress/e2e/form-submission-public-no-status-assign.cy.js
+++ b/tests/functional/cypress/e2e/form-submission-public-no-status-assign.cy.js
@@ -94,6 +94,13 @@ describe('Form Designer', () => {
     cy.get('label').contains('Text Field').should('be.visible');
     cy.location('pathname').should('eq', `/${depEnv}/form/success`);
     cy.contains('h1', 'Your form has been submitted successfully');
+    //Re-login as IDIR before viewing submissions (manage page requires authentication)
+    cy.visit(`/${depEnv}`);
+    cy.get('#loginButton').click();
+    cy.get('[data-test="idir"]').click();
+    cy.get('#user').type(username);
+    cy.get('#password').type(password);
+    cy.get('.btn').click();
     //view submission
     cy.visit(`/${depEnv}/form/manage?f=${formId}`);
     cy.get('.mdi-list-box-outline').click();

--- a/tests/functional/cypress/e2e/form-submission-public-status-assign.cy.js
+++ b/tests/functional/cypress/e2e/form-submission-public-status-assign.cy.js
@@ -103,13 +103,21 @@ describe('Form Designer', () => {
     cy.get('button[title="Email a receipt of this submission"]').click();
     cy.get('span').contains('SEND').click();
     cy.get('.v-alert__content').contains('div','An email has been sent to testing@gov.bc.ca.').should('be.visible');
-    //Re-login as IDIR before viewing submissions (manage page requires authentication)
+    //Re-login before viewing submissions (manage page requires authentication).
+    //The Keycloak logout above does not clear the upstream IdP (SSO) session, so the
+    //login may complete silently. Only fill the IDIR credential form if it is shown.
     cy.visit(`/${depEnv}`);
     cy.get('#loginButton').click();
-    cy.get('[data-test="idir"]').click();
-    cy.get('#user').type(username);
-    cy.get('#password').type(password);
-    cy.get('.btn').click();
+    cy.wait(3000);
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-test="idir"]').length) {
+        cy.get('[data-test="idir"]').click();
+        cy.get('#user').type(username);
+        cy.get('#password').type(password);
+        cy.get('.btn').click();
+      }
+    });
+    cy.get('#logoutButton', { timeout: 60000 }).should('exist');
     //view submission   
     cy.visit(`/${depEnv}/form/manage?f=${formId}`);
     cy.get('.mdi-list-box-outline').click();

--- a/tests/functional/cypress/e2e/form-submission-public-status-assign.cy.js
+++ b/tests/functional/cypress/e2e/form-submission-public-status-assign.cy.js
@@ -103,6 +103,13 @@ describe('Form Designer', () => {
     cy.get('button[title="Email a receipt of this submission"]').click();
     cy.get('span').contains('SEND').click();
     cy.get('.v-alert__content').contains('div','An email has been sent to testing@gov.bc.ca.').should('be.visible');
+    //Re-login as IDIR before viewing submissions (manage page requires authentication)
+    cy.visit(`/${depEnv}`);
+    cy.get('#loginButton').click();
+    cy.get('[data-test="idir"]').click();
+    cy.get('#user').type(username);
+    cy.get('#password').type(password);
+    cy.get('.btn').click();
     //view submission   
     cy.visit(`/${depEnv}/form/manage?f=${formId}`);
     cy.get('.mdi-list-box-outline').click();


### PR DESCRIPTION
fix: restore file API access and fix file storage transaction races

# Description

A user reported they could no longer download files using a Basic Auth API key. This turned out to be fallout from the earlier `requireApiKeyBasic` gateway work: the file routes had been switched to the system `checkApiKey` middleware, which is meant to guard internal cron-only endpoints, not file access.

While tracing that, I found two file-storage bugs in the submission flow that were (potentially) causing uploads to hang and deletes to leave files behind.

This PR has three parts:

1. **File API access.** The file download, clone, and delete routes now use the Basic Auth middleware (`basicApiAccess`) instead of the system `checkApiKey`. This restores the three access paths these routes are supposed to support: public users on public-form drafts, API users with Basic Auth on protected forms, and signed-in users with Bearer tokens. Comment added on the routes describing what each piece of the chain allows and blocks, so the next person doesn't have to reverse-engineer it.

2. **Hardened `checkApiKey`.** Removed the `Authorization` header bypass so the middleware only honours the `apikey` header. It now fails closed when `APITOKEN` isn't configured and compares keys with a constant-time comparison. This is the only thing guarding the reminder and records-management deletion cron routes, so the bypass was an auth hole. The OpenShift cron jobs send the `apikey` header, so they keep working.

3. **File transaction race conditions.**
   - Uploading a submission with new files could deadlock. `moveSubmissionFile` opened its own transaction to update a `FileStorage` row that the submission's outer transaction had already locked, so the two waited on each other. It now runs inside the caller's transaction and deletes the original object after that transaction commits.
   - Deleting a submission called `deleteFiles` without awaiting it, in a separate transaction that deleted the same rows the outer transaction was deleting. That was a fire-and-forget call that could orphan files in storage. The deletion now happens in one transaction and the stored objects are purged (best effort) after commit.

## Type of Change

fix (a bug fix)

## Checklist

- [ ] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

The storage cleanup after a move or delete is intentionally best effort: it runs after the database transaction commits and a storage failure is logged rather than thrown. The alternative is failing a submission or delete that has already succeeded in the database, which is worse than leaving an object to be cleaned up later. The bulk file-delete route still uses `deleteFiles` as before, since it manages its own transaction correctly.

Tests added/updated cover the hardened `checkApiKey` (including the bypass regression and the unset-`APITOKEN` case), the file routes' middleware chain, `moveSubmissionFile` reusing a passed-in transaction, the new `deleteStorageObject` helper, and the submission-delete path (commit-then-purge, no fire-and-forget, rollback leaves storage untouched).
