### PR TITLE
fix: CCP-4948 - My Submissions col select

### DIFF
--- a/app/src/forms/form/routes.js
+++ b/app/src/forms/form/routes.js
@@ -49,7 +49,12 @@ routes.get('/:formId/version', apiAccess, hasFormPermissions([P.FORM_READ]), asy
   await controller.readPublishedForm(req, res, next);
 });
 
-routes.get('/:formId/fields', apiAccess, hasFormPermissions([P.FORM_READ, P.SUBMISSION_READ]), async (req, res, next) => {
+// Gated by FORM_READ only (not SUBMISSION_READ): this endpoint returns just the
+// field key names and schema-free version metadata, which is form design info
+// already exposed at FORM_READ via /:formId/versions/:formVersionId/fields. It
+// must stay accessible to form_submitters (who have form_read but not
+// submission_read) so the "My Submissions" column picker works for them.
+routes.get('/:formId/fields', apiAccess, hasFormPermissions([P.FORM_READ]), async (req, res, next) => {
   await controller.readFormFields(req, res, next);
 });
 


### PR DESCRIPTION
<!--
The above Title for the Pull Request should use the format:
    type: FORMS-ABCD your change description

For example:
    feat: FORMS-1234 add Assigned To column to submission table
-->

# Description
Second fix for CCP-4948.

The original fix was too restrictive to people that are only allowed to submit, the have a View My Submissions that has column select. Changing to only require `FORM_READ` as that data (schema fields names) is available for anyone with `FORM_READ`

<!--
Describe your changes in detail.
 - Why is this change required?
 - What problem does it solve?
-->

## Type of Change

<!--
Uncomment the main reason for the change. For example: all "feat" PRs should
include documentation ("docs") and tests ("test"), but only uncomment "feat".
-->

<!-- feat (a new feature) -->
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
