### PR TITLE
Bugfix/ccp 4706:  Fix transient 503s from CSTAR tenant-check fan-out

### DIFF
--- a/app/src/components/tenantService.js
+++ b/app/src/components/tenantService.js
@@ -44,28 +44,29 @@ class TenantService {
     const userId = req.currentUser.idpUserId;
     const now = Date.now();
     const cached = listTenantsCache.get(userId);
-    if (cached && cached.expiresAt > now) {
+    if (cached?.expiresAt > now) {
       return cached.promise;
     }
     const url = `${endpoint}${listUserTenantsPath.replace('{userId}', userId)}`;
     const headers = this._getAuthHeaders(req);
-    const entry = { promise: null, expiresAt: now + LIST_TENANTS_TTL_MS };
-    entry.promise = axios
+    const promise = axios
       .get(url, { headers })
-      .then((res) => ({ tenants: res?.data?.data?.tenants || [], degraded: false }))
+      .then((res) => {
+        const raw = res?.data?.data?.tenants;
+        return { tenants: Array.isArray(raw) ? raw : [], degraded: false };
+      })
       .catch((error) => {
-        // Drop the entry so the next call retries. Guard against evicting a
-        // newer entry that may have replaced ours after TTL.
+        // Guard prevents evicting a newer entry that replaced ours after TTL.
         const current = listTenantsCache.get(userId);
-        if (current === entry) listTenantsCache.delete(userId);
+        if (current?.promise === promise) listTenantsCache.delete(userId);
         const status = error?.response?.status;
         const isUnavailable = [500, 502, 503, 504].includes(status);
         const isNetworkError = ['ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT'].includes(error?.code);
         if (isUnavailable || isNetworkError) return { tenants: [], degraded: true };
         throw error;
       });
-    listTenantsCache.set(userId, entry);
-    return entry.promise;
+    listTenantsCache.set(userId, { promise, expiresAt: now + LIST_TENANTS_TTL_MS });
+    return promise;
   }
 
   _clearListTenantsCache() {
@@ -89,7 +90,7 @@ class TenantService {
     }
     const { tenants, degraded } = await this._fetchUserTenantsList(req);
     if (degraded) return { belongs: false, degraded: true };
-    const belongs = Array.isArray(tenants) && tenants.some((t) => t?.id === tenantId);
+    const belongs = tenants.some((t) => t?.id === tenantId);
     return { belongs, degraded: false };
   }
 
@@ -105,7 +106,7 @@ class TenantService {
       req._tenantServiceDegraded = true;
       return [];
     }
-    if (!Array.isArray(tenants) || tenants.length === 0) return [];
+    if (tenants.length === 0) return [];
 
     const tenantsWithRoles = await Promise.all(
       tenants.map(async (tenant) => {

--- a/app/src/components/tenantService.js
+++ b/app/src/components/tenantService.js
@@ -13,6 +13,14 @@ const FormGroup = require('../forms/common/models/tables/formGroup');
 const FormTenant = require('../forms/common/models/tables/formTenant');
 const uuid = require('uuid');
 
+// Single-flight + short-TTL cache for the list-user-tenants CSTAR call. Every
+// authenticated CHEFS request routes through the tenant middleware (see
+// userAccess.currentUser), so bursts of concurrent requests from one user must
+// share one CSTAR call to avoid stampedes. Rejections are dropped so transient
+// failures don't get pinned for the whole TTL.
+const LIST_TENANTS_TTL_MS = 30 * 1000;
+const listTenantsCache = new Map();
+
 class TenantService {
   /**
    * Get authorization headers with Bearer token from request
@@ -24,6 +32,67 @@ class TenantService {
     return token ? { Authorization: `Bearer ${token}` } : {};
   }
 
+  /**
+   * Fetch the raw list-user-tenants array from CSTAR with request coalescing
+   * and short-TTL caching. Does NOT fan out into per-tenant roles.
+   *
+   * Returns `{ tenants, degraded }`. On transient CSTAR failure (5xx / network)
+   * returns `{ tenants: [], degraded: true }` without caching. On 4xx or other
+   * unexpected errors, throws.
+   */
+  _fetchUserTenantsList(req) {
+    const userId = req.currentUser.idpUserId;
+    const now = Date.now();
+    const cached = listTenantsCache.get(userId);
+    if (cached && cached.expiresAt > now) {
+      return cached.promise;
+    }
+    const url = `${endpoint}${listUserTenantsPath.replace('{userId}', userId)}`;
+    const headers = this._getAuthHeaders(req);
+    const entry = { promise: null, expiresAt: now + LIST_TENANTS_TTL_MS };
+    entry.promise = axios
+      .get(url, { headers })
+      .then((res) => ({ tenants: res?.data?.data?.tenants || [], degraded: false }))
+      .catch((error) => {
+        // Drop the entry so the next call retries. Guard against evicting a
+        // newer entry that may have replaced ours after TTL.
+        const current = listTenantsCache.get(userId);
+        if (current === entry) listTenantsCache.delete(userId);
+        const status = error?.response?.status;
+        const isUnavailable = [500, 502, 503, 504].includes(status);
+        const isNetworkError = ['ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT'].includes(error?.code);
+        if (isUnavailable || isNetworkError) return { tenants: [], degraded: true };
+        throw error;
+      });
+    listTenantsCache.set(userId, entry);
+    return entry.promise;
+  }
+
+  _clearListTenantsCache() {
+    listTenantsCache.clear();
+  }
+
+  /**
+   * Lightweight membership check for use by the currentUser middleware. Only
+   * makes the list-user-tenants CSTAR call; no per-tenant roles fan-out.
+   *
+   * @param {object} req      Express request with currentUser.idpUserId
+   * @param {string} tenantId Tenant ID from the x-tenant-id header
+   * @returns {Promise<{ belongs: boolean, degraded: boolean }>}
+   */
+  async verifyTenantMembership(req, tenantId) {
+    if (!req || !req.currentUser) {
+      throw new TypeError(`${SERVICE}: missing currentUser`);
+    }
+    if (!req.currentUser.idpUserId) {
+      throw new TypeError(`${SERVICE}: missing currentUser.idpUserId`);
+    }
+    const { tenants, degraded } = await this._fetchUserTenantsList(req);
+    if (degraded) return { belongs: false, degraded: true };
+    const belongs = Array.isArray(tenants) && tenants.some((t) => t?.id === tenantId);
+    return { belongs, degraded: false };
+  }
+
   async getCurrentUserTenants(req) {
     if (!req || !req.currentUser) {
       throw new TypeError(`${SERVICE}: missing currentUser`);
@@ -31,41 +100,31 @@ class TenantService {
     if (!req.currentUser.idpUserId) {
       throw new TypeError(`${SERVICE}: missing currentUser.idpUserId`);
     }
-    const url = `${endpoint}${listUserTenantsPath.replace('{userId}', req.currentUser.idpUserId)}`;
-    const headers = this._getAuthHeaders(req);
-    try {
-      const { data } = await axios.get(url, { headers });
-      const tenants = data?.data?.tenants || [];
-      if (!Array.isArray(tenants) || tenants.length === 0) return [];
-
-      const tenantsWithRoles = await Promise.all(
-        tenants.map(async (tenant) => {
-          const tenantId = tenant?.id;
-          if (!tenantId) return { ...tenant, roles: [] };
-
-          const reqContext = {
-            ...req,
-            currentUser: { ...req.currentUser, tenantId },
-            headers: req.headers,
-          };
-
-          const groups = await this.getUserTenantGroupsAndRoles(reqContext, tenantId);
-          const roles = Array.isArray(groups) ? groups.flatMap((group) => group.roles || []) : [];
-          return { ...tenant, roles: [...new Set(roles)] };
-        })
-      );
-
-      return tenantsWithRoles;
-    } catch (error) {
-      const status = error?.response?.status;
-      const isUnavailable = [500, 502, 503, 504].includes(status);
-      const isNetworkError = ['ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT'].includes(error?.code);
-      if (isUnavailable || isNetworkError) {
-        req._tenantServiceDegraded = true;
-        return [];
-      }
-      throw error;
+    const { tenants, degraded } = await this._fetchUserTenantsList(req);
+    if (degraded) {
+      req._tenantServiceDegraded = true;
+      return [];
     }
+    if (!Array.isArray(tenants) || tenants.length === 0) return [];
+
+    const tenantsWithRoles = await Promise.all(
+      tenants.map(async (tenant) => {
+        const tenantId = tenant?.id;
+        if (!tenantId) return { ...tenant, roles: [] };
+
+        const reqContext = {
+          ...req,
+          currentUser: { ...req.currentUser, tenantId },
+          headers: req.headers,
+        };
+
+        const groups = await this.getUserTenantGroupsAndRoles(reqContext, tenantId);
+        const roles = Array.isArray(groups) ? groups.flatMap((group) => group.roles || []) : [];
+        return { ...tenant, roles: [...new Set(roles)] };
+      })
+    );
+
+    return tenantsWithRoles;
   }
 
   async getUserTenantGroupsAndRoles(req, tenantId) {

--- a/app/src/components/tenantService.js
+++ b/app/src/components/tenantService.js
@@ -82,7 +82,7 @@ class TenantService {
    * @returns {Promise<{ belongs: boolean, degraded: boolean }>}
    */
   async verifyTenantMembership(req, tenantId) {
-    if (!req || !req.currentUser) {
+    if (!req?.currentUser) {
       throw new TypeError(`${SERVICE}: missing currentUser`);
     }
     if (!req.currentUser.idpUserId) {

--- a/app/src/forms/auth/middleware/userAccess.js
+++ b/app/src/forms/auth/middleware/userAccess.js
@@ -117,15 +117,13 @@ const currentUser = async (req, _res, next) => {
     }
 
     if (tenantId) {
-      const userTenants = await tenantService.getCurrentUserTenants(req);
-      if (req._tenantServiceDegraded) {
+      const { belongs, degraded } = await tenantService.verifyTenantMembership(req, tenantId);
+      if (degraded) {
         throw new Problem(503, {
           detail: 'Tenant service unavailable.',
         });
       }
-
-      const tenantBelongsToUser = Array.isArray(userTenants) && userTenants.some((tenant) => tenant?.id === tenantId);
-      if (!tenantBelongsToUser) {
+      if (!belongs) {
         throw new Problem(403, {
           detail: 'Tenant not accessible for current user.',
         });

--- a/app/tests/unit/components/tenantService.spec.js
+++ b/app/tests/unit/components/tenantService.spec.js
@@ -30,6 +30,7 @@ describe('TenantService', () => {
   beforeEach(() => {
     mockAxios = new MockAdapter(axios);
     jwtService.getBearerToken.mockReset();
+    tenantService._clearListTenantsCache();
   });
 
   afterEach(() => {
@@ -177,6 +178,158 @@ describe('TenantService', () => {
       });
 
       await tenantService.getCurrentUserTenants(req);
+    });
+  });
+
+  describe('verifyTenantMembership', () => {
+    const userId = 'user-verify';
+    const tenantId = '0d3f5d5f-1a2b-4c3d-9e8f-112233445566';
+    const otherTenantId = '1d3f5d5f-1a2b-4c3d-9e8f-112233445567';
+    const req = {
+      currentUser: { idpUserId: userId },
+      headers: { authorization: 'Bearer testtoken' },
+    };
+    const apiUrl = `${endpoint}${listUserTenantsPath.replace('{userId}', userId)}`;
+
+    it('returns belongs=true without fanning out to groups/roles', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      const rolesSpy = jest.spyOn(tenantService, 'getUserTenantGroupsAndRoles');
+      mockAxios.onGet(apiUrl).reply(200, { data: { tenants: [{ id: tenantId }, { id: otherTenantId }] } });
+
+      const result = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(result).toEqual({ belongs: true, degraded: false });
+      expect(rolesSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns belongs=false when tenantId is not in the user list', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      mockAxios.onGet(apiUrl).reply(200, { data: { tenants: [{ id: otherTenantId }] } });
+
+      const result = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(result).toEqual({ belongs: false, degraded: false });
+    });
+
+    it('returns degraded=true on CSTAR 503', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      mockAxios.onGet(apiUrl).reply(503, { error: 'Service unavailable' });
+
+      const result = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(result).toEqual({ belongs: false, degraded: true });
+    });
+
+    it('returns degraded=true on CSTAR 500', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      mockAxios.onGet(apiUrl).reply(500, { error: 'Internal' });
+
+      const result = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(result).toEqual({ belongs: false, degraded: true });
+    });
+
+    it('returns degraded=true on network error (ECONNREFUSED)', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      mockAxios.onGet(apiUrl).reply(() => Promise.reject(Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' })));
+
+      const result = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(result).toEqual({ belongs: false, degraded: true });
+    });
+
+    it('throws on 401', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      mockAxios.onGet(apiUrl).reply(401, { error: 'Unauthorized' });
+
+      await expect(tenantService.verifyTenantMembership(req, tenantId)).rejects.toThrow();
+    });
+
+    it('throws on 403', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      mockAxios.onGet(apiUrl).reply(403, { error: 'Forbidden' });
+
+      await expect(tenantService.verifyTenantMembership(req, tenantId)).rejects.toThrow();
+    });
+
+    it('throws if no currentUser', async () => {
+      await expect(tenantService.verifyTenantMembership({}, tenantId)).rejects.toThrow('TenantService: missing currentUser');
+    });
+
+    it('throws if no idpUserId', async () => {
+      await expect(tenantService.verifyTenantMembership({ currentUser: {} }, tenantId)).rejects.toThrow('TenantService: missing currentUser.idpUserId');
+    });
+
+    it('caches a successful list so back-to-back calls make one CSTAR call', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      let hits = 0;
+      mockAxios.onGet(apiUrl).reply(() => {
+        hits += 1;
+        return [200, { data: { tenants: [{ id: tenantId }] } }];
+      });
+
+      const first = await tenantService.verifyTenantMembership(req, tenantId);
+      const second = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(first).toEqual({ belongs: true, degraded: false });
+      expect(second).toEqual({ belongs: true, degraded: false });
+      expect(hits).toBe(1);
+    });
+
+    it('coalesces concurrent in-flight calls onto one CSTAR call', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      let hits = 0;
+      let resolveAxios;
+      const gate = new Promise((r) => (resolveAxios = r));
+      mockAxios.onGet(apiUrl).reply(async () => {
+        hits += 1;
+        await gate;
+        return [200, { data: { tenants: [{ id: tenantId }] } }];
+      });
+
+      const p1 = tenantService.verifyTenantMembership(req, tenantId);
+      const p2 = tenantService.verifyTenantMembership(req, tenantId);
+      const p3 = tenantService.verifyTenantMembership(req, tenantId);
+      resolveAxios();
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+      expect(r1).toEqual({ belongs: true, degraded: false });
+      expect(r2).toEqual({ belongs: true, degraded: false });
+      expect(r3).toEqual({ belongs: true, degraded: false });
+      expect(hits).toBe(1);
+    });
+
+    it('does not cache degraded results (next call retries)', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      let call = 0;
+      mockAxios.onGet(apiUrl).reply(() => {
+        call += 1;
+        if (call === 1) return [503, { error: 'Service unavailable' }];
+        return [200, { data: { tenants: [{ id: tenantId }] } }];
+      });
+
+      const first = await tenantService.verifyTenantMembership(req, tenantId);
+      const second = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(first).toEqual({ belongs: false, degraded: true });
+      expect(second).toEqual({ belongs: true, degraded: false });
+      expect(call).toBe(2);
+    });
+
+    it('does not cache thrown errors (next call retries)', async () => {
+      jwtService.getBearerToken.mockReturnValue('testtoken');
+      let call = 0;
+      mockAxios.onGet(apiUrl).reply(() => {
+        call += 1;
+        if (call === 1) return [401, { error: 'Unauthorized' }];
+        return [200, { data: { tenants: [{ id: tenantId }] } }];
+      });
+
+      await expect(tenantService.verifyTenantMembership(req, tenantId)).rejects.toThrow();
+      const second = await tenantService.verifyTenantMembership(req, tenantId);
+
+      expect(second).toEqual({ belongs: true, degraded: false });
+      expect(call).toBe(2);
     });
   });
 

--- a/app/tests/unit/forms/auth/middleware/userAccess.spec.js
+++ b/app/tests/unit/forms/auth/middleware/userAccess.spec.js
@@ -49,7 +49,6 @@ describe('currentUser', () => {
   // Bearer token and its authorization header.
   const bearerToken = Math.random().toString(36).substring(2);
   const tenantId = '0d3f5d5f-1a2b-4c3d-9e8f-112233445566';
-  const otherTenantId = '1d3f5d5f-1a2b-4c3d-9e8f-112233445567';
 
   // Default mock of the token validation.
   jwtService.getBearerToken = jest.fn().mockReturnValue(bearerToken);
@@ -68,7 +67,7 @@ describe('currentUser', () => {
 
       return undefined;
     });
-    jest.spyOn(tenantService, 'getCurrentUserTenants').mockResolvedValue([{ id: tenantId }]);
+    jest.spyOn(tenantService, 'verifyTenantMembership').mockResolvedValue({ belongs: true, degraded: false });
   });
 
   describe('401 response when', () => {
@@ -169,7 +168,7 @@ describe('currentUser', () => {
 
     expect(req.currentUser).toBeDefined();
     expect(req.currentUser.tenantId).toBe(tenantId);
-    expect(tenantService.getCurrentUserTenants).toHaveBeenCalledWith(req);
+    expect(tenantService.verifyTenantMembership).toHaveBeenCalledWith(req, tenantId);
     expect(next).toBeCalledTimes(1);
     expect(next).toBeCalledWith();
   });
@@ -193,7 +192,7 @@ describe('currentUser', () => {
   });
 
   it('rejects a tenantId not owned by the current user', async () => {
-    tenantService.getCurrentUserTenants.mockResolvedValueOnce([{ id: otherTenantId }]);
+    tenantService.verifyTenantMembership.mockResolvedValueOnce({ belongs: false, degraded: false });
     const req = getMockReq({
       headers: { 'x-tenant-id': tenantId },
     });
@@ -213,10 +212,7 @@ describe('currentUser', () => {
   });
 
   it('returns 503 when tenant service is degraded', async () => {
-    tenantService.getCurrentUserTenants.mockImplementationOnce((req) => {
-      req._tenantServiceDegraded = true;
-      return Promise.resolve([]);
-    });
+    tenantService.verifyTenantMembership.mockResolvedValueOnce({ belongs: false, degraded: true });
     const req = getMockReq({
       headers: { 'x-tenant-id': tenantId },
     });


### PR DESCRIPTION
## Description
Fixed netrwork flood of CSTAR requests.  Consolidated multiple quick requests into single requests

The Submissions Sort Button was a symptom of this

## Type of Change
fix (a bug fix) 

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- revert (reverts changes in a previous commit) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply. If
you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have run the npm script lint on the frontend and backend
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have approval from the product owner for the contribution in this pull request

## How to Test
- Open https://chefs-dev.apps.silver.devops.gov.bc.ca/pr-1935/
- Click Login (top right), sign in with your IDIR.
- In the header, click the My Forms dropdown (top right) and select Test_Aug7. 
- A light orange "Test_Aug7" banner appears at the top; you're now in Enterprise mode.
- click on "Group Forms" if not already selected
- You should see "My Test Form".  Click on "Submissions" on the right
- There shouldm already be a few submissions
- CLick on the headers to change the sorting
- No Errors should be displayed.  Sorting should work as expected




