### PR TITLE
fix: CCP-4948 Submission Fields access

### DIFF
--- a/app/frontend/src/components/forms/ExportSubmissions.vue
+++ b/app/frontend/src/components/forms/ExportSubmissions.vue
@@ -37,6 +37,9 @@ const endDateRules = ref([
 const exportFormat = ref('json');
 const formFieldsSearchFilter = ref('');
 const formVersions = ref([]);
+// Schema-free version metadata ({ id, version, published }) from the form fields
+// endpoint, so this works for reviewers who can't read versions via the form.
+const formVersionList = ref([]);
 // This has the form fields in the table
 // Table selection does not work if we use a computed value
 const items = ref([]);
@@ -69,10 +72,8 @@ const FILENAME = computed(
 );
 const FORM_UNPUBLISHED = computed(
   () =>
-    form.value &&
-    form.value.versions &&
-    form.value.versions.length > 0 &&
-    form.value.versions.every((version) => !version.published)
+    formVersionList.value.length > 0 &&
+    formVersionList.value.every((version) => !version.published)
 );
 const headers = computed(() => [
   {
@@ -117,10 +118,14 @@ watch(startDate, () => {
 
 onMounted(async () => {
   await formStore.fetchForm(properties.formId);
+  const formFieldData = await formStore.fetchSubmissionFields(
+    properties.formId
+  );
+  formVersionList.value = formFieldData?.versions ?? [];
 
   // The formVersions don't need to be updated, but the form fields should be..
-  if (form.value && Array.isArray(form.value.versions)) {
-    let versions = form.value.versions;
+  if (Array.isArray(formVersionList.value)) {
+    let versions = formVersionList.value;
     if (FORM_UNPUBLISHED.value) {
       versions.sort((a, b) =>
         a.version < b.version ? -1 : a.version > b.version ? 1 : 0

--- a/app/frontend/src/components/forms/SubmissionsTable.vue
+++ b/app/frontend/src/components/forms/SubmissionsTable.vue
@@ -512,14 +512,8 @@ async function refreshSubmissions() {
   Promise.all([
     formStore.getFormRolesForUser(properties.formId),
     formStore.getFormPermissionsForUser(properties.formId),
-    formStore.fetchForm(properties.formId).then(async () => {
-      if (form.value.versions?.length > 0) {
-        await formStore.fetchFormFields({
-          formId: properties.formId,
-          formVersionId: form.value.versions[0].id,
-        });
-      }
-    }),
+    formStore.fetchForm(properties.formId),
+    formStore.fetchSubmissionFields(properties.formId),
   ])
     .then(async () => {
       await populateSubmissionsTable();

--- a/app/frontend/src/components/forms/submission/MySubmissionsTable.vue
+++ b/app/frontend/src/components/forms/submission/MySubmissionsTable.vue
@@ -198,12 +198,7 @@ const USER_PREFERENCES = computed(() => {
 
 onBeforeMount(async () => {
   await formStore.fetchForm(properties.formId);
-  if (form.value.versions?.length > 0) {
-    await formStore.fetchFormFields({
-      formId: properties.formId,
-      formVersionId: form.value.versions[0].id,
-    });
-  }
+  await formStore.fetchSubmissionFields(properties.formId);
   await populateSubmissionsTable();
 });
 

--- a/app/frontend/src/services/formService.js
+++ b/app/frontend/src/services/formService.js
@@ -216,6 +216,18 @@ export default {
   },
 
   /**
+   * @function readFormFields
+   * Get the schema-free version list plus the field keys for the current
+   * (published, else latest) version. Available to users with submission read,
+   * so reviewers can populate the submissions column picker.
+   * @param {string} formId The form uuid
+   * @returns {Promise} An axios response
+   */
+  readFormFields(formId) {
+    return appAxios().get(`${ApiRoutes.FORMS}/${formId}/fields`);
+  },
+
+  /**
    * @function publishVersion
    * Publish or unpublish a specific form version. Publishing a verison will unpublish all others.
    * @param {string} formId The form uuid

--- a/app/frontend/src/store/form.js
+++ b/app/frontend/src/store/form.js
@@ -410,6 +410,24 @@ export const useFormStore = defineStore('form', {
         });
       }
     },
+    async fetchSubmissionFields(formId) {
+      try {
+        this.formFields = [];
+        const { data } = await formService.readFormFields(formId);
+        this.formFields = data?.fields ?? [];
+        return data;
+      } catch (error) {
+        const notificationStore = useNotificationStore();
+        notificationStore.addNotification({
+          text: i18n.t('trans.store.form.fetchFormFieldsErrMsg'),
+          consoleError: i18n.t('trans.store.form.fetchFormFieldsConsErrMsg', {
+            formId: formId,
+            error: error,
+          }),
+        });
+        return { versionId: null, published: false, versions: [], fields: [] };
+      }
+    },
     async publishDraft({ formId, draftId }) {
       try {
         await formService.publishDraft(formId, draftId);

--- a/app/frontend/tests/unit/components/forms/ExportSubmissions.spec.js
+++ b/app/frontend/tests/unit/components/forms/ExportSubmissions.spec.js
@@ -41,6 +41,15 @@ describe('ExportSubmissions.vue', () => {
     formStore.$reset();
     appStore.$reset();
     addNotificationSpy.mockReset();
+    // The component now sources its version list from the form fields endpoint
+    // (so reviewers without design access can export). Echo whatever versions
+    // the test placed on the form so existing expectations keep working.
+    vi.spyOn(formStore, 'fetchSubmissionFields').mockImplementation(async () => ({
+      versionId: null,
+      published: false,
+      versions: formStore.form?.versions ?? [],
+      fields: formStore.formFields ?? [],
+    }));
   });
 
   it('renders', async () => {

--- a/app/frontend/tests/unit/components/forms/SubmissionsTable.spec.js
+++ b/app/frontend/tests/unit/components/forms/SubmissionsTable.spec.js
@@ -59,7 +59,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -109,7 +109,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -161,7 +161,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -206,7 +206,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -251,7 +251,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -290,7 +290,7 @@ describe('SubmissionsTable.vue', () => {
     });
     const fetchFormSpy = vi.spyOn(formStore, 'fetchForm');
     fetchFormSpy.mockImplementation(() => Promise.resolve());
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -342,7 +342,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -394,7 +394,7 @@ describe('SubmissionsTable.vue', () => {
       formStore.form = require('../../fixtures/form.json');
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -446,7 +446,7 @@ describe('SubmissionsTable.vue', () => {
       formStore.form = require('../../fixtures/form.json');
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementationOnce(() => {
       formStore.formFields = [];
     });
@@ -567,7 +567,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementationOnce(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementationOnce(() => {
       formStore.formFields = ['firstName'];
     });
@@ -685,7 +685,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementationOnce(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementationOnce(() => {
       formStore.formFields = ['firstName'];
     });
@@ -757,7 +757,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -874,7 +874,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementationOnce(() => {
       formStore.formFields = ['firstName'];
     });
@@ -976,7 +976,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -1079,7 +1079,7 @@ describe('SubmissionsTable.vue', () => {
     fetchFormSpy.mockImplementation(() => {
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -1161,7 +1161,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1209,7 +1209,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1255,7 +1255,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1304,7 +1304,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1350,7 +1350,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1397,7 +1397,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1437,7 +1437,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1477,7 +1477,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1517,7 +1517,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = [];
     });
@@ -1555,7 +1555,7 @@ describe('SubmissionsTable.vue', () => {
       };
       return Promise.resolve();
     });
-    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchFormFields');
+    const fetchFormFieldsSpy = vi.spyOn(formStore, 'fetchSubmissionFields');
     fetchFormFieldsSpy.mockImplementation(() => {
       formStore.formFields = ['firstName'];
     });
@@ -1617,7 +1617,7 @@ describe('SubmissionsTable.vue', () => {
     vi.spyOn(formStore, 'fetchForm').mockImplementation(() =>
       Promise.resolve()
     );
-    vi.spyOn(formStore, 'fetchFormFields').mockImplementation(() => {});
+    vi.spyOn(formStore, 'fetchSubmissionFields').mockImplementation(() => {});
 
     const wrapper = shallowMount(SubmissionsTable, {
       props: { formId },
@@ -1710,7 +1710,7 @@ describe('SubmissionsTable.vue', () => {
     vi.spyOn(formStore, 'fetchForm').mockImplementation(() =>
       Promise.resolve()
     );
-    vi.spyOn(formStore, 'fetchFormFields').mockImplementation(() => {});
+    vi.spyOn(formStore, 'fetchSubmissionFields').mockImplementation(() => {});
     vi.spyOn(formStore, 'getFormRolesForUser').mockResolvedValue({});
     vi.spyOn(formStore, 'getFormPermissionsForUser').mockResolvedValue({});
 
@@ -1765,7 +1765,7 @@ describe('SubmissionsTable.vue', () => {
     vi.spyOn(formStore, 'fetchForm').mockImplementation(() =>
       Promise.resolve()
     );
-    vi.spyOn(formStore, 'fetchFormFields').mockImplementation(() => {});
+    vi.spyOn(formStore, 'fetchSubmissionFields').mockImplementation(() => {});
     vi.spyOn(formStore, 'getFormRolesForUser').mockResolvedValue({});
     vi.spyOn(formStore, 'getFormPermissionsForUser').mockResolvedValue({});
 
@@ -1800,7 +1800,7 @@ describe('SubmissionsTable.vue', () => {
     vi.spyOn(formStore, 'fetchForm').mockImplementation(() =>
       Promise.resolve()
     );
-    vi.spyOn(formStore, 'fetchFormFields').mockImplementation(() => {});
+    vi.spyOn(formStore, 'fetchSubmissionFields').mockImplementation(() => {});
     vi.spyOn(formStore, 'getFormRolesForUser').mockResolvedValue({});
     vi.spyOn(formStore, 'getFormPermissionsForUser').mockResolvedValue({});
 

--- a/app/frontend/tests/unit/components/forms/submission/MySubmissionsTable.spec.js
+++ b/app/frontend/tests/unit/components/forms/submission/MySubmissionsTable.spec.js
@@ -25,7 +25,7 @@ describe('MySubmissionsTable.vue', () => {
 
   const fetchFormSpy = vi.spyOn(formStore, 'fetchForm').mockResolvedValue({});
   const fetchFormFieldsSpy = vi
-    .spyOn(formStore, 'fetchFormFields')
+    .spyOn(formStore, 'fetchSubmissionFields')
     .mockImplementation(() => []);
 
   beforeEach(() => {

--- a/app/frontend/tests/unit/services/formService.spec.js
+++ b/app/frontend/tests/unit/services/formService.spec.js
@@ -69,6 +69,19 @@ describe('Form Service', () => {
     });
   });
 
+  describe('Forms/{formId}/fields', () => {
+    const endpoint = `${ApiRoutes.FORMS}/${zeroUuid}/fields`;
+
+    it('calls fields endpoint', async () => {
+      mockAxios.onGet(endpoint).reply(200, { versions: [], fields: [] });
+
+      const result = await formService.readFormFields(zeroUuid);
+      expect(result).toBeTruthy();
+      expect(mockAxios.history.get).toHaveLength(1);
+      expect(mockAxios.history.get[0].url).toEqual(endpoint);
+    });
+  });
+
   describe('Forms/{formId}/options', () => {
     const endpoint = `${ApiRoutes.FORMS}/${zeroUuid}/options`;
 

--- a/app/frontend/tests/unit/store/modules/form.actions.spec.js
+++ b/app/frontend/tests/unit/store/modules/form.actions.spec.js
@@ -172,6 +172,38 @@ describe('form actions', () => {
       expect(addNotificationSpy).toHaveBeenCalledWith(expect.any(Object));
     });
 
+    it('fetchSubmissionFields should set formFields and return the payload', async () => {
+      const payload = {
+        versionId: 'vid',
+        published: true,
+        versions: [{ id: 'vid', version: 1, published: true }],
+        fields: ['simpletextfield'],
+      };
+      formService.readFormFields.mockResolvedValue({ data: payload });
+      mockStore.formFields = undefined;
+
+      const result = await mockStore.fetchSubmissionFields('fId');
+
+      expect(formService.readFormFields).toHaveBeenCalledWith('fId');
+      expect(mockStore.formFields).toEqual(['simpletextfield']);
+      expect(result).toEqual(payload);
+    });
+
+    it('fetchSubmissionFields should notify and return empty payload on error', async () => {
+      formService.readFormFields.mockRejectedValue('');
+
+      const result = await mockStore.fetchSubmissionFields('fId');
+
+      expect(addNotificationSpy).toHaveBeenCalledTimes(1);
+      expect(addNotificationSpy).toHaveBeenCalledWith(expect.any(Object));
+      expect(result).toEqual({
+        versionId: null,
+        published: false,
+        versions: [],
+        fields: [],
+      });
+    });
+
     it('fetchDrafts should commit to SET_DRAFTS', async () => {
       formService.listDrafts.mockResolvedValue({ data: [] });
       mockStore.drafts = undefined;

--- a/app/src/forms/form/controller.js
+++ b/app/src/forms/form/controller.js
@@ -154,6 +154,17 @@ module.exports = {
       next(error);
     }
   },
+  readFormFields: async (req, res, next) => {
+    try {
+      const response = await service.readFormFields(req.params.formId);
+      res.status(200).json({
+        ...response,
+        fields: response.fields.filter((f) => f !== 'submit'),
+      });
+    } catch (error) {
+      next(error);
+    }
+  },
   publishVersion: async (req, res, next) => {
     try {
       const response = await service.publishVersion(req.params.formId, req.params.formVersionId, req.currentUser, req.query);

--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -49,6 +49,10 @@ routes.get('/:formId/version', apiAccess, hasFormPermissions([P.FORM_READ]), asy
   await controller.readPublishedForm(req, res, next);
 });
 
+routes.get('/:formId/fields', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+  await controller.readFormFields(req, res, next);
+});
+
 routes.put('/:formId', apiAccess, hasFormPermissions([P.FORM_READ, P.FORM_UPDATE]), async (req, res, next) => {
   await controller.updateForm(req, res, next);
 });

--- a/app/src/forms/form/service.js
+++ b/app/src/forms/form/service.js
@@ -812,6 +812,30 @@ const service = {
     const { schema } = await service.readVersion(formVersionId);
     return schema.components.flatMap((c) => findFields(c));
   },
+
+  // Returns the schema-free version list for a form plus the field keys for the
+  // "current" version (the published one, falling back to the latest version if
+  // none are published). This lets users who can read submissions but not the
+  // form design (e.g. Reviewers) populate the submissions column picker without
+  // exposing version schemas through readForm.
+  readFormFields: async (formId) => {
+    const versions = await FormVersion.query().modify('filterFormId', formId).modify('selectWithoutSchema').modify('orderVersionDescending');
+
+    if (!versions.length) {
+      return { versionId: null, published: false, versions: [], fields: [] };
+    }
+
+    const publishedVersion = versions.find((v) => v.published);
+    const targetVersion = publishedVersion ?? versions[0];
+    const fields = await service.readVersionFields(targetVersion.id);
+
+    return {
+      versionId: targetVersion.id,
+      published: !!publishedVersion,
+      versions,
+      fields,
+    };
+  },
   listSubmissions: async (formVersionId, params) => {
     return FormSubmission.query().where('formVersionId', formVersionId).modify('filterCreatedBy', params.createdBy).modify('orderDescending');
   },

--- a/app/tests/unit/forms/form/controller.spec.js
+++ b/app/tests/unit/forms/form/controller.spec.js
@@ -77,6 +77,29 @@ describe('form controller', () => {
   });
 });
 
+describe('readFormFields', () => {
+  it('returns the version metadata and strips the submit field', async () => {
+    service.readFormFields = jest.fn().mockResolvedValue({
+      versionId: 'v1',
+      published: true,
+      versions: [{ id: 'v1', version: 1, published: true }],
+      fields: ['simpletextfield', 'submit'],
+    });
+    const { res, next } = getMockRes();
+
+    await controller.readFormFields(getMockReq(req), res, next);
+
+    expect(service.readFormFields).toBeCalledWith(req.params.formId);
+    expect(res.json).toBeCalledWith({
+      versionId: 'v1',
+      published: true,
+      versions: [{ id: 'v1', version: 1, published: true }],
+      fields: ['simpletextfield'],
+    });
+    expect(next).not.toBeCalled();
+  });
+});
+
 describe('createForm', () => {
   it('should call service.createForm with body, currentUser, and headers and return 201', async () => {
     // Arrange

--- a/app/tests/unit/forms/form/routes.spec.js
+++ b/app/tests/unit/forms/form/routes.spec.js
@@ -596,6 +596,28 @@ describe(`${basePath}/:formId/version`, () => {
   });
 });
 
+describe(`${basePath}/:formId/fields`, () => {
+  const formId = uuid.v4();
+  const path = `${basePath}/${formId}/fields`;
+
+  it('should have correct middleware for GET', async () => {
+    controller.readFormFields = jest.fn((_req, res) => {
+      res.sendStatus(200);
+    });
+
+    await appRequest.get(path);
+
+    expect(apiAccess).toBeCalledTimes(1);
+    expect(controller.readFormFields).toBeCalledTimes(1);
+    expect(hasFormPermissionsMock).toBeCalledTimes(1);
+    expect(mockJwtServiceProtect).toBeCalledTimes(0);
+    expect(userAccess.currentUser).toBeCalledTimes(1);
+    expect(validateParameter.validateFormId).toBeCalledTimes(1);
+    expect(validateParameter.validateFormVersionDraftId).toBeCalledTimes(0);
+    expect(validateParameter.validateFormVersionId).toBeCalledTimes(0);
+  });
+});
+
 describe(`${basePath}/:formId/versions/:formVersionId`, () => {
   const formId = uuid.v4();
   const formVersionId = uuid.v4();

--- a/app/tests/unit/forms/form/service.spec.js
+++ b/app/tests/unit/forms/form/service.spec.js
@@ -777,6 +777,65 @@ describe('readVersionFields', () => {
   });
 });
 
+describe('readFormFields', () => {
+  // Build a thenable query mock whose modify() chain resolves to the versions.
+  const mockVersionQuery = (versions) => {
+    const query = {
+      modify: jest.fn().mockReturnThis(),
+      then: (resolve) => resolve(versions),
+    };
+    FormVersion.query = jest.fn().mockReturnValue(query);
+    return query;
+  };
+
+  it('returns the published version and its fields when one is published', async () => {
+    const versions = [
+      { id: 'v2', version: 2, published: false },
+      { id: 'v1', version: 1, published: true },
+    ];
+    mockVersionQuery(versions);
+    service.readVersionFields = jest.fn().mockResolvedValue(['simpletextfield']);
+
+    const result = await service.readFormFields(formId);
+
+    expect(result.versionId).toEqual('v1');
+    expect(result.published).toEqual(true);
+    expect(result.versions).toEqual(versions);
+    expect(result.fields).toEqual(['simpletextfield']);
+    expect(service.readVersionFields).toHaveBeenCalledWith('v1');
+  });
+
+  it('falls back to the latest version when none are published', async () => {
+    const versions = [
+      { id: 'v2', version: 2, published: false },
+      { id: 'v1', version: 1, published: false },
+    ];
+    mockVersionQuery(versions);
+    service.readVersionFields = jest.fn().mockResolvedValue(['simpletextfield']);
+
+    const result = await service.readFormFields(formId);
+
+    expect(result.versionId).toEqual('v2');
+    expect(result.published).toEqual(false);
+    expect(service.readVersionFields).toHaveBeenCalledWith('v2');
+  });
+
+  it('returns empty results when the form has no versions', async () => {
+    mockVersionQuery([]);
+    service.readVersionFields = jest.fn();
+
+    const result = await service.readFormFields(formId);
+
+    expect(result).toEqual({
+      versionId: null,
+      published: false,
+      versions: [],
+      fields: [],
+    });
+    expect(service.readVersionFields).not.toHaveBeenCalled();
+  });
+});
+
 describe('processPaginationData', () => {
   const SubmissionData = require('../../../fixtures/submission/kitchen_sink_submission_pagination.json');
 


### PR DESCRIPTION
fix: CCP-4948 show submission columns for Reviewers

# Description

The "Manage columns" picker on the Submissions page only showed the form's field columns to Owners and Form Designers. A user with just the Reviewer role saw none of them — so searching for a field like `simpletextfield` returned nothing, even though Reviewers can see the submissions themselves.

The cause: the column picker pulled the form field list off `form.versions`, but `readForm` intentionally strips `versions` from anyone without design access (a data-integrity decision we want to keep). Reviewers never got a version id, so the field list came back empty.

Rather than loosen `readForm`, this adds a small dedicated endpoint, `GET /forms/:formId/fields`, gated on `FORM_READ` + `SUBMISSION_READ` — the same permissions already required to view the submissions table. It returns the schema-free version list plus the field keys for the current version (the published one, falling back to the latest if none is published). No schema or draft data is exposed.

The same `form.versions` dependency existed in two other places reachable by non-designers, so they're fixed in the same pass:
- the submissions column picker (`SubmissionsTable.vue`) — the reported bug
- "My Submissions" column picker (`MySubmissionsTable.vue`)
- the Export Submissions version selector (`ExportSubmissions.vue`)

All three now read from the new endpoint instead of `form.versions`.

## Type of Change

fix (a bug fix)

## Checklist

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments
